### PR TITLE
fix(vercel): use branch-based ignoreCommand + add org-name search BDD tests

### DIFF
--- a/.bdd/features/search/search.feature
+++ b/.bdd/features/search/search.feature
@@ -67,6 +67,23 @@ Feature: Skill discovery via hybrid search
     When I search for "auth"
     Then the first result name contains "auth"
 
+  # ── Bare org-name matching (C10) ──────────────────────────────────
+
+  @high
+  Scenario: Bare org name without @ finds all org skills (E11)
+    When I search for the bare org name without @
+    Then the results contain all 5 seeded skills
+
+  @medium
+  Scenario: Bare org name match ranks org skills above unrelated hits (E12)
+    When I search for the bare org name without @
+    Then every result from the seeded org has a positive score
+
+  @medium
+  Scenario: Org name search is case-insensitive (E13)
+    When I search for the org name in mixed case
+    Then the results contain all 5 seeded skills
+
   # ── Safety & edge cases (C4) ───────────────────────────────────────
 
   @high

--- a/.bdd/steps/search.steps.ts
+++ b/.bdd/steps/search.steps.ts
@@ -158,6 +158,14 @@ function thenRanksAbove(higherName: string, lowerName: string): void {
   }
 }
 
+function thenEverySeededOrgResultHasPositiveScore(): void {
+  const ourResults = world.lastResults.filter((r) => r.name.startsWith(`@${world.org}/`));
+  expect(ourResults.length).toBeGreaterThanOrEqual(1);
+  for (const r of ourResults) {
+    expect(r.score).toBeGreaterThan(0);
+  }
+}
+
 function thenNoResultsMatchSeededOrg(): void {
   const ourResults = world.lastResults.filter((r) => r.name.startsWith(`@${world.org}/`));
   expect(ourResults.length).toBe(0);
@@ -247,6 +255,30 @@ describe('Feature: Skill discovery via hybrid search', () => {
     it('runs Given/When/Then', async () => {
       await whenISearchFor('auth');
       thenFirstResultNameContains('auth');
+    });
+  });
+
+  // ── Bare org-name matching ──────────────────────────────────────────
+
+  describe('Scenario: Bare org name without @ finds all org skills (E11)', () => {
+    it('runs Given/When/Then', async () => {
+      await whenISearchFor(world.org);
+      thenResultsContainAllSeeded();
+    });
+  });
+
+  describe('Scenario: Bare org name match ranks org skills above unrelated hits (E12)', () => {
+    it('runs Given/When/Then', async () => {
+      await whenISearchFor(world.org);
+      thenEverySeededOrgResultHasPositiveScore();
+    });
+  });
+
+  describe('Scenario: Org name search is case-insensitive (E13)', () => {
+    it('runs Given/When/Then', async () => {
+      const mixedCase = world.org.charAt(0).toUpperCase() + world.org.slice(1);
+      await whenISearchFor(mixedCase);
+      thenResultsContainAllSeeded();
     });
   });
 

--- a/.idd/modules/search/INTENT.md
+++ b/.idd/modules/search/INTENT.md
@@ -49,6 +49,7 @@ No new tables. Extends the existing `skills` table with a GIN trigram index.
 | C7 | Results include: name, description, visibility, latestVersion, auditScore, publisher, downloads, stars | CLI and web UI depend on this response shape | Unit test |
 | C8 | Requires `pg_trgm` extension and GIN index on `skills.name` | Without the extension, `similarity()` calls fail at runtime | Migration + CI |
 | C9 | API route delegates entirely to `searchSkills()` — no duplicated SQL | Prevents logic drift between API and Server Component consumers | Code review |
+| C10 | Bare org name (without `@`) must match the org portion of scoped names | Users type "tank" not "@tank" — the search must split on `@`/`/` and match the org segment | BDD scenario |
 
 ---
 
@@ -66,3 +67,6 @@ No new tables. Extends the existing `skills` table with a GIN trigram index.
 | E8 | `searchSkills("auth", ...)` where `auth-patterns` exists plus a description-only match | Name-contains match ranks above description-only match |
 | E9 | `searchSkills("zzzyyyxxx-nonexistent", ...)` | Returns zero results for the seeded org |
 | E10 | `searchSkills("'; DROP TABLE skills;--", ...)` | No SQL error, returns empty or unrelated results — input safely escaped |
+| E11 | `searchSkills("myorg", ...)` where 5 `@myorg/*` skills exist | Returns all 5 skills — bare org name matches the org segment before `/` |
+| E12 | `searchSkills("myorg", ...)` ranking | Org-prefix matches rank above unrelated description-only hits |
+| E13 | `searchSkills("Myorg", ...)` (mixed case) | Case-insensitive — returns same results as lowercase |

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "cd ../.. && pnpm install",
   "buildCommand": "cd ../.. && pnpm turbo build --filter=@tank/web...",
-  "ignoreCommand": "[ \"$VERCEL_ENV\" != \"production\" ]"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; exit 0"
 }

--- a/python-api/vercel.json
+++ b/python-api/vercel.json
@@ -3,5 +3,5 @@
   "rewrites": [
     { "source": "/(.*)", "destination": "/index" }
   ],
-  "ignoreCommand": "[ \"$VERCEL_ENV\" != \"production\" ]"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; exit 0"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,5 @@
   "buildCommand": "pnpm turbo build --filter=@tank/web...",
   "installCommand": "pnpm install",
   "devCommand": "pnpm --filter=@tank/web dev",
-  "ignoreCommand": "[ \"$VERCEL_ENV\" != \"production\" ]"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; exit 0"
 }


### PR DESCRIPTION
## Summary

- **Fix production deployment**: The `VERCEL_ENV`-based `ignoreCommand` was skipping ALL builds including production. Switched to `VERCEL_GIT_COMMIT_REF=main` check so production always deploys while PR previews are still skipped.
- **Add 3 BDD scenarios** (E11–E13) for bare org-name search — searching "tank" (without `@`) must find all `@tank/*` skills
- **Add INTENT constraint C10** documenting org-name matching requirement

## Root cause of the search issue

The user's screenshots showed only 2 results for "tank" because **production was still running the old FTS-only code** — our merge was blocked from deploying by the broken `ignoreCommand`. The hybrid search SQL is correct (ILIKE `%tank%` matches all 46 public `@tank/*` skills).

## Changed files

| File | Change |
|------|--------|
| `vercel.json` | Fix ignoreCommand to use branch name |
| `apps/web/vercel.json` | Same fix |
| `python-api/vercel.json` | Same fix |
| `.idd/modules/search/INTENT.md` | Add C10 constraint + E11–E13 examples |
| `.bdd/features/search/search.feature` | Add 3 org-name scenarios |
| `.bdd/steps/search.steps.ts` | Add step definitions for E11–E13 |