### PR TITLE
fix(ci): add @tankpkg/mcp-server to npm publish pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,16 +237,26 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           node -e "const p=require('./apps/cli/package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./apps/cli/package.json', JSON.stringify(p, null, 2)+'\n')"
+          node -e "const p=require('./packages/mcp-server/package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./packages/mcp-server/package.json', JSON.stringify(p, null, 2)+'\n')"
 
-      - name: Build CLI package
+      - name: Build packages
         run: |
           pnpm --filter @tank/shared build
           pnpm --filter ./apps/cli build
+          pnpm --filter @tankpkg/mcp-server build
 
-      - name: Publish to npm
+      - name: Publish CLI to npm
         continue-on-error: true
         if: ${{ env.NPM_TOKEN != '' }}
         working-directory: apps/cli
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+        run: pnpm publish --no-git-checks --access public
+
+      - name: Publish MCP server to npm
+        continue-on-error: true
+        if: ${{ env.NPM_TOKEN != '' }}
+        working-directory: packages/mcp-server
         env:
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         run: pnpm publish --no-git-checks --access public


### PR DESCRIPTION
## Summary

- Adds `@tankpkg/mcp-server` to the Release workflow's `publish-npm` job
- Version injection now stamps both `apps/cli` and `packages/mcp-server` with the git tag version
- Build step now also builds `@tankpkg/mcp-server` (after `@tank/shared`)
- Separate publish step for the MCP server with `continue-on-error: true` so CLI and MCP server publishes are independent

## Why

PR #27 added `packages/mcp-server` but the release workflow was never updated to publish it. The v0.4.0 release published the CLI successfully but `@tankpkg/mcp-server` was never uploaded to npm, making `npx -y @tankpkg/mcp-server` fail with a 404.

## Verification

- YAML syntax validated
- `pnpm --filter @tankpkg/mcp-server build` — compiles clean
- `pnpm --filter @tankpkg/mcp-server test` — 28/28 tests pass