### PR TITLE
fix(admin): ensure rescan-skills route is dynamically rendered

### DIFF
--- a/apps/web/app/api/admin/rescan-skills/route.ts
+++ b/apps/web/app/api/admin/rescan-skills/route.ts
@@ -8,7 +8,9 @@ import { rescanVersion } from '@/lib/rescan';
 // Statuses that indicate a version has been scanned and can be rescanned
 const RESCANNABLE_STATUSES = ['completed', 'flagged', 'scan-failed'] as const;
 
-const handler = async (_req: NextRequest, _context: AdminAuthContext): Promise<NextResponse> => {
+export const dynamic = 'force-dynamic';
+
+async function handler(_req: NextRequest, _context: AdminAuthContext): Promise<NextResponse> {
   try {
     // Get only the latest version of each skill by ordering and filtering
     const versions = await db


### PR DESCRIPTION
## Summary
- Add `export const dynamic = 'force-dynamic'` to the rescan-skills API route
- This ensures the route is always dynamically rendered and not cached by Vercel
- Fixes 404 error when accessing `/api/admin/rescan-skills`

## Test plan
- [ ] Deploy to Vercel and verify the route returns 200 instead of 404
- [ ] Click "Rescan All Skills" button in admin panel
- [ ] Verify rescans complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)