### PR TITLE
perf(web): fix SSR page loading performance (PERF-001–007)

### DIFF
--- a/apps/web/app/(registry)/layout.tsx
+++ b/apps/web/app/(registry)/layout.tsx
@@ -1,17 +1,44 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { headers } from 'next/headers';
+import { Suspense } from 'react';
 import { auth } from '@/lib/auth';
 
-export default async function RegistryLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+async function AuthLink() {
   const session = await auth.api.getSession({
     headers: await headers(),
   });
 
+  if (session) {
+    return (
+      <Link
+        href="/dashboard"
+        className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        Dashboard
+      </Link>
+    );
+  }
+
+  return <SignInLink />;
+}
+
+function SignInLink() {
+  return (
+    <Link
+      href="/login"
+      className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+    >
+      Sign In
+    </Link>
+  );
+}
+
+export default function RegistryLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <div className="min-h-screen bg-background">
       <header className="border-b">
@@ -29,21 +56,9 @@ export default async function RegistryLayout({
             </Link>
           </nav>
           <div className="ml-auto">
-            {session ? (
-              <Link
-                href="/dashboard"
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Dashboard
-              </Link>
-            ) : (
-              <Link
-                href="/login"
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Sign In
-              </Link>
-            )}
+            <Suspense fallback={<SignInLink />}>
+              <AuthLink />
+            </Suspense>
           </div>
         </div>
       </header>

--- a/apps/web/app/(registry)/skills/[...name]/page.tsx
+++ b/apps/web/app/(registry)/skills/[...name]/page.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
+import { unstable_noStore as noStore } from 'next/cache';
 import {
   Table,
   TableBody,
@@ -15,6 +16,9 @@ import { SkillReadme } from './skill-readme';
 import { SkillTabs } from './skill-tabs';
 import { FileExplorer } from './file-explorer';
 import { DownloadButton } from './download-button';
+
+// ISR: cache page at CDN for 60s, survives serverless cold starts (PERF-005/006)
+export const revalidate = 60;
 
 function formatDate(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date;
@@ -120,6 +124,8 @@ interface SkillDetailPageProps {
 export default async function SkillDetailPage({
   params,
 }: SkillDetailPageProps) {
+  if (process.env.TANK_PERF_MODE === '1') noStore();
+
   const { name: nameParts } = await params;
   const skillName = decodeURIComponent(nameParts.join('/'));
   const data = await getSkillDetail(skillName);

--- a/apps/web/app/(registry)/skills/page.tsx
+++ b/apps/web/app/(registry)/skills/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { unstable_noStore as noStore } from 'next/cache';
 import {
   Card,
   CardHeader,
@@ -12,6 +13,9 @@ import { searchSkills } from '@/lib/data/skills';
 import type { SkillSearchResult } from '@/lib/data/skills';
 import { SearchBar } from './search-bar';
 
+// ISR: cache page at CDN for 60s, survives serverless cold starts (PERF-005/006)
+export const revalidate = 60;
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 interface SkillsPageProps {
@@ -19,6 +23,8 @@ interface SkillsPageProps {
 }
 
 export default async function SkillsPage({ searchParams }: SkillsPageProps) {
+  // Bypass ISR cache for perf tests so every request hits the DB
+  if (process.env.TANK_PERF_MODE === '1') noStore();
   const params = await searchParams;
   const query = params.q ?? '';
   const page = Math.max(1, parseInt(params.page ?? '1', 10) || 1);

--- a/apps/web/perf/budgets.json
+++ b/apps/web/perf/budgets.json
@@ -1,8 +1,8 @@
 {
   "webRoutes": [
-    { "route": "/", "ttfbMs": 15, "lcpMs": 30, "fcpMs": 25, "cls": 0.1 },
-    { "route": "/skills", "ttfbMs": 60, "lcpMs": 120, "fcpMs": 90, "cls": 0.1 },
-    { "route": "/skills/test-org/test-skill", "ttfbMs": 35, "lcpMs": 70, "fcpMs": 55, "cls": 0.1 }
+    { "route": "/", "responseTimeMs": 15, "lcpMs": 30, "fcpMs": 25, "cls": 0.1 },
+    { "route": "/skills", "responseTimeMs": 60, "lcpMs": 120, "fcpMs": 90, "cls": 0.1 },
+    { "route": "/skills/test-org/test-skill", "responseTimeMs": 35, "lcpMs": 70, "fcpMs": 55, "cls": 0.1 }
   ],
   "apiRoutes": [
     { "route": "/api/v1/search?q=test", "p95Ms": 90, "sampleCount": 20 },

--- a/apps/web/scripts/perf-report.ts
+++ b/apps/web/scripts/perf-report.ts
@@ -12,7 +12,7 @@ import path from 'node:path';
 // Mirrored from tests/perf/helpers/budgets.ts — standalone script can't import test helpers
 interface WebRouteBudget {
   route: string;
-  ttfbMs: number;
+  responseTimeMs: number;
   lcpMs: number;
   fcpMs: number;
   cls: number;
@@ -41,8 +41,8 @@ interface PerfBudgets {
 
 interface WebRouteResult {
   route: string;
-  runs: Array<{ ttfbMs: number; fcpMs: number; lcpMs: number; cls: number }>;
-  aggregated: { ttfbMs: number; fcpMs: number; lcpMs: number; cls: number };
+  runs: Array<{ responseTimeMs: number; fcpMs: number; lcpMs: number; cls: number }>;
+  aggregated: { responseTimeMs: number; fcpMs: number; lcpMs: number; cls: number };
 }
 
 interface ApiRouteResult {
@@ -107,7 +107,7 @@ function main(): void {
     console.log('\n--- Web Routes (no-cache, median) ---\n');
     console.log(
       padRight('Route', 40) +
-        padRight('TTFB', 12) +
+        padRight('Resp', 12) +
         padRight('FCP', 12) +
         padRight('LCP', 12) +
         padRight('CLS', 10) +
@@ -123,22 +123,22 @@ function main(): void {
       }
 
       const agg = result.aggregated;
-      const ttfbOk = agg.ttfbMs <= budget.ttfbMs;
+      const respOk = agg.responseTimeMs <= budget.responseTimeMs;
       const fcpOk = agg.fcpMs <= budget.fcpMs;
       const lcpOk = agg.lcpMs <= budget.lcpMs;
       const clsOk = agg.cls <= budget.cls;
-      const allOk = ttfbOk && fcpOk && lcpOk && clsOk;
+      const allOk = respOk && fcpOk && lcpOk && clsOk;
 
       console.log(
         padRight(result.route, 40) +
-          padRight(fmtMs(agg.ttfbMs, budget.ttfbMs), 12) +
+          padRight(fmtMs(agg.responseTimeMs, budget.responseTimeMs), 12) +
           padRight(fmtMs(agg.fcpMs, budget.fcpMs), 12) +
           padRight(fmtMs(agg.lcpMs, budget.lcpMs), 12) +
           padRight(fmtCls(agg.cls, budget.cls), 10) +
           (allOk ? 'PASS' : 'FAIL'),
       );
 
-      if (!ttfbOk) breaches.push(`${result.route} TTFB: ${agg.ttfbMs.toFixed(0)}ms > ${budget.ttfbMs}ms`);
+      if (!respOk) breaches.push(`${result.route} Response: ${agg.responseTimeMs.toFixed(0)}ms > ${budget.responseTimeMs}ms`);
       if (!fcpOk) breaches.push(`${result.route} FCP: ${agg.fcpMs.toFixed(0)}ms > ${budget.fcpMs}ms`);
       if (!lcpOk) breaches.push(`${result.route} LCP: ${agg.lcpMs.toFixed(0)}ms > ${budget.lcpMs}ms`);
       if (!clsOk) breaches.push(`${result.route} CLS: ${agg.cls.toFixed(3)} > ${budget.cls}`);

--- a/apps/web/tests/perf/helpers/budgets.ts
+++ b/apps/web/tests/perf/helpers/budgets.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 export interface WebRouteBudget {
   route: string;
-  ttfbMs: number;
+  responseTimeMs: number;
   lcpMs: number;
   fcpMs: number;
   cls: number;
@@ -50,13 +50,13 @@ export function loadBudgets(): PerfBudgets {
 export interface WebRouteResult {
   route: string;
   runs: Array<{
-    ttfbMs: number;
+    responseTimeMs: number;
     fcpMs: number;
     lcpMs: number;
     cls: number;
   }>;
   aggregated: {
-    ttfbMs: number;
+    responseTimeMs: number;
     fcpMs: number;
     lcpMs: number;
     cls: number;

--- a/apps/web/tests/perf/web-routes.perf.test.ts
+++ b/apps/web/tests/perf/web-routes.perf.test.ts
@@ -24,7 +24,7 @@ describe('P0 Web Route Performance (no-cache)', () => {
 
   for (const budget of budgets.webRoutes) {
     describe(`${budget.route}`, () => {
-      it(`TTFB median < ${budget.ttfbMs}ms`, async () => {
+      it(`response time median < ${budget.responseTimeMs}ms`, async () => {
         const runs = await measureWebRouteWithWarmup(
           PERF_BASE_URL,
           budget.route,
@@ -32,11 +32,11 @@ describe('P0 Web Route Performance (no-cache)', () => {
           budgets.runs.warmupRuns.web,
         );
 
-        const ttfbValues = runs.map((r) => r.ttfbMs);
-        const medianTtfb = median(ttfbValues);
+        const responseTimeValues = runs.map((r) => r.responseTimeMs);
+        const medianResponseTime = median(responseTimeValues);
 
         const aggregated = {
-          ttfbMs: medianTtfb,
+          responseTimeMs: medianResponseTime,
           fcpMs: median(runs.map((r) => r.fcpMs)),
           lcpMs: median(runs.map((r) => r.lcpMs)),
           cls: median(runs.map((r) => r.cls)),
@@ -45,7 +45,7 @@ describe('P0 Web Route Performance (no-cache)', () => {
         webResults.push({
           route: budget.route,
           runs: runs.map((r) => ({
-            ttfbMs: r.ttfbMs,
+            responseTimeMs: r.responseTimeMs,
             fcpMs: r.fcpMs,
             lcpMs: r.lcpMs,
             cls: r.cls,
@@ -54,9 +54,9 @@ describe('P0 Web Route Performance (no-cache)', () => {
         });
 
         expect(
-          medianTtfb,
-          `TTFB for ${budget.route}: ${medianTtfb.toFixed(0)}ms exceeds budget ${budget.ttfbMs}ms`,
-        ).toBeLessThanOrEqual(budget.ttfbMs);
+          medianResponseTime,
+          `Response time for ${budget.route}: ${medianResponseTime.toFixed(0)}ms exceeds budget ${budget.responseTimeMs}ms`,
+        ).toBeLessThanOrEqual(budget.responseTimeMs);
       }, 120_000);
 
       it(`FCP median < ${budget.fcpMs}ms`, async () => {


### PR DESCRIPTION
## Summary

Fixes all 8 performance issues from the QA report (`tank-pr8-qa-report.docx`) that explain why Next.js SSR pages load in ~600-800ms while equivalent API routes respond in ~5ms.

- **PERF-001**: Registry layout `auth.api.getSession()` blocked rendering — wrapped in `<Suspense>` so page shell renders instantly, auth streams in async
- **PERF-002/003**: Skill detail page ran 3 sequential DB queries (~450ms total on remote Supabase) — consolidated into a single SQL query with JSON subqueries
- **PERF-004**: Perf metric `ttfbMs` was mislabeled (actually measures full response time, not TTFB) — renamed to `responseTimeMs` across all source files and result JSON, added doc comments documenting synthetic FCP/LCP/CLS estimates
- **PERF-005/006**: In-memory `Map` cache lost on every redeployment — replaced with Next.js ISR (`revalidate = 60`), with `TANK_PERF_MODE=1` bypass via `unstable_noStore`
- **PERF-007**: Production DB created new `postgres()` instance per cold start — fixed to use `globalThis` caching like dev mode
- **PERF-008**: Claimed missing index on `skill_downloads.skill_id` — verified index already exists in schema, correlated subquery is O(1). No action needed.

## Key insight

`postgres.js` doesn't pipeline `Promise.all` queries — they run sequentially on a single connection. Each round-trip to remote Supabase costs ~150-200ms. The only way to be fast is to minimize the number of separate queries.

## Changes

11 files changed, 161 insertions, 178 deletions (net code reduction).

## Verification

- ✅ `pnpm build` — all 3 packages compile cleanly
- ✅ `pnpm test` — 563/563 tests pass
- ✅ Zero LSP errors on all modified files