### PR TITLE
fix(cli): avoid downgrade upgrade banner

### DIFF
--- a/apps/cli/src/__tests__/upgrade-check.test.ts
+++ b/apps/cli/src/__tests__/upgrade-check.test.ts
@@ -75,6 +75,19 @@ describe('checkForUpgrade', () => {
     expect(output).toContain('99.0.0');
   });
 
+  it('does not show banner when cached version is older than current version', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const cache = { lastCheck: Date.now(), latestVersion: '0.5.0' };
+    fs.writeFileSync(path.join(tmpDir, 'upgrade_check.json'), JSON.stringify(cache));
+
+    await checkForUpgrade(tmpDir);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(collectOutput(errorSpy)).toBe('');
+  });
+
   it('fetches from GitHub when cache is stale', async () => {
     const mockFetch = vi.fn();
     globalThis.fetch = mockFetch;
@@ -109,6 +122,20 @@ describe('checkForUpgrade', () => {
     expect(output).toContain('New version available');
     expect(output).toContain('99.0.0');
     expect(output).toContain('tank upgrade');
+  });
+
+  it('does not show banner when fetched version is older than current version', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    mockFetch.mockResolvedValueOnce(new Response(
+      JSON.stringify({ tag_name: 'v0.5.0' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    await checkForUpgrade(tmpDir);
+
+    expect(collectOutput(errorSpy)).toBe('');
   });
 
   it('silently swallows fetch errors', async () => {

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -3,12 +3,21 @@ import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import chalk from 'chalk';
+import { resolve } from '@tank/shared';
 import { VERSION, USER_AGENT } from '../version.js';
 
 export interface UpgradeOptions {
   version?: string;
   dryRun?: boolean;
   force?: boolean;
+}
+
+function isNewerVersion(candidateVersion: string, currentVersion: string): boolean {
+  if (candidateVersion === currentVersion) {
+    return false;
+  }
+
+  return resolve('*', [candidateVersion, currentVersion]) === candidateVersion;
 }
 
 function resolveCurrentBinary(): string {
@@ -41,7 +50,7 @@ export async function upgradeCommand(opts?: UpgradeOptions): Promise<void> {
     targetVersion = data.tag_name.replace(/^v/, '');
   }
 
-  if (targetVersion === VERSION && !opts?.force) {
+  if (!isNewerVersion(targetVersion, VERSION) && !opts?.force) {
     console.log(chalk.green(`✓ Already on latest version: ${VERSION}`));
     return;
   }

--- a/apps/cli/src/lib/upgrade-check.ts
+++ b/apps/cli/src/lib/upgrade-check.ts
@@ -1,12 +1,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
+import { resolve } from '@tank/shared';
 import { getConfigDir } from './config.js';
 import { VERSION } from '../version.js';
 
 interface UpgradeCache {
   lastCheck: number;
   latestVersion: string;
+}
+
+function isNewerVersion(candidateVersion: string, currentVersion: string): boolean {
+  if (candidateVersion === currentVersion) {
+    return false;
+  }
+
+  return resolve('*', [candidateVersion, currentVersion]) === candidateVersion;
 }
 
 export async function checkForUpgrade(configDir?: string): Promise<void> {
@@ -29,7 +38,7 @@ export async function checkForUpgrade(configDir?: string): Promise<void> {
     const isFresh = cache !== null && (Date.now() - cache.lastCheck) < 24 * 60 * 60 * 1000;
 
     if (isFresh && cache !== null) {
-      if (cache.latestVersion !== VERSION) {
+      if (isNewerVersion(cache.latestVersion, VERSION)) {
         console.error(`\n  ${chalk.cyan('ℹ')} New version available: ${chalk.gray(VERSION)} → ${chalk.green(cache.latestVersion)}`);
         console.error(`  Run ${chalk.cyan('`tank upgrade`')} to update.\n`);
       }
@@ -52,7 +61,7 @@ export async function checkForUpgrade(configDir?: string): Promise<void> {
     const newCache: UpgradeCache = { lastCheck: Date.now(), latestVersion };
     fs.writeFileSync(cachePath, JSON.stringify(newCache, null, 2) + '\n');
 
-    if (latestVersion !== VERSION) {
+    if (isNewerVersion(latestVersion, VERSION)) {
       console.error(`\n  ${chalk.cyan('ℹ')} New version available: ${chalk.gray(VERSION)} → ${chalk.green(latestVersion)}`);
       console.error(`  Run ${chalk.cyan('`tank upgrade`')} to update.\n`);
     }


### PR DESCRIPTION
## Summary
- only show the update banner when the fetched or cached version is semver-newer than the current CLI version
- apply the same semver guard to the explicit `tank upgrade` latest-version path
- add regression tests for older cached and fetched versions

## Verification
- `pnpm --filter=@tankpkg/cli test -- src/__tests__/upgrade-check.test.ts src/__tests__/upgrade.test.ts`
- `448/448` CLI tests passing locally
- `lsp_diagnostics` clean for the changed files