### PR TITLE
fix(ci): prevent Homebrew formula step from blocking releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
         run: sha256sum tank-* *.deb > SHA256SUMS
 
       - name: Update in-repo Homebrew formula
+        continue-on-error: true
         run: |
           VERSION_NO_V="${VERSION#v}"
 


### PR DESCRIPTION
## Problem

The release workflow's "Update Homebrew formula" step pushes directly to `main`, which fails due to branch protection (requires PRs + status checks). This step runs before "Create GitHub release", so the entire workflow fails — **no binaries get published**.

This broke v0.2.0 and v0.3.0 releases.

## Fix

Add `continue-on-error: true` to the Homebrew formula step. The release gets created regardless of whether the formula push succeeds.