### PR TITLE
fix: use reverse proxy for PostHog and add ui_host for EU region

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -15,6 +15,7 @@ if (
 ) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    ui_host: 'https://eu.posthog.com',
     // GDPR: don't track until user accepts cookies
     opt_out_capturing_by_default: true,
     opt_out_capturing_persistence_type: 'localStorage',


### PR DESCRIPTION
## Summary

- Route PostHog events through `https://t.tankpkg.dev` reverse proxy to avoid ad blockers
- Add `ui_host: 'https://eu.posthog.com'` so PostHog UI links resolve correctly for EU region
- Updated `NEXT_PUBLIC_POSTHOG_HOST` in Vercel to `https://t.tankpkg.dev`