### PR TITLE
fix(vercel): add build-system section to pyproject.toml

### DIFF
--- a/python-api/pyproject.toml
+++ b/python-api/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "tank-scanner"
 version = "2.0.0"
@@ -23,3 +27,7 @@ dev = [
 
 [project.scripts]
 app = "api.main:app"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["api*", "lib*"]


### PR DESCRIPTION
## Summary
- Add `[build-system]` section required by Vercel's Python runtime
- Add `[tool.setuptools.packages.find]` for proper package discovery

## Problem
Vercel deployment failed with:
```
ModuleNotFoundError: No module named 'fastapi'
```

Vercel wasn't installing dependencies because `pyproject.toml` lacked a `[build-system]` section.

## Solution
- Added PEP 517 compliant `[build-system]` section
- Configured setuptools to find `api*` and `lib*` packages

## Test Plan
- [ ] Merge this PR
- [ ] Verify Vercel deployment succeeds
- [ ] Test: `curl https://python-api-pink.vercel.app/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)