### PR TITLE
feat(web): add organization invitation emails and acceptance page

### DIFF
--- a/apps/web/app/(dashboard)/orgs/accept-invitation/page.tsx
+++ b/apps/web/app/(dashboard)/orgs/accept-invitation/page.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { acceptInvitation, getInvitation } from '../actions';
+import { Button } from '@/components/ui/button';
+
+type InvitationState =
+  | { status: 'loading' }
+  | { status: 'preview'; orgName: string; role: string }
+  | { status: 'accepting'; orgName: string; role: string }
+  | { status: 'accepted' }
+  | { status: 'error'; message: string };
+
+export default function AcceptInvitationPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const invitationId = searchParams.get('id');
+
+  const [state, setState] = useState<InvitationState>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!invitationId) {
+      setState({ status: 'error', message: 'No invitation ID provided.' });
+      return;
+    }
+
+    getInvitation(invitationId)
+      .then((inv) => {
+        if (!inv) {
+          setState({ status: 'error', message: 'Invitation not found.' });
+          return;
+        }
+        if (inv.status === 'accepted') {
+          setState({ status: 'error', message: 'This invitation has already been accepted.' });
+          return;
+        }
+        if (inv.status === 'canceled') {
+          setState({ status: 'error', message: 'This invitation has been canceled.' });
+          return;
+        }
+        if (inv.status === 'rejected') {
+          setState({ status: 'error', message: 'This invitation has been rejected.' });
+          return;
+        }
+        if (new Date(inv.expiresAt) < new Date()) {
+          setState({ status: 'error', message: 'This invitation has expired.' });
+          return;
+        }
+        setState({
+          status: 'preview',
+          orgName: inv.organizationName || inv.organizationId,
+          role: inv.role || 'member',
+        });
+      })
+      .catch(() => {
+        setState({ status: 'error', message: 'Failed to load invitation details.' });
+      });
+  }, [invitationId]);
+
+  const handleAccept = async () => {
+    if (!invitationId) return;
+    setState((prev) => {
+      const orgName = 'orgName' in prev ? prev.orgName : '';
+      const role = 'role' in prev ? prev.role : 'member';
+      return { status: 'accepting', orgName, role };
+    });
+
+    try {
+      await acceptInvitation(invitationId);
+      setState({ status: 'accepted' });
+    } catch (err) {
+      setState({
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Failed to accept invitation.',
+      });
+    }
+  };
+
+  if (state.status === 'loading') {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-muted-foreground text-sm">Loading invitation...</p>
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 space-y-4">
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">Invitation Error</h1>
+          <p className="text-muted-foreground">{state.message}</p>
+        </div>
+        <Link href="/orgs">
+          <Button variant="outline">Go to Organizations</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  if (state.status === 'accepted') {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 space-y-4">
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">You&apos;re in!</h1>
+          <p className="text-muted-foreground">You&apos;ve successfully joined the organization.</p>
+        </div>
+        <Button onClick={() => router.push('/orgs')}>Go to Organizations</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 space-y-6">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight">Organization Invitation</h1>
+        <p className="text-muted-foreground">
+          You&apos;ve been invited to join <strong>{state.orgName}</strong> as a <strong>{state.role}</strong>.
+        </p>
+      </div>
+      <div className="flex gap-3">
+        <Link href="/orgs">
+          <Button variant="outline">Decline</Button>
+        </Link>
+        <Button
+          onClick={handleAccept}
+          disabled={state.status === 'accepting'}
+        >
+          {state.status === 'accepting' ? 'Accepting...' : 'Accept Invitation'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/orgs/actions.ts
+++ b/apps/web/app/(dashboard)/orgs/actions.ts
@@ -105,6 +105,42 @@ export async function inviteMember(data: { organizationId: string; email: string
   return result;
 }
 
+export async function acceptInvitation(invitationId: string) {
+  const reqHeaders = await headers();
+  const session = await auth.api.getSession({ headers: reqHeaders });
+
+  if (!session) {
+    throw new Error('Unauthorized');
+  }
+
+  const result = await auth.api.acceptInvitation({
+    body: {
+      invitationId,
+    },
+    headers: reqHeaders,
+  });
+
+  return result;
+}
+
+export async function getInvitation(invitationId: string) {
+  const reqHeaders = await headers();
+  const session = await auth.api.getSession({ headers: reqHeaders });
+
+  if (!session) {
+    throw new Error('Unauthorized');
+  }
+
+  const result = await auth.api.getInvitation({
+    query: {
+      id: invitationId,
+    },
+    headers: reqHeaders,
+  });
+
+  return result;
+}
+
 export async function removeMember(data: { organizationId: string; memberIdOrEmail: string }) {
   const reqHeaders = await headers();
   const session = await auth.api.getSession({ headers: reqHeaders });

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -4,7 +4,7 @@ import { nextCookies } from 'better-auth/next-js';
 import { apiKey, genericOAuth, organization } from 'better-auth/plugins';
 import { db } from './db';
 import { sendEmail, getFromAddress, getProvider } from './email/service';
-import { checkVerificationRateLimit } from './email/rate-limiter';
+import { checkVerificationRateLimit, checkEmailRateLimit } from './email/rate-limiter';
 
 const enabledProviders = new Set(
   (process.env.AUTH_PROVIDERS || 'github,credentials')
@@ -113,6 +113,64 @@ export const auth = betterAuth({
     }),
     organization({
       allowUserToCreateOrganization: true,
+      async sendInvitationEmail(data) {
+        const rateLimit = await checkEmailRateLimit(data.email)
+        if (!rateLimit.allowed) {
+          throw new Error(`Too many emails sent. Please wait ${Math.ceil(rateLimit.resetIn / 60000)} minutes before retrying.`)
+        }
+
+        const from = getFromAddress()
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+        const appName = process.env.APP_NAME || 'Tank'
+        const acceptUrl = `${appUrl}/orgs/accept-invitation?id=${data.id}`
+        const inviterName = data.inviter.user.name || data.inviter.user.email
+        const expiresAt = new Date(data.invitation.expiresAt).toLocaleDateString('en-US', {
+          month: 'long', day: 'numeric', year: 'numeric',
+        })
+
+        const html = `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          </head>
+          <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+              <h1 style="color: white; margin: 0; font-size: 24px;">${appName}</h1>
+            </div>
+            <div style="background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px;">
+              <p style="margin-bottom: 20px;">Hello,</p>
+              <p style="margin-bottom: 20px;"><strong>${inviterName}</strong> has invited you to join <strong>${data.organization.name}</strong> as a <strong>${data.role}</strong>.</p>
+              <div style="text-align: center; margin: 30px 0;">
+                <a href="${acceptUrl}" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; font-weight: bold; display: inline-block;">Accept Invitation</a>
+              </div>
+              <p style="margin-bottom: 20px; color: #666; font-size: 14px;">Or copy this link to your browser:<br><code style="word-break: break-all; background: #eee; padding: 5px; border-radius: 3px;">${acceptUrl}</code></p>
+              <p style="margin-bottom: 0; color: #999; font-size: 12px;">This invitation expires on ${expiresAt}. If you weren't expecting this, you can safely ignore it.</p>
+            </div>
+          </body>
+          </html>
+        `
+
+        const text = `Hello,\n\n${inviterName} has invited you to join ${data.organization.name} as a ${data.role}.\n\nAccept the invitation: ${acceptUrl}\n\nThis invitation expires on ${expiresAt}. If you weren't expecting this, you can safely ignore it.`
+
+        const result = await sendEmail({
+          from,
+          to: data.email,
+          subject: `You've been invited to join ${data.organization.name} on ${appName}`,
+          html,
+          text,
+        })
+
+        if (!result.success) {
+          console.error(`Failed to send invitation email to ${data.email}:`, result.error)
+          throw new Error('Failed to send invitation email. Please try again later.')
+        }
+
+        if (getProvider() === 'console') {
+          console.log(`Invitation link for ${data.email}: ${acceptUrl}`)
+        }
+      },
     }),
     ...(oidcEnabled
       ? [


### PR DESCRIPTION
## Summary

- Wire up `sendInvitationEmail` hook in better-auth's organization plugin so invitation emails are actually sent via Resend
- Add `/orgs/accept-invitation` page with preview, accepting, accepted, and error states
- Add `acceptInvitation` and `getInvitation` server actions

## Problem

Inviting a member to an organization created the invitation record in the DB but never sent an email — the `organization()` plugin had no `sendInvitationEmail` callback configured.

## Changes

| File | Change |
|------|--------|
| `apps/web/lib/auth.ts` | Added `sendInvitationEmail` hook with styled HTML email, rate limiting, and console fallback |
| `apps/web/app/(dashboard)/orgs/actions.ts` | Added `acceptInvitation` + `getInvitation` server actions |
| `apps/web/app/(dashboard)/orgs/accept-invitation/page.tsx` | New page — loads invitation details, shows org/role, handles accept flow |