### PR TITLE
fix(cli): send auth token in installFromLockfile and update commands

### DIFF
--- a/apps/cli/src/__tests__/install.test.ts
+++ b/apps/cli/src/__tests__/install.test.ts
@@ -929,6 +929,43 @@ describe('installFromLockfile', () => {
     expect(fs.existsSync(extractDir)).toBe(true);
   });
 
+  it('sends bearer token when config contains token', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
+
+    fs.writeFileSync(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ registry: 'https://tankpkg.dev', token: 'tank_ci_token' }),
+    );
+
+    writeLockfile({
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+        integrity: fakeTarball1Integrity,
+        permissions: {},
+        audit_score: 8.0,
+      },
+    });
+
+    // Mock API metadata response
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        name: '@test-org/my-skill',
+        version: '2.0.0',
+        integrity: fakeTarball1Integrity,
+        downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    // Mock tarball download
+    mockFetch.mockResolvedValueOnce(
+      new Response(new Uint8Array(fakeTarball1), { status: 200 }),
+    );
+
+    await installFromLockfile({ directory: tmpDir, configDir });
+
+    const [, metaOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((metaOpts.headers as Record<string, string>).Authorization).toBe('Bearer tank_ci_token');
+  });
+
   it('aborts entire install when integrity mismatch on any skill', async () => {
     const { installFromLockfile } = await import('../commands/install.js');
 

--- a/apps/cli/src/__tests__/update.test.ts
+++ b/apps/cli/src/__tests__/update.test.ts
@@ -187,6 +187,26 @@ describe('updateCommand', () => {
     );
   });
 
+  it('sends bearer token when config contains token', async () => {
+    const { updateCommand } = await import('../commands/update.js');
+    const { installCommand } = await import('../commands/install.js');
+
+    fs.writeFileSync(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ registry: 'https://tankpkg.dev', token: 'tank_ci_token' }),
+    );
+
+    writeSkillsJson();
+    writeLockfile();
+
+    mockVersionsResponse(['2.0.0', '2.1.0']);
+
+    await updateCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir });
+
+    const [, versionsOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((versionsOpts.headers as Record<string, string>).Authorization).toBe('Bearer tank_ci_token');
+  });
+
   it('prints "Already at latest" when no newer version', async () => {
     const { updateCommand } = await import('../commands/update.js');
     const { installCommand } = await import('../commands/install.js');

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -325,6 +325,10 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
   const resolvedHome = homedir ?? os.homedir();
   const config = getConfig(configDir);
 
+  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+  if (config.token) {
+    requestHeaders.Authorization = `Bearer ${config.token}`;
+  }
   const lockPath = global
     ? path.join(resolvedHome, '.tank', 'skills.lock')
     : path.join(directory, 'skills.lock');
@@ -364,7 +368,7 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
       let metaRes: Response;
       try {
         metaRes = await fetch(metaUrl, {
-          headers: { 'User-Agent': USER_AGENT },
+          headers: requestHeaders,
         });
       } catch (err) {
         throw new Error(`Network error fetching ${key}: ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -119,6 +119,10 @@ async function updateSingle(
   }
 
   const config = getConfig(configDir);
+  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+  if (config.token) {
+    requestHeaders.Authorization = `Bearer ${config.token}`;
+  }
 
   // 3. Fetch available versions from registry
   const encodedName = encodeURIComponent(name);
@@ -127,7 +131,7 @@ async function updateSingle(
   let versionsRes: Response;
   try {
     versionsRes = await fetch(versionsUrl, {
-      headers: { 'User-Agent': USER_AGENT },
+      headers: requestHeaders,
     });
   } catch (err) {
     throw new Error(`Network error fetching versions for ${name}: ${err instanceof Error ? err.message : String(err)}`);
@@ -207,6 +211,10 @@ async function updateAll(
 
   for (const [name] of skillEntries) {
     const config = getConfig(configDir);
+    const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+    if (config.token) {
+      requestHeaders.Authorization = `Bearer ${config.token}`;
+    }
     const versionRange = skills[name];
 
     // Fetch available versions
@@ -216,7 +224,7 @@ async function updateAll(
     let versionsRes: Response;
     try {
       versionsRes = await fetch(versionsUrl, {
-        headers: { 'User-Agent': USER_AGENT },
+        headers: requestHeaders,
       });
     } catch (err) {
       throw new Error(`Network error fetching versions for ${name}: ${err instanceof Error ? err.message : String(err)}`);
@@ -295,13 +303,17 @@ async function updateSingleGlobal(
   }
 
   const config = getConfig(configDir);
+  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+  if (config.token) {
+    requestHeaders.Authorization = `Bearer ${config.token}`;
+  }
   const encodedName = encodeURIComponent(name);
   const versionsUrl = `${config.registry}/api/v1/skills/${encodedName}/versions`;
 
   let versionsRes: Response;
   try {
     versionsRes = await fetch(versionsUrl, {
-      headers: { 'User-Agent': USER_AGENT },
+      headers: requestHeaders,
     });
   } catch (err) {
     throw new Error(`Network error fetching versions for ${name}: ${err instanceof Error ? err.message : String(err)}`);
@@ -362,6 +374,10 @@ async function updateAllGlobal(
     if (!parsed) continue;
     const { name } = parsed;
     const config = getConfig(configDir);
+    const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+    if (config.token) {
+      requestHeaders.Authorization = `Bearer ${config.token}`;
+    }
     const versionRange = '*';
 
     const encodedName = encodeURIComponent(name);
@@ -370,7 +386,7 @@ async function updateAllGlobal(
     let versionsRes: Response;
     try {
       versionsRes = await fetch(versionsUrl, {
-        headers: { 'User-Agent': USER_AGENT },
+        headers: requestHeaders,
       });
     } catch (err) {
       throw new Error(`Network error fetching versions for ${name}: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary

- **Bug**: `installFromLockfile()` and all four `update` functions (`updateSingle`, `updateAll`, `updateSingleGlobal`, `updateAllGlobal`) call `getConfig()` but never include the auth token in their fetch headers — only `User-Agent` is sent. This causes private skill installs (from lockfile) and updates to fail with `Skill not found or no access` even when authenticated.
- **Fix**: Add `Authorization: Bearer` header to all affected fetch calls, matching the existing pattern in `installCommand()`.
- **Tests**: Added auth token verification tests for both `installFromLockfile` and `updateCommand`.

## Affected Functions

| Function | File | Before | After |
|---|---|---|---|
| `installFromLockfile()` | `install.ts` | ❌ No auth | ✅ Auth sent |
| `updateSingle()` | `update.ts` | ❌ No auth | ✅ Auth sent |
| `updateAll()` | `update.ts` | ❌ No auth | ✅ Auth sent |
| `updateSingleGlobal()` | `update.ts` | ❌ No auth | ✅ Auth sent |
| `updateAllGlobal()` | `update.ts` | ❌ No auth | ✅ Auth sent |

All 55 tests pass including 2 new auth token tests.