### PR TITLE
fix(vercel): update vercel.json to use rewrites

### DIFF
--- a/python-api/vercel.json
+++ b/python-api/vercel.json
@@ -1,14 +1,5 @@
 {
-  "builds": [
-    {
-      "src": "index.py",
-      "use": "@vercel/python"
-    }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "index.py"
-    }
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- Update `vercel.json` to use modern `rewrites` format instead of legacy `builds`/`routes`
- This fixes the 404 errors on `/api/analyze/scan` endpoint

## Problem
The legacy `builds`/`routes` configuration was breaking FastAPI routing:
- `/api/analyze/scan` returned 404
- The `dest: "index.py"` was stripping the request paths

## Solution
- Replace `builds`/`routes` with `rewrites`
- The new configuration preserves the full request path to FastAPI
- All routes (`/api/analyze/*`, `/health`, etc.) will work correctly

## Test Plan
- [ ] Merge this PR
- [ ] Verify deployment succeeds on Vercel
- [ ] Test: `curl https://python-api-pink.vercel.app/health`
- [ ] Test: `curl -X POST https://python-api-pink.vercel.app/api/analyze/scan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)