### PR TITLE
fix(cli): resolve binary path for Bun SEA builds in upgrade command

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -11,9 +11,17 @@ export interface UpgradeOptions {
   force?: boolean;
 }
 
+function resolveCurrentBinary(): string {
+  try {
+    return fs.realpathSync(process.argv[1]);
+  } catch {
+    return process.execPath;
+  }
+}
+
 export async function upgradeCommand(opts?: UpgradeOptions): Promise<void> {
-  const resolvedArgv1 = fs.realpathSync(process.argv[1]);
-  if (resolvedArgv1.includes('/Cellar/') || resolvedArgv1.includes('/homebrew/')) {
+  const currentBinaryPath = resolveCurrentBinary();
+  if (currentBinaryPath.includes('/Cellar/') || currentBinaryPath.includes('/homebrew/')) {
     console.log(chalk.yellow('Tank was installed via Homebrew. Run `brew upgrade tank` instead.'));
     return;
   }
@@ -101,7 +109,6 @@ export async function upgradeCommand(opts?: UpgradeOptions): Promise<void> {
 
     fs.chmodSync(tmpBin, 0o755);
 
-    const currentBinaryPath = fs.realpathSync(process.argv[1]);
     fs.copyFileSync(tmpBin, currentBinaryPath);
     fs.chmodSync(currentBinaryPath, 0o755);
 


### PR DESCRIPTION
## Problem

`tank upgrade` crashes on Bun SEA binaries because `process.argv[1]` points to `/$bunfs/root/tank-darwin-arm64` (Bun's virtual filesystem), causing `fs.realpathSync()` to throw ENOENT.

## Fix

Fall back to `process.execPath` when `realpathSync(process.argv[1])` fails. `process.execPath` gives the actual binary path on disk for both Node.js and Bun SEA.

Bumps CLI `0.3.0` → `0.3.1`.