### PR TITLE
fix(admin): fix rescan-skills 405 error and scan only latest versions

### DIFF
--- a/apps/web/app/api/admin/rescan-skills/route.ts
+++ b/apps/web/app/api/admin/rescan-skills/route.ts
@@ -65,3 +65,14 @@ const handler = async (_req: NextRequest, _context: AdminAuthContext): Promise<N
 };
 
 export const POST = withAdminAuth(handler);
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
+  });
+}

--- a/apps/web/components/admin/rescan-skills-button.tsx
+++ b/apps/web/components/admin/rescan-skills-button.tsx
@@ -26,6 +26,7 @@ export function RescanSkillsButton() {
     try {
       const response = await fetch('/api/admin/rescan-skills', {
         method: 'POST',
+        credentials: 'include',
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary
- Fix 405 error by adding CORS OPTIONS handler for preflight requests
- Add `credentials: 'include'` to fetch request for session cookies  
- Scan only the **latest version** of each skill (not all versions)
- Include `flagged` and `scan-failed` statuses in rescannable versions
- Remove duplicate rescan button from admin dashboard (kept in packages page)
- Add CI job to auto-deploy Python API when `python-api/` changes

## Test plan
- [ ] Verify rescan button in `/admin/packages` works without 405 error
- [ ] Confirm only latest versions are scanned (not all versions)
- [ ] Check that `PYTHON_API_URL` is set on Vercel for scans to work

## Required setup
After merge, add these GitHub secrets for Python API auto-deployment:
- `VERCEL_TOKEN` - Create at vercel.com/account/tokens
- `VERCEL_ORG_ID` - `team_qt1Zy0XR2RSgRS2nftw48CKx`
- `VERCEL_PYTHON_API_PROJECT_ID` - `prj_4PE40Q6PmgbJ1jYUY2zwcDgc1Z37`

And set `PYTHON_API_URL=https://python-api-pink.vercel.app` on the web app in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)