### PR TITLE
fix(cli): guard against null response body in error handling

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/apps/cli/src/commands/info.ts
+++ b/apps/cli/src/commands/info.ts
@@ -70,8 +70,8 @@ export async function infoCommand(options: InfoOptions): Promise<void> {
   }
 
   if (!metaRes.ok) {
-    const body = await metaRes.json().catch(() => ({})) as { error?: string };
-    throw new Error(body.error ?? `Failed to fetch skill info: ${metaRes.statusText}`);
+    const body = await metaRes.json().catch(() => null) as { error?: string } | null;
+    throw new Error(body?.error ?? `Failed to fetch skill info: ${metaRes.statusText}`);
   }
 
   const meta = await metaRes.json() as SkillMetadata;

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -109,8 +109,8 @@ function createRegistryFetcher(
       if (!res.ok) {
         if (res.status === 403) throw new Error('Token lacks required scope: skills:read');
         if (res.status === 404) throw new Error(`Skill not found or no access: ${name}`);
-        const body = await res.json().catch(() => ({})) as { error?: string };
-        throw new Error(body.error ?? res.statusText);
+        const body = await res.json().catch(() => null) as { error?: string } | null;
+        throw new Error(body?.error ?? res.statusText);
       }
       const data = await res.json() as { name: string; versions: RegistryVersionInfo[] };
       versionsCache.set(name, data.versions);
@@ -134,8 +134,8 @@ function createRegistryFetcher(
       if (!res.ok) {
         if (res.status === 403) throw new Error('Token lacks required scope: skills:read');
         if (res.status === 404) throw new Error(`Skill not found or no access: ${name}@${version}`);
-        const body = await res.json().catch(() => ({})) as { error?: string };
-        throw new Error(body.error ?? res.statusText);
+        const body = await res.json().catch(() => null) as { error?: string } | null;
+        throw new Error(body?.error ?? res.statusText);
       }
 
       const data = await res.json() as RegistrySkillMeta;
@@ -546,8 +546,8 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
         if (metaRes.status === 404) {
           throw new Error(`Skill or version not found: ${key}`);
         }
-        const body = await metaRes.json().catch(() => ({})) as { error?: string };
-        throw new Error(`Failed to fetch ${key}: ${body.error ?? metaRes.statusText}`);
+        const body = await metaRes.json().catch(() => null) as { error?: string } | null;
+        throw new Error(`Failed to fetch ${key}: ${body?.error ?? metaRes.statusText}`);
       }
 
       const metadata = await metaRes.json() as VersionMetadata;

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -43,10 +43,10 @@ export async function loginCommand(options: LoginOptions = {}): Promise<void> {
   });
 
   if (!startRes.ok) {
-    const body = await startRes.json().catch(() => ({}));
-    authFlowLog.error({ status: startRes.status, error: (body as { error?: string }).error }, 'Start request failed');
+    const body = await startRes.json().catch(() => null) as { error?: string } | null;
+    authFlowLog.error({ status: startRes.status, error: body?.error }, 'Start request failed');
     throw new Error(
-      `Failed to start auth session: ${(body as { error?: string }).error ?? startRes.statusText}`,
+      `Failed to start auth session: ${body?.error ?? startRes.statusText}`,
     );
   }
 
@@ -101,9 +101,9 @@ export async function loginCommand(options: LoginOptions = {}): Promise<void> {
       // 400 means session not yet authorized — keep polling
       // Any other error is unexpected
       if (exchangeRes.status !== 400) {
-        const body = await exchangeRes.json().catch(() => ({}));
+        const body = await exchangeRes.json().catch(() => null) as { error?: string } | null;
         throw new Error(
-          `Exchange failed: ${(body as { error?: string }).error ?? exchangeRes.statusText}`,
+          `Exchange failed: ${body?.error ?? exchangeRes.statusText}`,
         );
       }
     } catch (err) {

--- a/apps/cli/src/commands/publish.ts
+++ b/apps/cli/src/commands/publish.ts
@@ -135,8 +135,8 @@ export async function publishCommand(options: PublishOptions = {}): Promise<void
 
   if (!step1Res.ok) {
     spinner.fail('Publish failed');
-    const body = await step1Res.json().catch(() => ({})) as { error?: string };
-    const errorMsg = body.error ?? step1Res.statusText;
+    const body = await step1Res.json().catch(() => null) as { error?: string } | null;
+    const errorMsg = body?.error ?? step1Res.statusText;
 
     if (step1Res.status === 401) {
       throw new Error('Authentication failed. Your token may be expired or invalid. Run: tank login');
@@ -196,9 +196,9 @@ export async function publishCommand(options: PublishOptions = {}): Promise<void
 
   if (!confirmRes.ok) {
     spinner.fail('Publish confirmation failed');
-    const body = await confirmRes.json().catch(() => ({})) as { error?: string };
+    const body = await confirmRes.json().catch(() => null) as { error?: string } | null;
     throw new Error(
-      `Failed to confirm publish: ${body.error ?? confirmRes.statusText}`,
+      `Failed to confirm publish: ${body?.error ?? confirmRes.statusText}`,
     );
   }
 

--- a/apps/cli/src/commands/scan.ts
+++ b/apps/cli/src/commands/scan.ts
@@ -141,12 +141,12 @@ export async function scanCommand(options: ScanOptions = {}): Promise<void> {
 
   if (!scanRes.ok) {
     spinner.fail('Scan failed');
-    const body = await scanRes.json().catch(() => ({})) as { error?: string };
+    const body = await scanRes.json().catch(() => null) as { error?: string } | null;
 
     if (scanRes.status === 401) {
       throw new Error('Authentication failed. Your token may be expired or invalid. Run: tank login');
     }
-    throw new Error(body.error ?? scanRes.statusText);
+    throw new Error(body?.error ?? scanRes.statusText);
   }
 
   const result = await scanRes.json() as ScanResponse;

--- a/apps/cli/src/commands/search.ts
+++ b/apps/cli/src/commands/search.ts
@@ -61,8 +61,8 @@ export async function searchCommand(options: SearchOptions): Promise<void> {
   }
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as { error?: string };
-    throw new Error(body.error ?? `Search failed: ${res.statusText}`);
+    const body = await res.json().catch(() => null) as { error?: string } | null;
+    throw new Error(body?.error ?? `Search failed: ${res.statusText}`);
   }
 
   const data = await res.json() as SearchResponse;

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -125,8 +125,8 @@ async function fetchAvailableVersions(
     if (versionsRes.status === 404) {
       throw new Error(`Skill not found in registry: ${name}`);
     }
-    const body = await versionsRes.json().catch(() => ({})) as { error?: string };
-    throw new Error(body.error ?? versionsRes.statusText);
+    const body = await versionsRes.json().catch(() => null) as { error?: string } | null;
+    throw new Error(body?.error ?? versionsRes.statusText);
   }
 
   const versionsData = await versionsRes.json() as { name: string; versions: VersionInfo[] };


### PR DESCRIPTION
## Summary

- Fixes `null is not an object (evaluating 'body.error')` TypeError when API returns non-OK response with null/empty JSON body
- Root cause: `res.json().catch(() => ({}))` catches **rejection** (non-JSON body) but not `json()` resolving to `null` — accessing `body.error` on `null` throws TypeError (observed in Bun/JSCore runtime)
- Fix: `.catch(() => null)` + optional chaining (`body?.error`) across all 10 error-handling sites in 7 command files
- Bumps CLI to `0.6.3`

## Files Changed

| File | Changes |
|------|---------|
| `commands/update.ts` | 1 site |
| `commands/install.ts` | 3 sites |
| `commands/publish.ts` | 2 sites |
| `commands/scan.ts` | 1 site |
| `commands/search.ts` | 1 site |
| `commands/info.ts` | 1 site |
| `commands/login.ts` | 2 sites (also removed unnecessary `as` casts) |
| `package.json` | Version bump `0.6.2` → `0.6.3` |

## Testing

All 448 CLI tests pass, zero regressions.