### PR TITLE
chore(release): align mcp-server with v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-#### CLI Dependency Graph Resolver (`@tankpkg/cli` 0.5.0 → 0.6.0)
+#### CLI + MCP Release Alignment (`@tankpkg/cli` 0.5.0 → 0.6.0, `@tankpkg/mcp-server` 0.2.0 → 0.6.0)
 
 - `tank install` now resolves the full skill dependency graph up front from registry metadata before downloading tarballs
 - Transitive skill dependencies are recorded in `skills.lock`, making the resolved graph reconstructable from lockfile data alone
 - Shared dependencies are deduplicated into a single resolved version per skill name during install planning
 - Tarball downloads for resolved skills now run in parallel with a bounded concurrency limit
+- `@tankpkg/mcp-server` is version-aligned with the CLI for the `v0.6.0` repo release
 
 ### Changed
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/mcp-server",
-  "version": "0.2.0",
+  "version": "0.6.0",
   "description": "MCP server for Tank - scan and publish AI agent skills from your editor",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump `@tankpkg/mcp-server` from 0.2.0 to 0.6.0 so package metadata matches the 0.6.0 release
- update the 0.6.0 changelog entry to note the CLI + MCP release alignment

## Verification
- metadata-only change; no code paths changed
- relevant install BDD suite already passed locally against the local registry