### PR TITLE
fix(cli,web): distinguish auth errors from permission errors in publish flow

### DIFF
--- a/apps/cli/src/__tests__/publish.test.ts
+++ b/apps/cli/src/__tests__/publish.test.ts
@@ -165,18 +165,51 @@ describe('publishCommand', () => {
     });
   });
 
-  it('dry run: packs and prints summary without uploading', async () => {
+  it('dry run: packs, prints summary, and verifies auth with server', async () => {
     const { publishCommand } = await import('../commands/publish.js');
 
     mockPack.mockResolvedValueOnce(mockPackResult);
 
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ valid: true }), { status: 200 }),
+    );
+
     await publishCommand({ directory: tmpDir, configDir, dryRun: true });
 
-    // Verify pack was called
     expect(mockPack).toHaveBeenCalledWith(tmpDir);
 
-    // Verify NO fetch calls were made (no API calls)
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/auth/whoami');
+    expect(opts.headers['Authorization']).toBe('Bearer tank_test-token');
+  });
+
+  it('dry run: warns when server auth check fails', async () => {
+    const { publishCommand } = await import('../commands/publish.js');
+
+    mockPack.mockResolvedValueOnce(mockPackResult);
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }),
+    );
+
+    await publishCommand({ directory: tmpDir, configDir, dryRun: true });
+
+    const allOutput = getAllOutput();
+    expect(allOutput).toMatch(/expired|invalid/i);
+  });
+
+  it('dry run: warns when server is unreachable', async () => {
+    const { publishCommand } = await import('../commands/publish.js');
+
+    mockPack.mockResolvedValueOnce(mockPackResult);
+
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    await publishCommand({ directory: tmpDir, configDir, dryRun: true });
+
+    const allOutput = getAllOutput();
+    expect(allOutput).toMatch(/could not reach server/i);
   });
 
   it('sets manifest.visibility=private when private option is enabled', async () => {
@@ -267,7 +300,6 @@ describe('publishCommand', () => {
 
     mockPack.mockResolvedValueOnce(mockPackResult);
 
-    // Step 1 returns 401
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({ error: 'Unauthorized' }),
@@ -280,12 +312,11 @@ describe('publishCommand', () => {
     ).rejects.toThrow(/Authentication failed/);
   });
 
-  it('handles API 403 with permission error message', async () => {
+  it('handles API 403 by forwarding server error message', async () => {
     const { publishCommand } = await import('../commands/publish.js');
 
     mockPack.mockResolvedValueOnce(mockPackResult);
 
-    // Step 1 returns 403
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({ error: "You are not a member of org 'test-org'" }),
@@ -295,10 +326,10 @@ describe('publishCommand', () => {
 
     await expect(
       publishCommand({ directory: tmpDir, configDir }),
-    ).rejects.toThrow(/permission/i);
+    ).rejects.toThrow(/not a member of org/i);
   });
 
-  it('handles API 403 with explicit scope message', async () => {
+  it('handles API 403 with scope error by forwarding message', async () => {
     const { publishCommand } = await import('../commands/publish.js');
 
     mockPack.mockResolvedValueOnce(mockPackResult);
@@ -313,6 +344,23 @@ describe('publishCommand', () => {
     await expect(
       publishCommand({ directory: tmpDir, configDir }),
     ).rejects.toThrow(/skills:publish/i);
+  });
+
+  it('handles API 404 for org not found', async () => {
+    const { publishCommand } = await import('../commands/publish.js');
+
+    mockPack.mockResolvedValueOnce(mockPackResult);
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: "Organization 'solarai' not found. You must create the org before publishing scoped packages." }),
+        { status: 404 },
+      ),
+    );
+
+    await expect(
+      publishCommand({ directory: tmpDir, configDir }),
+    ).rejects.toThrow(/not found/i);
   });
 
   it('handles API 409 with version conflict message', async () => {

--- a/apps/cli/src/__tests__/whoami.test.ts
+++ b/apps/cli/src/__tests__/whoami.test.ts
@@ -126,7 +126,7 @@ describe('whoamiCommand', () => {
     errorSpy.mockRestore();
   });
 
-  it('handles network error gracefully', async () => {
+  it('handles network error gracefully and sets exit code 1', async () => {
     fs.writeFileSync(
       path.join(tmpDir, 'config.json'),
       JSON.stringify({
@@ -142,14 +142,49 @@ describe('whoamiCommand', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
+    process.exitCode = 0;
     await whoamiCommand({ configDir: tmpDir });
 
     const allOutput = [...logSpy.mock.calls, ...errorSpy.mock.calls]
       .map((c) => c.join(' '))
       .join('\n');
-    // Should show cached user info or error message
-    expect(allOutput).toMatch(/error|failed|could not/i);
+    expect(allOutput).toMatch(/could not/i);
+    expect(process.exitCode).toBe(1);
 
+    process.exitCode = 0;
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('sets exit code 1 when server returns non-401 error', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'config.json'),
+      JSON.stringify({
+        token: 'tank_server-err',
+        user: { name: 'Server User', email: 'srv@e.com' },
+        registry: 'https://tankpkg.dev',
+      }),
+    );
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Internal error' }), { status: 500 }),
+    );
+
+    const { whoamiCommand } = await import('../commands/whoami.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    process.exitCode = 0;
+    await whoamiCommand({ configDir: tmpDir });
+
+    const allOutput = [...logSpy.mock.calls, ...errorSpy.mock.calls]
+      .map((c) => c.join(' '))
+      .join('\n');
+    expect(allOutput).toContain('Could not verify token');
+    expect(allOutput).toContain('tank login');
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = 0;
     logSpy.mockRestore();
     errorSpy.mockRestore();
   });

--- a/apps/cli/src/commands/publish.ts
+++ b/apps/cli/src/commands/publish.ts
@@ -85,7 +85,7 @@ export async function publishCommand(options: PublishOptions = {}): Promise<void
 
   const { tarball, integrity, fileCount, totalSize, readme, files } = packResult;
 
-  // 4. Dry run — print summary and exit
+  // 4. Dry run — print summary, verify auth with server, and exit
   if (dryRun) {
     spinner.stop();
     logger.info(`name:    ${name}`);
@@ -93,6 +93,28 @@ export async function publishCommand(options: PublishOptions = {}): Promise<void
     logger.info(`visibility: ${String(manifest.visibility ?? 'default')}`);
     logger.info(`size:    ${formatSize(totalSize)} (${fileCount} files)`);
     logger.info(`tarball: ${formatSize(tarball.length)} (compressed)`);
+
+    // Verify token with server to catch stale auth before real publish
+    try {
+      const verifyRes = await fetch(`${config.registry}/api/v1/auth/whoami`, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${config.token}`,
+          'User-Agent': USER_AGENT,
+        },
+      });
+
+      if (verifyRes.status === 401) {
+        logger.warn('Token is invalid or expired. Run: tank login');
+      } else if (!verifyRes.ok) {
+        logger.warn('Could not verify token with server. Publish may fail.');
+      } else {
+        logger.success('Auth verified with server.');
+      }
+    } catch {
+      logger.warn('Could not reach server to verify token. Publish may fail.');
+    }
+
     logger.success('Dry run complete — no files were uploaded.');
     return;
   }
@@ -117,14 +139,16 @@ export async function publishCommand(options: PublishOptions = {}): Promise<void
     const errorMsg = body.error ?? step1Res.statusText;
 
     if (step1Res.status === 401) {
-      throw new Error('Authentication failed. Run: tank login');
+      throw new Error('Authentication failed. Your token may be expired or invalid. Run: tank login');
     }
     if (step1Res.status === 403) {
-      if ((body.error ?? '').includes('skills:publish')) {
-        throw new Error('Token lacks required scope: skills:publish');
-      }
       throw new Error(
-        "You don't have permission to publish to this organization",
+        `Publish failed: ${errorMsg}`,
+      );
+    }
+    if (step1Res.status === 404) {
+      throw new Error(
+        `Publish failed: ${errorMsg}`,
       );
     }
     if (step1Res.status === 409) {

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -32,10 +32,11 @@ export async function whoamiCommand(options: WhoamiOptions = {}): Promise<void> 
     if (!res.ok) {
       if (config.user) {
         printUserInfo(config.user);
-        logger.warn('Could not verify token with server.');
+        logger.warn('Could not verify token with server. Run: tank login');
       } else {
-        logger.error('Could not verify token. Server returned an error.');
+        logger.error('Could not verify token. Server returned an error. Run: tank login');
       }
+      process.exitCode = 1;
       return;
     }
 
@@ -48,10 +49,11 @@ export async function whoamiCommand(options: WhoamiOptions = {}): Promise<void> 
     if (config.user) {
       logger.info(`Logged in as: ${config.user.name ?? 'unknown'} (offline)`);
       logger.info(`Email: ${config.user.email ?? 'unknown'}`);
-      logger.warn('Could not reach server to verify token.');
+      logger.warn('Could not reach server to verify token. Run: tank login');
     } else {
       logger.error('Could not verify token. Check your network connection.');
     }
+    process.exitCode = 1;
   }
 }
 

--- a/apps/web/app/api/v1/auth/whoami/route.ts
+++ b/apps/web/app/api/v1/auth/whoami/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { verifyCliAuth } from '@/lib/auth-helpers';
+import { db } from '@/lib/db';
+import { user } from '@/lib/db/auth-schema';
+
+export async function GET(request: Request) {
+  const verified = await verifyCliAuth(request);
+  if (!verified) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const users = await db
+    .select({ name: user.name, email: user.email })
+    .from(user)
+    .where(eq(user.id, verified.userId))
+    .limit(1);
+
+  if (users.length === 0) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    name: users[0].name,
+    email: users[0].email,
+    userId: verified.userId,
+  });
+}

--- a/apps/web/app/api/v1/skills/__tests__/publish.test.ts
+++ b/apps/web/app/api/v1/skills/__tests__/publish.test.ts
@@ -270,7 +270,7 @@ describe('POST /api/v1/skills', () => {
     );
     const response = await POST(request);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
   });
 
   it('returns 409 for duplicate version', async () => {

--- a/apps/web/app/api/v1/skills/route.ts
+++ b/apps/web/app/api/v1/skills/route.ts
@@ -118,7 +118,7 @@ export async function POST(request: Request) {
     if (orgs.length === 0) {
       return NextResponse.json(
         { error: `Organization '${orgSlug}' not found. You must create the org before publishing scoped packages.` },
-        { status: 403 },
+        { status: 404 },
       );
     }
 

--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -30,6 +30,17 @@ For self-hosted deployments, replace with your domain.
 | Authenticated | 1,000 |
 | Pro | 10,000 |
 
+## /api/v1/auth
+
+### GET /api/v1/auth/whoami
+
+GET endpoint for /auth/whoami
+
+```http
+GET /api/v1/auth/whoami
+```
+
+
 ## /api/v1/cli-auth
 
 ### POST /api/v1/cli-auth/authorize

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -38,6 +38,17 @@ For self-hosted deployments, replace with your domain.
 | Authenticated | 1,000 |
 | Pro | 10,000 |
 
+## /api/v1/auth
+
+### GET /api/v1/auth/whoami
+
+GET endpoint for /auth/whoami
+
+```http
+GET /api/v1/auth/whoami
+```
+
+
 ## /api/v1/cli-auth
 
 ### POST /api/v1/cli-auth/authorize


### PR DESCRIPTION
## Summary

Fixes #19 — authenticated org owner gets misleading 403 when publishing because auth failures and permission errors are conflated.

- **Server**: org-not-found now returns 404 (was 403), clearly separating "not found" from "forbidden"
- **CLI publish**: forwards actual server error messages instead of hardcoded generic "permission denied"
- **CLI whoami**: exits 1 when token can't be verified (was exit 0 with warning), so scripts like `tank whoami && tank publish` fail correctly
- **CLI publish --dry-run**: now verifies auth with server, catching stale tokens before the real publish attempt
- **Error messages**: suggest `tank login` on auth failures

## Changes

| File | Change |
|------|--------|
| `apps/web/app/api/v1/skills/route.ts` | Org not found → 404 instead of 403 |
| `apps/cli/src/commands/publish.ts` | Forward server error on 403/404; dry-run auth check |
| `apps/cli/src/commands/whoami.ts` | `process.exitCode = 1` on verification failure |
| `apps/cli/src/__tests__/publish.test.ts` | Tests for 404, forwarded errors, dry-run auth |
| `apps/cli/src/__tests__/whoami.test.ts` | Tests for exit code 1 on failure |

## Testing

All 317 CLI tests pass. No regressions.