### PR TITLE
chore: add structured GitHub issue templates for OSS development

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,13 +6,23 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for reporting a bug! Please fill out the sections below to help us understand and reproduce the issue.
+        Thanks for taking the time to report this. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: checkboxes
+    id: pre-submission
+    attributes:
+      label: Pre-Submission Checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I can reproduce this on the latest version of Tank.
+          required: true
 
   - type: textarea
     id: description
     attributes:
       label: Description
-      description: A clear description of the bug.
+      description: A clear, concise description of the bug.
       placeholder: What happened?
     validations:
       required: true
@@ -21,7 +31,7 @@ body:
     id: steps
     attributes:
       label: Steps to Reproduce
-      description: Step-by-step instructions to reproduce the issue.
+      description: Minimal steps to reproduce the issue.
       placeholder: |
         1. Run `tank install @org/skill`
         2. ...
@@ -41,7 +51,30 @@ body:
     id: actual
     attributes:
       label: Actual Behavior
-      description: What actually happened? Include error messages or logs if available.
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output / Logs
+      description: Paste the full error message, stack trace, or relevant log output. Run with `TANK_DEBUG=1` for verbose logs.
+      render: bash
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Affected Area
+      description: Which part of Tank is affected?
+      options:
+        - CLI
+        - MCP Server
+        - Registry / Web
+        - Security Scanner
+        - Permissions
+        - Skills Resolution
+        - Other
     validations:
       required: true
 
@@ -51,13 +84,17 @@ body:
       label: Tank Version
       description: Output of `tank --version`
       placeholder: "0.1.0"
+    validations:
+      required: true
 
   - type: input
     id: node-version
     attributes:
       label: Node.js Version
       description: Output of `node --version`
-      placeholder: "v20.10.0"
+      placeholder: "v24.0.0"
+    validations:
+      required: true
 
   - type: dropdown
     id: os
@@ -68,9 +105,11 @@ body:
         - Linux
         - Windows
         - Other
+    validations:
+      required: true
 
   - type: textarea
     id: context
     attributes:
       label: Additional Context
-      description: Any other context, screenshots, or logs that might help.
+      description: Any other context, screenshots, or `skills.json` / `tank-lock.json` snippets that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/tankpkg/tank/security/advisories/new
+    about: Report security vulnerabilities privately. Do NOT open a public issue for security bugs.
+  - name: Questions & Discussions
+    url: https://github.com/tankpkg/tank/discussions
+    about: Ask questions, share ideas, or get help from the community.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,60 @@
+name: Documentation
+description: Report incorrect, missing, or unclear documentation
+title: "[Docs]: "
+labels: ["documentation", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the docs! Whether it's a typo, missing info, or a confusing explanation — we want to hear about it.
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What kind of documentation issue is this?
+      options:
+        - Incorrect / outdated information
+        - Missing documentation
+        - Unclear or confusing explanation
+        - Typo or formatting issue
+        - New documentation request
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Page URL or File Path
+      description: Link to the page or path to the file with the issue.
+      placeholder: "https://tank.dev/docs/... or apps/web/content/docs/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's wrong or missing? Be as specific as possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Fix
+      description: If you have a proposed fix or improvement, describe it here.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Documentation Area
+      options:
+        - Getting Started / Installation
+        - CLI Reference
+        - MCP Server
+        - Skills Authoring
+        - Security / Permissions
+        - API Reference
+        - Contributing Guide
+        - Other

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,13 +6,21 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting a feature! Please describe the problem you're trying to solve and your proposed solution.
+        Thanks for suggesting a feature! Focus on the problem you're trying to solve — we'll figure out the best solution together.
+
+  - type: checkboxes
+    id: pre-submission
+    attributes:
+      label: Pre-Submission Checklist
+      options:
+        - label: I have searched existing issues and this feature has not been requested.
+          required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: Problem
-      description: What problem does this feature solve? What's the use case?
+      label: Problem Statement
+      description: What problem does this feature solve? What's the use case? Focus on the problem, not the solution.
       placeholder: "I'm always frustrated when..."
     validations:
       required: true
@@ -21,7 +29,7 @@ body:
     id: solution
     attributes:
       label: Proposed Solution
-      description: How would you like this to work? Be as specific as you can.
+      description: How would you like this to work? Include API design, CLI UX, or configuration examples if applicable.
     validations:
       required: true
 
@@ -32,20 +40,38 @@ body:
       description: Have you considered any alternative solutions or workarounds?
 
   - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this to your workflow?
+      options:
+        - Critical — blocking my use of Tank
+        - High — significantly impacts my workflow
+        - Medium — would be a meaningful improvement
+        - Low — nice to have
+      default: 2
+    validations:
+      required: true
+
+  - type: dropdown
     id: scope
     attributes:
-      label: Scope
-      description: Which part of Tank does this relate to?
+      label: Affected Areas
+      description: Which parts of Tank does this relate to?
+      multiple: true
       options:
         - CLI
-        - Registry API
-        - Permission system
-        - Audit / security
+        - MCP Server
+        - Registry / Web
+        - Security Scanner
+        - Permissions
+        - Skills Resolution
         - Documentation
+        - GitHub Action
         - Other
 
   - type: textarea
     id: context
     attributes:
       label: Additional Context
-      description: Any other context, mockups, or examples.
+      description: Links to related issues, prior art, mockups, or other supporting context.


### PR DESCRIPTION
## Summary

- **Upgraded** `bug_report.yml` — pre-submission checklist, `render: bash` for error output, affected area dropdown, all env fields required
- **Upgraded** `feature_request.yml` — pre-submission checklist, priority dropdown (Critical→Low), multi-select affected areas matching monorepo components
- **Added** `docs.yml` — documentation improvement template with type classification and doc area scope
- **Added** `config.yml` — disables blank issues, redirects security vulnerabilities to private advisory, questions to Discussions

All templates validated against GitHub Issue Forms spec (YAML syntax, unique IDs/labels, valid types, dropdown constraints, required fields).