### PR TITLE
feat(cli): add `tank upgrade` self-update command

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/apps/cli/src/__tests__/upgrade-check.test.ts
+++ b/apps/cli/src/__tests__/upgrade-check.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { checkForUpgrade } from '../lib/upgrade-check.js';
+
+vi.mock('chalk', () => ({
+  default: {
+    green: (s: string) => s,
+    red: (s: string) => s,
+    yellow: (s: string) => s,
+    cyan: (s: string) => s,
+    gray: (s: string) => s,
+    bold: (s: string) => s,
+  },
+}));
+
+const collectOutput = (spy: ReturnType<typeof vi.spyOn>): string =>
+  spy.mock.calls.map(call => call.join(' ')).join('\n');
+
+describe('checkForUpgrade', () => {
+  let tmpDir: string;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-upgrade-check-test-'));
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    originalFetch = globalThis.fetch;
+    originalEnv = { ...process.env };
+    delete process.env.TANK_NO_UPDATE_CHECK;
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    globalThis.fetch = originalFetch;
+    process.env = originalEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips check when TANK_NO_UPDATE_CHECK is set', async () => {
+    process.env.TANK_NO_UPDATE_CHECK = '1';
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    await checkForUpgrade(tmpDir);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips check when CI is set', async () => {
+    process.env.CI = 'true';
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    await checkForUpgrade(tmpDir);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('uses cached result within 24 hours', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const cache = { lastCheck: Date.now(), latestVersion: '99.0.0' };
+    fs.writeFileSync(path.join(tmpDir, 'upgrade_check.json'), JSON.stringify(cache));
+
+    await checkForUpgrade(tmpDir);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    const output = collectOutput(errorSpy);
+    expect(output).toContain('New version available');
+    expect(output).toContain('99.0.0');
+  });
+
+  it('fetches from GitHub when cache is stale', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const staleCache = { lastCheck: Date.now() - 25 * 60 * 60 * 1000, latestVersion: '0.1.0' };
+    fs.writeFileSync(path.join(tmpDir, 'upgrade_check.json'), JSON.stringify(staleCache));
+
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ tag_name: 'v99.0.0' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    await checkForUpgrade(tmpDir);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const updatedCache = JSON.parse(fs.readFileSync(path.join(tmpDir, 'upgrade_check.json'), 'utf-8'));
+    expect(updatedCache.latestVersion).toBe('99.0.0');
+  });
+
+  it('shows banner when new version available', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ tag_name: 'v99.0.0' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    await checkForUpgrade(tmpDir);
+
+    const output = collectOutput(errorSpy);
+    expect(output).toContain('New version available');
+    expect(output).toContain('99.0.0');
+    expect(output).toContain('tank upgrade');
+  });
+
+  it('silently swallows fetch errors', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(checkForUpgrade(tmpDir)).resolves.toBeUndefined();
+  });
+
+  it('silently swallows timeout errors', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+    mockFetch.mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'));
+
+    await expect(checkForUpgrade(tmpDir)).resolves.toBeUndefined();
+  });
+});

--- a/apps/cli/src/__tests__/upgrade.test.ts
+++ b/apps/cli/src/__tests__/upgrade.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { upgradeCommand } from '../commands/upgrade.js';
+
+vi.mock('chalk', () => ({
+  default: {
+    green: (s: string) => s,
+    red: (s: string) => s,
+    yellow: (s: string) => s,
+    cyan: (s: string) => s,
+    gray: (s: string) => s,
+    bold: (s: string) => s,
+  },
+}));
+
+const collectOutput = (spy: ReturnType<typeof vi.spyOn>): string =>
+  spy.mock.calls.map(call => call.join(' ')).join('\n');
+
+describe('upgradeCommand', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let originalArgv1: string;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    originalArgv1 = process.argv[1];
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    process.argv[1] = originalArgv1;
+    globalThis.fetch = originalFetch;
+  });
+
+  it('detects Homebrew installation and warns', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-upgrade-test-'));
+    try {
+      const fakeBrewBin = path.join(tmpDir, 'Cellar', 'tank', 'bin', 'tank');
+      fs.mkdirSync(path.dirname(fakeBrewBin), { recursive: true });
+      fs.writeFileSync(fakeBrewBin, '#!/bin/sh\n');
+      process.argv[1] = fakeBrewBin;
+
+      await upgradeCommand();
+
+      const output = collectOutput(logSpy);
+      expect(output).toContain('Homebrew');
+      expect(output).toContain('brew upgrade tank');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('shows already up-to-date when versions match', async () => {
+    const { VERSION } = await import('../version.js');
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ tag_name: `v${VERSION}` }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    await upgradeCommand();
+
+    const output = collectOutput(logSpy);
+    expect(output).toContain('Already on latest version');
+    expect(output).toContain(VERSION);
+  });
+
+  it('dry-run shows what would happen without downloading', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ tag_name: 'v99.0.0' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    await upgradeCommand({ dryRun: true });
+
+    const output = collectOutput(logSpy);
+    expect(output).toContain('Would upgrade');
+    expect(output).toContain('99.0.0');
+    // Only the version-check fetch, no binary download
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects on checksum mismatch', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const fakeBinary = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+    const wrongHash = 'deadbeef'.repeat(8);
+    const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+    const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+    const binaryName = `tank-${platform}-${arch}`;
+
+    // 1. Latest version response
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ tag_name: 'v99.0.0' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    // 2. Binary download
+    mockFetch.mockResolvedValueOnce(new Response(fakeBinary, { status: 200 }));
+
+    // 3. SHA256SUMS with wrong hash
+    mockFetch.mockResolvedValueOnce(new Response(
+      `${wrongHash}  ${binaryName}\n`,
+      { status: 200 },
+    ));
+
+    await upgradeCommand();
+
+    const output = collectOutput(logSpy);
+    expect(output).toContain('Checksum mismatch');
+  });
+
+  it('successfully upgrades with valid checksum', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-upgrade-target-'));
+    try {
+      // Create a fake binary that process.argv[1] points to so copyFileSync
+      // writes to our temp file instead of the real vitest process
+      const fakeBinPath = path.join(tmpDir, 'tank');
+      fs.writeFileSync(fakeBinPath, 'old-binary');
+      process.argv[1] = fakeBinPath;
+
+      const mockFetch = vi.fn();
+      globalThis.fetch = mockFetch;
+
+      const fakeBinary = new Uint8Array([0xCA, 0xFE, 0xBA, 0xBE]);
+      const actualHash = crypto.createHash('sha256').update(fakeBinary).digest('hex');
+      const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+      const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+      const binaryName = `tank-${platform}-${arch}`;
+
+      // 1. Latest version response
+      mockFetch.mockResolvedValueOnce(new Response(
+        JSON.stringify({ tag_name: 'v99.0.0' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+
+      // 2. Binary download
+      mockFetch.mockResolvedValueOnce(new Response(fakeBinary, { status: 200 }));
+
+      // 3. SHA256SUMS with correct hash
+      mockFetch.mockResolvedValueOnce(new Response(
+        `${actualHash}  ${binaryName}\n`,
+        { status: 200 },
+      ));
+
+      await upgradeCommand();
+
+      const output = collectOutput(logSpy);
+      expect(output).toContain('Upgraded tank');
+      expect(output).toContain('99.0.0');
+      expect(output).toContain('Release notes');
+
+      // Verify the binary was actually written
+      const written = fs.readFileSync(fakeBinPath);
+      expect(Buffer.from(fakeBinary).equals(written)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('force flag bypasses version check', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-upgrade-force-'));
+    try {
+      const fakeBinPath = path.join(tmpDir, 'tank');
+      fs.writeFileSync(fakeBinPath, 'old-binary');
+      process.argv[1] = fakeBinPath;
+
+      const { VERSION } = await import('../version.js');
+      const mockFetch = vi.fn();
+      globalThis.fetch = mockFetch;
+
+      const fakeBinary = new Uint8Array([0xDE, 0xAD, 0xBE, 0xEF]);
+      const actualHash = crypto.createHash('sha256').update(fakeBinary).digest('hex');
+      const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+      const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+      const binaryName = `tank-${platform}-${arch}`;
+
+      // Return current version — without force, this would short-circuit
+      mockFetch.mockResolvedValueOnce(new Response(
+        JSON.stringify({ tag_name: `v${VERSION}` }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+
+      mockFetch.mockResolvedValueOnce(new Response(fakeBinary, { status: 200 }));
+
+      mockFetch.mockResolvedValueOnce(new Response(
+        `${actualHash}  ${binaryName}\n`,
+        { status: 200 },
+      ));
+
+      await upgradeCommand({ force: true });
+
+      const output = collectOutput(logSpy);
+      // Should NOT say "already up to date" — force bypasses that
+      expect(output).not.toContain('Already on latest version');
+      // Should have made all 3 fetches (version + binary + sums)
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/bin/tank.ts
+++ b/apps/cli/src/bin/tank.ts
@@ -16,6 +16,8 @@ import { auditCommand } from '../commands/audit.js';
 import { linkCommand } from '../commands/link.js';
 import { unlinkCommand } from '../commands/unlink.js';
 import { doctorCommand } from '../commands/doctor.js';
+import { upgradeCommand } from '../commands/upgrade.js';
+import { checkForUpgrade } from '../lib/upgrade-check.js';
 import { flushLogs } from '../lib/debug-logger.js';
 import { VERSION } from '../version.js';
 
@@ -256,5 +258,25 @@ program
       process.exit(1);
     }
   });
+
+program
+  .command('upgrade')
+  .description('Update tank to the latest version')
+  .argument('[version]', 'Target version (default: latest)')
+  .option('--dry-run', 'Check for updates without installing')
+  .option('--force', 'Reinstall even if already on the target version')
+  .action(async (version: string | undefined, opts: { dryRun?: boolean; force?: boolean }) => {
+    try {
+      await upgradeCommand({ version, dryRun: opts.dryRun, force: opts.force });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Upgrade failed: ${msg}`);
+      await flushLogs();
+      process.exit(1);
+    }
+    await flushLogs();
+  });
+
+checkForUpgrade().catch(() => {});
 
 program.parse();

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import chalk from 'chalk';
+import { VERSION, USER_AGENT } from '../version.js';
+
+export interface UpgradeOptions {
+  version?: string;
+  dryRun?: boolean;
+  force?: boolean;
+}
+
+export async function upgradeCommand(opts?: UpgradeOptions): Promise<void> {
+  const resolvedArgv1 = fs.realpathSync(process.argv[1]);
+  if (resolvedArgv1.includes('/Cellar/') || resolvedArgv1.includes('/homebrew/')) {
+    console.log(chalk.yellow('Tank was installed via Homebrew. Run `brew upgrade tank` instead.'));
+    return;
+  }
+
+  let targetVersion: string;
+
+  if (opts?.version) {
+    targetVersion = opts.version;
+  } else {
+    const res = await fetch('https://api.github.com/repos/tankpkg/tank/releases/latest', {
+      headers: { 'User-Agent': USER_AGENT },
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch latest release: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as { tag_name: string };
+    targetVersion = data.tag_name.replace(/^v/, '');
+  }
+
+  if (targetVersion === VERSION && !opts?.force) {
+    console.log(chalk.green(`✓ Already on latest version: ${VERSION}`));
+    return;
+  }
+
+  const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  const binaryName = `tank-${platform}-${arch}`;
+
+  if (opts?.dryRun) {
+    console.log(`Would upgrade tank ${VERSION} → ${targetVersion}`);
+    return;
+  }
+
+  console.log(chalk.cyan(`Upgrading tank ${VERSION} → ${targetVersion}...`));
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-upgrade-'));
+
+  try {
+    const binaryUrl = `https://github.com/tankpkg/tank/releases/download/v${targetVersion}/${binaryName}`;
+    const tmpBin = path.join(tmpDir, binaryName);
+
+    const binRes = await fetch(binaryUrl, {
+      headers: { 'User-Agent': USER_AGENT },
+    });
+    if (!binRes.ok) {
+      throw new Error(`Failed to download binary: ${binRes.status} ${binRes.statusText}`);
+    }
+    if (!binRes.body) {
+      throw new Error('Empty response body when downloading binary');
+    }
+
+    const binBuffer = Buffer.from(await binRes.arrayBuffer());
+    fs.writeFileSync(tmpBin, binBuffer);
+
+    const sumsUrl = `https://github.com/tankpkg/tank/releases/download/v${targetVersion}/SHA256SUMS`;
+    const sumsRes = await fetch(sumsUrl, {
+      headers: { 'User-Agent': USER_AGENT },
+    });
+    if (!sumsRes.ok) {
+      throw new Error(`Failed to download SHA256SUMS: ${sumsRes.status} ${sumsRes.statusText}`);
+    }
+    const sumsText = await sumsRes.text();
+
+    let expectedHash: string | undefined;
+    for (const line of sumsText.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const parts = trimmed.split(/\s+/);
+      if (parts.length >= 2 && parts[1] === binaryName) {
+        expectedHash = parts[0];
+        break;
+      }
+    }
+    if (!expectedHash) {
+      throw new Error(`No checksum found for ${binaryName} in SHA256SUMS`);
+    }
+
+    const fileBuffer = fs.readFileSync(tmpBin);
+    const actualHash = crypto.createHash('sha256').update(fileBuffer).digest('hex');
+
+    if (actualHash !== expectedHash) {
+      console.log(chalk.red('Checksum mismatch. Aborting for security.'));
+      return;
+    }
+
+    fs.chmodSync(tmpBin, 0o755);
+
+    const currentBinaryPath = fs.realpathSync(process.argv[1]);
+    fs.copyFileSync(tmpBin, currentBinaryPath);
+    fs.chmodSync(currentBinaryPath, 0o755);
+
+    console.log(chalk.green(`✓ Upgraded tank ${VERSION} → ${targetVersion}`));
+    console.log(chalk.gray(`Release notes: https://github.com/tankpkg/tank/releases/tag/v${targetVersion}`));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/apps/cli/src/lib/upgrade-check.ts
+++ b/apps/cli/src/lib/upgrade-check.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
+import { getConfigDir } from './config.js';
+import { VERSION } from '../version.js';
+
+interface UpgradeCache {
+  lastCheck: number;
+  latestVersion: string;
+}
+
+export async function checkForUpgrade(configDir?: string): Promise<void> {
+  try {
+    if (process.env.TANK_NO_UPDATE_CHECK || process.env.CI) {
+      return;
+    }
+
+    const cacheDir = getConfigDir(configDir);
+    const cachePath = path.join(cacheDir, 'upgrade_check.json');
+
+    let cache: UpgradeCache | null = null;
+    try {
+      const raw = fs.readFileSync(cachePath, 'utf-8');
+      cache = JSON.parse(raw) as UpgradeCache;
+    } catch {
+      // File doesn't exist or invalid JSON — treat as stale
+    }
+
+    const isFresh = cache !== null && (Date.now() - cache.lastCheck) < 24 * 60 * 60 * 1000;
+
+    if (isFresh && cache !== null) {
+      if (cache.latestVersion !== VERSION) {
+        console.error(`\n  ${chalk.cyan('ℹ')} New version available: ${chalk.gray(VERSION)} → ${chalk.green(cache.latestVersion)}`);
+        console.error(`  Run ${chalk.cyan('`tank upgrade`')} to update.\n`);
+      }
+      return;
+    }
+
+    const res = await fetch('https://api.github.com/repos/tankpkg/tank/releases/latest', {
+      headers: { 'User-Agent': `tank-cli/${VERSION}` },
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) {
+      return;
+    }
+    const data = (await res.json()) as { tag_name: string };
+    const latestVersion = data.tag_name.replace(/^v/, '');
+
+    if (!fs.existsSync(cacheDir)) {
+      fs.mkdirSync(cacheDir, { recursive: true });
+    }
+    const newCache: UpgradeCache = { lastCheck: Date.now(), latestVersion };
+    fs.writeFileSync(cachePath, JSON.stringify(newCache, null, 2) + '\n');
+
+    if (latestVersion !== VERSION) {
+      console.error(`\n  ${chalk.cyan('ℹ')} New version available: ${chalk.gray(VERSION)} → ${chalk.green(latestVersion)}`);
+      console.error(`  Run ${chalk.cyan('`tank upgrade`')} to update.\n`);
+    }
+  } catch {
+    // Silently swallow ALL errors — background check must never cause CLI to fail
+  }
+}

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -98,3 +98,25 @@ Diagnose agent integration health
 tank doctor
 ```
 
+
+## tank upgrade
+
+Update tank to the latest version
+
+```bash
+tank upgrade [version]
+```
+
+### Arguments
+
+| Name | Description | Required |
+|------|-------------|----------|
+| `version` | Target version (default: latest) | No |
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Check for updates without installing |
+| `--force` | Reinstall even if already on the target version |
+

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -501,6 +501,28 @@ tank doctor
 ```
 
 
+## tank upgrade
+
+Update tank to the latest version
+
+```bash
+tank upgrade [version]
+```
+
+### Arguments
+
+| Name | Description | Required |
+|------|-------------|----------|
+| `version` | Target version (default: latest) | No |
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Check for updates without installing |
+| `--force` | Reinstall even if already on the target version |
+
+
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `tank upgrade` — Deno/Bun-style in-place binary self-update from GitHub Releases
- Adds background version check (24hr cached) that shows a banner when a new version is available
- Bumps CLI version `0.2.0` → `0.3.0`

## `tank upgrade`

| Usage | Description |
|---|---|
| `tank upgrade` | Update to latest version |
| `tank upgrade 0.3.1` | Pin to specific version |
| `tank upgrade --dry-run` | Check without installing |
| `tank upgrade --force` | Reinstall same version |

- Downloads binary from GitHub Releases
- Verifies SHA-256 checksum before replacing
- Detects Homebrew installs → tells user to `brew upgrade tank` instead

## Background version check

On every `tank` invocation (fire-and-forget, non-blocking):
- Checks GitHub API at most once per 24 hours
- Shows banner: `ℹ New version available: 0.2.0 → 0.3.0 — Run tank upgrade to update.`
- Suppressed by `TANK_NO_UPDATE_CHECK=1` or `CI=true`
- 3s timeout, silently swallows all errors

## Testing

334 tests pass (321 existing + 13 new). New test files:
- `upgrade.test.ts` — 6 tests (Homebrew detection, version check, dry-run, checksum verification, successful upgrade, force flag)
- `upgrade-check.test.ts` — 7 tests (env var suppression, cache freshness, stale fetch, banner display, error swallowing)