### PR TITLE
feat(browse): add Cmd+K command palette, navbar dropdowns, centered search, and enhanced filters

### DIFF
--- a/apps/web/app/(registry)/layout.tsx
+++ b/apps/web/app/(registry)/layout.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import { headers } from 'next/headers';
 import { Suspense } from 'react';
 import { auth } from '@/lib/auth';
+import { SearchTrigger } from '@/components/search-trigger';
+import { Navbar } from '@/components/navbar';
 
 async function AuthLink() {
   const session = await auth.api.getSession({
@@ -41,27 +43,19 @@ export default function RegistryLayout({
 }) {
   return (
     <div className="min-h-screen bg-background">
-      <header className="border-b">
-        <div className="container mx-auto flex h-14 items-center px-4 gap-6">
-          <Link href="/" className="flex items-center gap-2 font-semibold text-lg">
-            <Image src="/logo.png" alt="Tank" width={24} height={24} className="rounded-sm" />
-            Tank
-          </Link>
-          <nav className="flex gap-4 text-sm">
-            <Link
-              href="/skills"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Browse Skills
+      <header className="border-b" style={{ position: 'sticky', top: 0, zIndex: 40, backgroundColor: 'hsl(var(--background) / 0.8)', backdropFilter: 'blur(12px)' }}>
+        <div className="container mx-auto h-14 px-4" style={{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', flexShrink: 0 }}>
+            <Link href="/" className="flex items-center gap-2 font-semibold text-lg">
+              <Image src="/logo.png" alt="Tank" width={24} height={24} className="rounded-sm" />
+              Tank
             </Link>
-            <Link
-              href="/docs"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Docs
-            </Link>
-          </nav>
-          <div className="ml-auto">
+            <Navbar />
+          </div>
+          <div style={{ position: 'absolute', left: '50%', transform: 'translateX(-50%)', width: '100%', maxWidth: '28rem', pointerEvents: 'auto' }}>
+            <SearchTrigger />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
             <Suspense fallback={<SignInLink />}>
               <AuthLink />
             </Suspense>

--- a/apps/web/app/(registry)/skills/page.tsx
+++ b/apps/web/app/(registry)/skills/page.tsx
@@ -1,15 +1,18 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { unstable_noStore as noStore } from 'next/cache';
-import { Lock } from 'lucide-react';
+import { Download, Lock, Star } from 'lucide-react';
+import { Suspense } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { searchSkills } from '@/lib/data/skills';
-import type { SkillSearchResult, SortOption, VisibilityFilter, ScoreBucket } from '@/lib/data/skills';
+import type { SkillSearchResult, SortOption, VisibilityFilter, ScoreBucket, FreshnessBucket, PopularityBucket } from '@/lib/data/skills';
 import { auth } from '@/lib/auth';
 import { headers } from 'next/headers';
 import { SearchBar } from './search-bar';
+import { SkillsFilters } from './skills-filters';
+import { SkillsSort } from './skills-sort';
 
 export const revalidate = 60;
 
@@ -35,12 +38,17 @@ interface SkillsPageProps {
     sort?: string;
     visibility?: string;
     score?: string;
+    freshness?: string;
+    popularity?: string;
+    docs?: string;
   }>;
 }
 
 const VALID_SORTS: SortOption[] = ['updated', 'downloads', 'stars', 'score', 'name'];
 const VALID_VISIBILITY: VisibilityFilter[] = ['all', 'public', 'private'];
 const VALID_SCORE: ScoreBucket[] = ['all', 'high', 'medium', 'low'];
+const VALID_FRESHNESS: FreshnessBucket[] = ['all', 'week', 'month', 'year'];
+const VALID_POPULARITY: PopularityBucket[] = ['all', 'popular', 'growing', 'new'];
 
 function parseSortParam(raw: string | undefined): SortOption {
   if (raw && (VALID_SORTS as string[]).includes(raw)) return raw as SortOption;
@@ -57,6 +65,16 @@ function parseScoreParam(raw: string | undefined): ScoreBucket {
   return 'all';
 }
 
+function parseFreshnessParam(raw: string | undefined): FreshnessBucket {
+  if (raw && (VALID_FRESHNESS as string[]).includes(raw)) return raw as FreshnessBucket;
+  return 'all';
+}
+
+function parsePopularityParam(raw: string | undefined): PopularityBucket {
+  if (raw && (VALID_POPULARITY as string[]).includes(raw)) return raw as PopularityBucket;
+  return 'all';
+}
+
 export default async function SkillsPage({ searchParams }: SkillsPageProps) {
   if (process.env.TANK_PERF_MODE === '1') noStore();
 
@@ -67,6 +85,9 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
   const sort = parseSortParam(params.sort);
   const visibility = parseVisibilityParam(params.visibility);
   const scoreBucket = parseScoreParam(params.score);
+  const freshness = parseFreshnessParam(params.freshness);
+  const popularity = parsePopularityParam(params.popularity);
+  const hasReadme = params.docs === '1';
 
   if (query) noStore();
 
@@ -80,13 +101,20 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
     sort,
     visibility,
     scoreBucket,
+    freshness,
+    popularity,
+    hasReadme: hasReadme || undefined,
     requesterUserId: session?.user?.id ?? null,
   });
 
   const totalPages = Math.max(1, Math.ceil(data.total / limit));
 
+  const countLabel = query
+    ? `${data.total.toLocaleString()} result${data.total !== 1 ? 's' : ''} for "${query}"`
+    : `${data.total.toLocaleString()} skill${data.total !== 1 ? 's' : ''}`;
+
   return (
-    <div className="space-y-8" data-testid="skills-list-root">
+    <div className="space-y-6" data-testid="skills-list-root">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Browse Skills</h1>
         <p className="mt-2 text-muted-foreground">
@@ -96,29 +124,77 @@ export default async function SkillsPage({ searchParams }: SkillsPageProps) {
 
       <SearchBar defaultValue={query} />
 
-      {data.results.length > 0 ? (
-        <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" data-testid="skills-grid">
-            {data.results.map((skill) => (
-              <SkillCard key={skill.name} skill={skill} isLoggedIn={isLoggedIn} />
-            ))}
+      <div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)]">
+        <Suspense fallback={<FiltersSkeleton />}>
+          <SkillsFilters
+            currentVisibility={visibility}
+            currentScoreBucket={scoreBucket}
+            currentFreshness={freshness}
+            currentPopularity={popularity}
+            currentHasReadme={hasReadme}
+            isLoggedIn={isLoggedIn}
+          />
+        </Suspense>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <p className="text-sm text-muted-foreground" data-testid="skills-count">
+              {countLabel}
+            </p>
+            <Suspense fallback={null}>
+              <SkillsSort currentSort={sort} />
+            </Suspense>
           </div>
 
-          {totalPages > 1 && (
-            <Pagination
-              page={page}
-              totalPages={totalPages}
-              query={query}
-              sort={sort}
-              visibility={visibility}
-              scoreBucket={scoreBucket}
-            />
+          {data.results.length > 0 ? (
+            <>
+              <div
+                className="grid grid-cols-1 md:grid-cols-2 gap-4"
+                data-testid="skills-grid"
+              >
+                {data.results.map((skill) => (
+                  <SkillCard key={skill.name} skill={skill} isLoggedIn={isLoggedIn} />
+                ))}
+              </div>
+
+              {totalPages > 1 && (
+                <Pagination
+                  page={page}
+                  totalPages={totalPages}
+                  query={query}
+                  sort={sort}
+                  visibility={visibility}
+                  scoreBucket={scoreBucket}
+                  freshness={freshness}
+                  popularity={popularity}
+                  hasReadme={hasReadme}
+                />
+              )}
+            </>
+          ) : (
+            <EmptyState query={query} />
           )}
-        </>
-      ) : (
-        <EmptyState query={query} />
-      )}
+        </div>
+      </div>
     </div>
+  );
+}
+
+/* ── Inline components ──────────────────────────────────────────────────── */
+
+function FiltersSkeleton() {
+  return (
+    <aside>
+      <div className="rounded-lg border border-border/60 bg-card/50 p-4 space-y-5 animate-pulse">
+        <div className="h-4 w-16 rounded bg-muted" />
+        <div className="space-y-2">
+          <div className="h-3 w-20 rounded bg-muted" />
+          <div className="h-7 w-full rounded bg-muted" />
+          <div className="h-7 w-full rounded bg-muted" />
+          <div className="h-7 w-full rounded bg-muted" />
+        </div>
+      </div>
+    </aside>
   );
 }
 
@@ -132,7 +208,7 @@ function SkillCard({
   return (
     <Link href={`/skills/${encodeURIComponent(skill.name)}`}>
       <Card className="h-full cursor-pointer transition-colors hover:border-primary/50">
-        <CardHeader>
+        <CardHeader className="pb-2">
           <div className="flex items-start justify-between gap-2">
             <CardTitle className="text-base leading-snug">{skill.name}</CardTitle>
             {isLoggedIn && skill.visibility === 'private' && (
@@ -140,18 +216,29 @@ function SkillCard({
             )}
           </div>
           {skill.description && (
-            <CardDescription className="line-clamp-2">{skill.description}</CardDescription>
+            <CardDescription className="line-clamp-2 text-xs">
+              {skill.description}
+            </CardDescription>
           )}
         </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-            {skill.latestVersion && <Badge variant="secondary">v{skill.latestVersion}</Badge>}
-            {skill.auditScore !== null && (
-              <Badge variant={skill.auditScore >= 7 ? 'default' : 'destructive'}>
-                Score: {skill.auditScore}
+        <CardContent className="pt-0">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {skill.latestVersion && (
+              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                v{skill.latestVersion}
               </Badge>
             )}
-            <span>{skill.downloads.toLocaleString()} downloads</span>
+            {skill.auditScore !== null && (
+              <ScoreBadge score={skill.auditScore} />
+            )}
+            <span className="flex items-center gap-1 ml-auto">
+              <Download className="size-3" />
+              {skill.downloads.toLocaleString()}
+            </span>
+            <span className="flex items-center gap-1">
+              <Star className="size-3" />
+              {skill.stars.toLocaleString()}
+            </span>
           </div>
         </CardContent>
       </Card>
@@ -159,15 +246,37 @@ function SkillCard({
   );
 }
 
+function ScoreBadge({ score }: { score: number }) {
+  if (score >= 7) {
+    return (
+      <Badge className="text-[10px] px-1.5 py-0 tank-badge-success border">
+        Score: {score}
+      </Badge>
+    );
+  }
+  if (score >= 4) {
+    return (
+      <Badge className="text-[10px] px-1.5 py-0 tank-badge-warning border">
+        Score: {score}
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="destructive" className="text-[10px] px-1.5 py-0">
+      Score: {score}
+    </Badge>
+  );
+}
+
 function EmptyState({ query }: { query: string }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
+    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border/40 py-16 text-center">
       <p className="text-lg font-medium">
         {query ? 'No skills found' : 'No skills published yet'}
       </p>
       <p className="mt-1 text-sm text-muted-foreground">
         {query
-          ? `No results for "${query}". Try a different search term.`
+          ? `No results for "${query}". Try a different search term or adjust filters.`
           : 'Be the first to publish a skill!'}
       </p>
     </div>
@@ -181,6 +290,9 @@ function Pagination({
   sort,
   visibility,
   scoreBucket,
+  freshness,
+  popularity,
+  hasReadme,
 }: {
   page: number;
   totalPages: number;
@@ -188,6 +300,9 @@ function Pagination({
   sort: SortOption;
   visibility: VisibilityFilter;
   scoreBucket: ScoreBucket;
+  freshness: FreshnessBucket;
+  popularity: PopularityBucket;
+  hasReadme: boolean;
 }) {
   function buildHref(p: number) {
     const urlParams = new URLSearchParams();
@@ -195,6 +310,9 @@ function Pagination({
     if (sort !== 'updated') urlParams.set('sort', sort);
     if (visibility !== 'all') urlParams.set('visibility', visibility);
     if (scoreBucket !== 'all') urlParams.set('score', scoreBucket);
+    if (freshness !== 'all') urlParams.set('freshness', freshness);
+    if (popularity !== 'all') urlParams.set('popularity', popularity);
+    if (hasReadme) urlParams.set('docs', '1');
     if (p > 1) urlParams.set('page', String(p));
     const qs = urlParams.toString();
     return `/skills${qs ? `?${qs}` : ''}`;

--- a/apps/web/app/(registry)/skills/search-bar.tsx
+++ b/apps/web/app/(registry)/skills/search-bar.tsx
@@ -27,7 +27,7 @@ export function SearchBar({ defaultValue }: { defaultValue: string }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex max-w-md gap-2">
+    <form onSubmit={handleSubmit} className="flex gap-2">
       <Input
         type="text"
         value={query}

--- a/apps/web/app/(registry)/skills/skills-filters.tsx
+++ b/apps/web/app/(registry)/skills/skills-filters.tsx
@@ -1,20 +1,34 @@
 'use client';
 
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
-import { X, SlidersHorizontal } from 'lucide-react';
+import { X, SlidersHorizontal, Clock, TrendingUp, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import type { ScoreBucket, VisibilityFilter } from '@/lib/data/skills';
+import type { ScoreBucket, VisibilityFilter, FreshnessBucket, PopularityBucket } from '@/lib/data/skills';
 
 interface SkillsFiltersProps {
   currentVisibility: VisibilityFilter;
   currentScoreBucket: ScoreBucket;
+  currentFreshness: FreshnessBucket;
+  currentPopularity: PopularityBucket;
+  currentHasReadme: boolean;
   isLoggedIn: boolean;
 }
+
+const PARAM_DEFAULTS: Record<string, string> = {
+  visibility: 'all',
+  score: 'all',
+  freshness: 'all',
+  popularity: 'all',
+  docs: '',
+};
 
 export function SkillsFilters({
   currentVisibility,
   currentScoreBucket,
+  currentFreshness,
+  currentPopularity,
+  currentHasReadme,
   isLoggedIn,
 }: SkillsFiltersProps) {
   const router = useRouter();
@@ -22,16 +36,30 @@ export function SkillsFilters({
   const searchParams = useSearchParams();
 
   const hasActiveFilters =
-    currentVisibility !== 'all' || currentScoreBucket !== 'all';
-
-  const DEFAULTS: Record<string, string> = { visibility: 'all', score: 'all' };
+    currentVisibility !== 'all' ||
+    currentScoreBucket !== 'all' ||
+    currentFreshness !== 'all' ||
+    currentPopularity !== 'all' ||
+    currentHasReadme;
 
   function updateParam(key: string, value: string) {
     const params = new URLSearchParams(searchParams.toString());
-    if (DEFAULTS[key] === value) {
+    if (PARAM_DEFAULTS[key] === value) {
       params.delete(key);
     } else {
       params.set(key, value);
+    }
+    params.delete('page');
+    const qs = params.toString();
+    router.replace(`${pathname}${qs ? `?${qs}` : ''}`);
+  }
+
+  function toggleParam(key: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (params.has(key)) {
+      params.delete(key);
+    } else {
+      params.set(key, '1');
     }
     params.delete('page');
     const qs = params.toString();
@@ -42,23 +70,16 @@ export function SkillsFilters({
     const params = new URLSearchParams(searchParams.toString());
     params.delete('visibility');
     params.delete('score');
+    params.delete('freshness');
+    params.delete('popularity');
+    params.delete('docs');
     params.delete('page');
     const qs = params.toString();
     router.replace(`${pathname}${qs ? `?${qs}` : ''}`);
   }
 
-  const scoreBuckets: { value: ScoreBucket; label: string }[] = [
-    { value: 'all', label: 'All' },
-    { value: 'high', label: 'High (7+)' },
-    { value: 'medium', label: 'Med (4–6)' },
-    { value: 'low', label: 'Low (<4)' },
-  ];
-
   return (
-    <aside
-      className="w-full md:w-56 shrink-0"
-      data-testid="skills-filters-sidebar"
-    >
+    <aside data-testid="skills-filters-sidebar">
       <div
         className={cn(
           'rounded-lg border border-border/60 bg-card/50 p-4 space-y-5',
@@ -86,71 +107,88 @@ export function SkillsFilters({
 
         {isLoggedIn && (
           <FilterSection label="Visibility">
-            <div className="flex flex-col gap-1.5">
-              {(['all', 'public', 'private'] as VisibilityFilter[]).map((v) => (
-                <button
-                  type="button"
-                  key={v}
-                  onClick={() => updateParam('visibility', v)}
-                  data-testid={`filter-visibility-${v}`}
-                  className={cn(
-                    'w-full text-left px-2.5 py-1.5 rounded-md text-sm transition-all',
-                    currentVisibility === v
-                      ? 'text-foreground font-medium'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
-                  )}
-                  style={
-                    currentVisibility === v
-                      ? {
-                          background: 'rgba(0, 212, 255, 0.08)',
-                          borderLeft: '2px solid var(--tank-cyan)',
-                          paddingLeft: '8px',
-                          boxShadow: 'inset 0 0 12px rgba(0, 212, 255, 0.05)',
-                        }
-                      : undefined
-                  }
-                >
-                  {v === 'all' ? 'All' : v === 'public' ? 'Public' : 'Private'}
-                </button>
-              ))}
-            </div>
+            <FilterOptionList
+              options={[
+                { value: 'all', label: 'All' },
+                { value: 'public', label: 'Public' },
+                { value: 'private', label: 'Private' },
+              ]}
+              current={currentVisibility}
+              paramKey="visibility"
+              onSelect={updateParam}
+            />
           </FilterSection>
         )}
 
         <FilterSection label="Security Score">
-          <div className="flex flex-col gap-1.5">
-            {scoreBuckets.map(({ value, label }) => (
-              <button
-                type="button"
-                key={value}
-                onClick={() => updateParam('score', value)}
-                data-testid={`filter-score-${value}`}
-                className={cn(
-                  'w-full text-left px-2.5 py-1.5 rounded-md text-sm transition-all',
-                  currentScoreBucket === value
-                    ? 'text-foreground font-medium'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
-                )}
-                style={
-                  currentScoreBucket === value
-                    ? {
-                        background: 'rgba(0, 212, 255, 0.08)',
-                        borderLeft: '2px solid var(--tank-cyan)',
-                        paddingLeft: '8px',
-                        boxShadow: 'inset 0 0 12px rgba(0, 212, 255, 0.05)',
-                      }
-                    : undefined
-                }
-              >
-                <span className="flex items-center gap-2">
-                  {value !== 'all' && (
-                    <ScoreDot bucket={value} />
-                  )}
-                  {label}
-                </span>
-              </button>
-            ))}
-          </div>
+          <FilterOptionList
+            options={[
+              { value: 'all', label: 'All' },
+              { value: 'high', label: 'High (7+)', dot: 'var(--tank-matrix-green)' },
+              { value: 'medium', label: 'Med (4–6)', dot: 'var(--tank-amber)' },
+              { value: 'low', label: 'Low (<4)', dot: '#ef4444' },
+            ]}
+            current={currentScoreBucket}
+            paramKey="score"
+            onSelect={updateParam}
+          />
+        </FilterSection>
+
+        <FilterSection label="Updated">
+          <FilterOptionList
+            options={[
+              { value: 'all', label: 'Any time' },
+              { value: 'week', label: 'This week' },
+              { value: 'month', label: 'This month' },
+              { value: 'year', label: 'This year' },
+            ]}
+            current={currentFreshness}
+            paramKey="freshness"
+            onSelect={updateParam}
+            icon={<Clock className="size-3 text-muted-foreground/50" />}
+          />
+        </FilterSection>
+
+        <FilterSection label="Downloads">
+          <FilterOptionList
+            options={[
+              { value: 'all', label: 'Any' },
+              { value: 'popular', label: 'Popular (10+)' },
+              { value: 'growing', label: 'Growing (1–9)' },
+              { value: 'new', label: 'New (0)' },
+            ]}
+            current={currentPopularity}
+            paramKey="popularity"
+            onSelect={updateParam}
+            icon={<TrendingUp className="size-3 text-muted-foreground/50" />}
+          />
+        </FilterSection>
+
+        <FilterSection label="Quality">
+          <button
+            type="button"
+            onClick={() => toggleParam('docs')}
+            data-testid="filter-has-readme"
+            className={cn(
+              'flex w-full items-center gap-2 text-left px-2.5 py-1.5 rounded-md text-sm transition-all',
+              currentHasReadme
+                ? 'text-foreground font-medium'
+                : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
+            )}
+            style={
+              currentHasReadme
+                ? {
+                    background: 'rgba(0, 212, 255, 0.08)',
+                    borderLeft: '2px solid var(--tank-cyan)',
+                    paddingLeft: '8px',
+                    boxShadow: 'inset 0 0 12px rgba(0, 212, 255, 0.05)',
+                  }
+                : undefined
+            }
+          >
+            <FileText className="size-3" />
+            Has documentation
+          </button>
         </FilterSection>
 
         {hasActiveFilters && (
@@ -187,16 +225,62 @@ function FilterSection({
   );
 }
 
-function ScoreDot({ bucket }: { bucket: ScoreBucket }) {
-  const colors: Record<string, string> = {
-    high: 'var(--tank-matrix-green)',
-    medium: 'var(--tank-amber)',
-    low: '#ef4444',
-  };
+interface FilterOption {
+  value: string;
+  label: string;
+  dot?: string;
+}
+
+function FilterOptionList({
+  options,
+  current,
+  paramKey,
+  onSelect,
+  icon,
+}: {
+  options: FilterOption[];
+  current: string;
+  paramKey: string;
+  onSelect: (key: string, value: string) => void;
+  icon?: React.ReactNode;
+}) {
   return (
-    <span
-      className="inline-block size-2 rounded-full shrink-0"
-      style={{ background: colors[bucket] ?? 'currentColor' }}
-    />
+    <div className="flex flex-col gap-1.5">
+      {options.map(({ value, label, dot }) => (
+        <button
+          type="button"
+          key={value}
+          onClick={() => onSelect(paramKey, value)}
+          data-testid={`filter-${paramKey}-${value}`}
+          className={cn(
+            'w-full text-left px-2.5 py-1.5 rounded-md text-sm transition-all',
+            current === value
+              ? 'text-foreground font-medium'
+              : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
+          )}
+          style={
+            current === value
+              ? {
+                  background: 'rgba(0, 212, 255, 0.08)',
+                  borderLeft: '2px solid var(--tank-cyan)',
+                  paddingLeft: '8px',
+                  boxShadow: 'inset 0 0 12px rgba(0, 212, 255, 0.05)',
+                }
+              : undefined
+          }
+        >
+          <span className="flex items-center gap-2">
+            {dot && (
+              <span
+                className="inline-block size-2 rounded-full shrink-0"
+                style={{ background: dot }}
+              />
+            )}
+            {icon && value === options[0].value && icon}
+            {label}
+          </span>
+        </button>
+      ))}
+    </div>
   );
 }

--- a/apps/web/app/(registry)/skills/skills-sort.tsx
+++ b/apps/web/app/(registry)/skills/skills-sort.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { SortOption } from '@/lib/data/skills';
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'updated', label: 'Recently Updated' },
+  { value: 'downloads', label: 'Most Downloads' },
+  { value: 'stars', label: 'Most Stars' },
+  { value: 'score', label: 'Highest Score' },
+  { value: 'name', label: 'Name A–Z' },
+];
+
+export function SkillsSort({ currentSort }: { currentSort: SortOption }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function handleSortChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === 'updated') {
+      params.delete('sort');
+    } else {
+      params.set('sort', value);
+    }
+    params.delete('page');
+    const qs = params.toString();
+    router.push(`${pathname}${qs ? `?${qs}` : ''}`);
+  }
+
+  return (
+    <Select value={currentSort} onValueChange={handleSortChange}>
+      <SelectTrigger
+        size="sm"
+        className="w-44"
+        data-testid="skills-sort-select"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {SORT_OPTIONS.map((opt) => (
+          <SelectItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from 'next/script';
 import { Inter } from 'next/font/google';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { CookieConsentManager } from '@/components/cookie-consent-manager';
+import { CommandMenu } from '@/components/command-menu';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -112,7 +113,10 @@ gtag('config','${process.env.NEXT_PUBLIC_GA_ID}',{send_page_view:false});`}
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
       </head>
       <body className={`${inter.className} antialiased`} suppressHydrationWarning>
-        <RootProvider>{children}</RootProvider>
+        <RootProvider search={{ enabled: false }}>
+          {children}
+          <CommandMenu />
+        </RootProvider>
         <CookieConsentManager />
       </body>
     </html>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,6 @@ import {
   GitBranch,
   Zap,
   Globe,
-  ChevronRight,
   ArrowRight,
   Sparkles,
   CheckCircle2,
@@ -24,6 +23,8 @@ import { eq } from 'drizzle-orm';
 import { HomeNavAuthCta, HomePrimaryAuthCta } from './home-auth-cta';
 import { CopyInstallButton } from './copy-install-button';
 import { CookiePreferencesButton } from './cookie-preferences-button';
+import { Navbar } from '@/components/navbar';
+import { SearchTrigger } from '@/components/search-trigger';
 
 const GITHUB_REPO = 'tankpkg/tank';
 
@@ -184,28 +185,20 @@ export default async function Home() {
       {/* Navigation */}
       <header className="sticky top-0 z-50 border-b border-emerald-500/10 bg-background/80 backdrop-blur-xl">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex h-16 items-center justify-between">
-            <Link href="/" className="flex items-center gap-2.5 font-bold text-lg tracking-tight hover:opacity-80 transition-all group">
-              <div className="relative">
-                <Image src="/logo.png" alt="Tank" width={28} height={28} className="rounded-sm" />
-              </div>
-              <span>Tank</span>
-            </Link>
-            <nav className="hidden md:flex items-center gap-8 text-sm">
-              <Link
-                href="/skills"
-                className="text-muted-foreground hover:text-emerald-400 transition-colors flex items-center gap-1.5"
-              >
-                Browse Skills
-                <ChevronRight className="w-3.5 h-3.5" />
+          <div className="h-16" style={{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', flexShrink: 0 }}>
+              <Link href="/" className="flex items-center gap-2.5 font-bold text-lg tracking-tight hover:opacity-80 transition-all group">
+                <div className="relative">
+                  <Image src="/logo.png" alt="Tank" width={28} height={28} className="rounded-sm" />
+                </div>
+                <span>Tank</span>
               </Link>
-              <Link
-                href="/docs"
-                className="text-muted-foreground hover:text-emerald-400 transition-colors flex items-center gap-1.5"
-              >
-                Docs
-                <ChevronRight className="w-3.5 h-3.5" />
-              </Link>
+              <Navbar />
+            </div>
+            <div style={{ position: 'absolute', left: '50%', transform: 'translateX(-50%)', width: '100%', maxWidth: '28rem', pointerEvents: 'auto' }}>
+              <SearchTrigger />
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
               <a
                 href="https://github.com/tankpkg/tank"
                 target="_blank"
@@ -214,6 +207,7 @@ export default async function Home() {
                 aria-label="Star Tank on GitHub"
               >
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <title>GitHub</title>
                   <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
                 </svg>
                 <span>Star</span>
@@ -221,8 +215,8 @@ export default async function Home() {
                   <span className="font-medium tabular-nums text-emerald-400">{starCount}</span>
                 )}
               </a>
-            </nav>
-            <HomeNavAuthCta />
+              <HomeNavAuthCta />
+            </div>
           </div>
         </div>
       </header>

--- a/apps/web/components/command-menu.tsx
+++ b/apps/web/components/command-menu.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  BookOpenIcon,
+  BoxIcon,
+  FileTextIcon,
+  GithubIcon,
+  LayoutDashboardIcon,
+  LogInIcon,
+  PackageSearchIcon,
+  RocketIcon,
+  SearchIcon,
+  ShieldCheckIcon,
+  TerminalIcon,
+  ServerIcon,
+  KeyIcon,
+  CloudIcon,
+  WrenchIcon,
+  BookIcon,
+} from 'lucide-react';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+
+interface SkillResult {
+  name: string;
+  description?: string;
+  owner?: string;
+}
+
+const DOC_PAGES = [
+  { title: 'Getting Started', slug: 'getting-started', icon: RocketIcon },
+  { title: 'Installing Skills', slug: 'installing', icon: PackageSearchIcon },
+  { title: 'Publishing Skills', slug: 'publishing', icon: BoxIcon },
+  { title: 'Publish Your First Skill', slug: 'publish-first-skill', icon: BookOpenIcon },
+  { title: 'CLI Reference', slug: 'cli', icon: TerminalIcon },
+  { title: 'API Reference', slug: 'api', icon: FileTextIcon },
+  { title: 'MCP Server', slug: 'mcp', icon: WrenchIcon },
+  { title: 'CI/CD Integration', slug: 'cicd', icon: CloudIcon },
+  { title: 'Security Checklist', slug: 'security-checklist', icon: ShieldCheckIcon },
+  { title: 'Self-Hosting', slug: 'self-hosting', icon: ServerIcon },
+  { title: 'Self-Host Quickstart', slug: 'self-host-quickstart', icon: KeyIcon },
+  { title: 'Documentation Home', slug: '', icon: BookIcon },
+] as const;
+
+const QUICK_LINKS = [
+  { title: 'Browse Skills', href: '/skills', icon: PackageSearchIcon },
+  { title: 'Dashboard', href: '/dashboard', icon: LayoutDashboardIcon },
+  { title: 'Documentation', href: '/docs', icon: BookOpenIcon },
+  { title: 'Sign In', href: '/login', icon: LogInIcon },
+  { title: 'GitHub', href: 'https://github.com/tankpkg/tank', icon: GithubIcon, external: true },
+] as const;
+
+export function CommandMenu() {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [skills, setSkills] = React.useState<SkillResult[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const router = useRouter();
+  const abortRef = React.useRef<AbortController | null>(null);
+
+  React.useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  React.useEffect(() => {
+    if (!query || query.length < 2) {
+      setSkills([]);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/v1/search?q=${encodeURIComponent(query)}&limit=8`, {
+          signal: controller.signal,
+        });
+        if (res.ok) {
+          const data = await res.json();
+          const items: SkillResult[] = (data.skills ?? data.results ?? []).map(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (s: any) => ({
+              name: s.name,
+              description: s.description ?? '',
+              owner: s.owner ?? s.ownerName ?? '',
+            })
+          );
+          setSkills(items);
+        }
+      } catch {
+        // AbortController.abort() throws here — expected for debounce
+      } finally {
+        setLoading(false);
+      }
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  React.useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setSkills([]);
+    }
+  }, [open]);
+
+  function navigate(href: string, external?: boolean) {
+    setOpen(false);
+    if (external) {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    } else {
+      router.push(href);
+    }
+  }
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Command Palette"
+      description="Search skills, docs, and navigate Tank"
+    >
+      <CommandInput
+        placeholder="Search skills, docs, and more…"
+        value={query}
+        onValueChange={setQuery}
+      />
+      <CommandList>
+        <CommandEmpty>
+          {loading ? 'Searching…' : 'No results found.'}
+        </CommandEmpty>
+
+        {skills.length > 0 && (
+          <CommandGroup heading="Skills">
+            {skills.map((skill) => (
+              <CommandItem
+                key={skill.name}
+                value={`skill-${skill.name}`}
+                onSelect={() => navigate(`/skills/${skill.name}`)}
+              >
+                <BoxIcon className="text-emerald-500" />
+                <div className="flex flex-col">
+                  <span className="font-medium">{skill.name}</span>
+                  {skill.description && (
+                    <span className="text-xs text-muted-foreground line-clamp-1">
+                      {skill.description}
+                    </span>
+                  )}
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        <CommandGroup heading="Documentation">
+          {DOC_PAGES.map((doc) => (
+            <CommandItem
+              key={doc.slug}
+              value={`doc-${doc.slug || 'home'}-${doc.title}`}
+              onSelect={() => navigate(`/docs/${doc.slug}`)}
+            >
+              <doc.icon className="text-blue-500" />
+              <span>{doc.title}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        <CommandSeparator />
+
+        <CommandGroup heading="Quick Links">
+          {QUICK_LINKS.map((link) => (
+            <CommandItem
+              key={link.href}
+              value={`link-${link.title}`}
+              onSelect={() => navigate(link.href, 'external' in link && link.external)}
+            >
+              <link.icon className="text-muted-foreground" />
+              <span>{link.title}</span>
+              {'external' in link && link.external && (
+                <span className="ml-auto text-xs text-muted-foreground">↗</span>
+              )}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/web/components/navbar.tsx
+++ b/apps/web/components/navbar.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import {
+  PackageSearchIcon,
+  TrendingUpIcon,
+  SparklesIcon,
+  ShieldCheckIcon,
+  BookOpenIcon,
+  RocketIcon,
+  TerminalIcon,
+  FileTextIcon,
+  CloudIcon,
+  ServerIcon,
+  WrenchIcon,
+} from 'lucide-react';
+
+interface DropdownItem {
+  icon: React.ReactNode;
+  text: string;
+  description: string;
+  href: string;
+}
+
+interface NavItem {
+  href?: string;
+  text: string;
+  items?: DropdownItem[];
+}
+
+const NAV_ITEMS: NavItem[] = [
+  {
+    text: 'Browse Skills',
+    items: [
+      {
+        icon: <PackageSearchIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'All Skills',
+        description: 'Browse the full registry',
+        href: '/skills',
+      },
+      {
+        icon: <TrendingUpIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'Most Popular',
+        description: 'Top downloaded skills',
+        href: '/skills?sort=downloads',
+      },
+      {
+        icon: <SparklesIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'Recently Updated',
+        description: 'Fresh and maintained',
+        href: '/skills?sort=updated',
+      },
+      {
+        icon: <ShieldCheckIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'Highest Rated',
+        description: 'Best security scores',
+        href: '/skills?sort=score',
+      },
+    ],
+  },
+  {
+    text: 'Docs',
+    items: [
+      {
+        icon: <RocketIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'Getting Started',
+        description: 'Set up Tank in 2 minutes',
+        href: '/docs/getting-started',
+      },
+      {
+        icon: <BookOpenIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'Publishing Guide',
+        description: 'Share your first skill',
+        href: '/docs/publish-first-skill',
+      },
+      {
+        icon: <TerminalIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'CLI Reference',
+        description: 'All commands documented',
+        href: '/docs/cli',
+      },
+      {
+        icon: <FileTextIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'API Reference',
+        description: 'REST API for integrations',
+        href: '/docs/api',
+      },
+      {
+        icon: <WrenchIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'MCP Server',
+        description: 'Editor integration',
+        href: '/docs/mcp',
+      },
+      {
+        icon: <CloudIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'CI/CD',
+        description: 'Automate publishing',
+        href: '/docs/cicd',
+      },
+      {
+        icon: <ServerIcon style={{ width: '16px', height: '16px' }} />,
+        text: 'Self-Hosting',
+        description: 'Run your own registry',
+        href: '/docs/self-hosting',
+      },
+    ],
+  },
+];
+
+function NavDropdownItem({ icon, text, description, href }: DropdownItem) {
+  return (
+    <li>
+      <Link
+        href={href}
+        style={{ display: 'flex', alignItems: 'center', gap: '12px', overflow: 'hidden', borderRadius: '8px', padding: '10px' }}
+        className="transition-colors hover:bg-accent"
+      >
+        <div
+          style={{ display: 'flex', width: '36px', height: '36px', flexShrink: 0, alignItems: 'center', justifyContent: 'center', borderRadius: '6px' }}
+          className="border border-border bg-muted/50 text-muted-foreground"
+        >
+          {icon}
+        </div>
+        <div style={{ minWidth: 0 }}>
+          <span style={{ display: 'block', fontSize: '14px', fontWeight: 500 }} className="text-foreground">{text}</span>
+          <span style={{ display: 'block', fontSize: '12px' }} className="text-muted-foreground">{description}</span>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      width="10"
+      height="6"
+      viewBox="0 0 10 6"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: '10px', height: '6px', opacity: 0.6 }}
+      aria-hidden="true"
+    >
+      <title>Toggle dropdown</title>
+      <path
+        d="M1 1L5 5L9 1"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function Navbar() {
+  const [openMenu, setOpenMenu] = React.useState<string | null>(null);
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = (text: string) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setOpenMenu(text);
+  };
+
+  const handleMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => setOpenMenu(null), 150);
+  };
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  return (
+    <nav>
+      <ul style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+        {NAV_ITEMS.map((item) => {
+          if (item.href && !item.items) {
+            return (
+              <li key={item.text}>
+                <Link
+                  href={item.href}
+                  style={{ display: 'block', borderRadius: '6px', padding: '8px 12px', fontSize: '14px' }}
+                  className="text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {item.text}
+                </Link>
+              </li>
+            );
+          }
+
+          const isOpen = openMenu === item.text;
+
+          return (
+            <li
+              key={item.text}
+              style={{ position: 'relative', perspective: '2000px' }}
+              onMouseEnter={() => handleMouseEnter(item.text)}
+              onMouseLeave={handleMouseLeave}
+            >
+              <button
+                type="button"
+                style={{ display: 'flex', alignItems: 'center', gap: '6px', borderRadius: '6px', padding: '8px 12px', fontSize: '14px' }}
+                className="text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {item.text}
+                {item.items && <ChevronIcon />}
+              </button>
+
+              {item.items && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    left: '-12px',
+                    top: '100%',
+                    zIndex: 50,
+                    width: '280px',
+                    paddingTop: '8px',
+                    transformOrigin: 'top left',
+                    transition: 'opacity 200ms ease, transform 200ms ease',
+                    opacity: isOpen ? 1 : 0,
+                    pointerEvents: isOpen ? 'auto' : 'none',
+                    transform: isOpen
+                      ? 'rotateX(0deg) scale(1)'
+                      : 'rotateX(-15deg) scale(0.95)',
+                  }}
+                >
+                  <ul
+                    style={{ display: 'flex', flexDirection: 'column', gap: '2px', borderRadius: '12px', padding: '8px' }}
+                    className="border border-border bg-popover shadow-lg"
+                  >
+                    {item.items.map((dropdownItem) => (
+                      <NavDropdownItem key={dropdownItem.href} {...dropdownItem} />
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/components/search-trigger.tsx
+++ b/apps/web/components/search-trigger.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { SearchIcon } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+export function SearchTrigger() {
+  const [isMac, setIsMac] = useState(true);
+
+  useEffect(() => {
+    setIsMac(!navigator.userAgent.includes('Windows'));
+  }, []);
+
+  function openCommandMenu() {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={openCommandMenu}
+      className="group flex w-full items-center gap-2 rounded-lg border border-input bg-muted/30 px-3 py-1.5 text-sm text-muted-foreground/70 transition-all hover:border-muted-foreground/25 hover:bg-muted/50 hover:text-muted-foreground"
+    >
+      <SearchIcon className="size-4 shrink-0" />
+      <span className="flex-1 text-left">Search skills, docs...</span>
+      <kbd className="pointer-events-none hidden select-none items-center gap-0.5 rounded border border-border bg-background px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground/70 sm:inline-flex">
+        {isMac ? '⌘' : 'Ctrl '}K
+      </kbd>
+    </button>
+  );
+}

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/apps/web/lib/data/skills.ts
+++ b/apps/web/lib/data/skills.ts
@@ -118,6 +118,8 @@ export interface SkillSearchResponse {
 export type SortOption = 'updated' | 'downloads' | 'stars' | 'score' | 'name';
 export type VisibilityFilter = 'all' | 'public' | 'private';
 export type ScoreBucket = 'all' | 'high' | 'medium' | 'low';
+export type FreshnessBucket = 'all' | 'week' | 'month' | 'year';
+export type PopularityBucket = 'all' | 'popular' | 'growing' | 'new';
 
 export interface SkillsSearchParams {
   q: string;
@@ -126,6 +128,9 @@ export interface SkillsSearchParams {
   sort: SortOption;
   visibility: VisibilityFilter;
   scoreBucket: ScoreBucket;
+  freshness?: FreshnessBucket;
+  popularity?: PopularityBucket;
+  hasReadme?: boolean;
   requesterUserId?: string | null;
 }
 
@@ -395,6 +400,37 @@ function buildVisibilityFilterClause(visibility: VisibilityFilter) {
   return sql``;
 }
 
+function buildFreshnessClause(freshness: FreshnessBucket | undefined) {
+  switch (freshness) {
+    case 'week':
+      return sql`AND s.updated_at >= CURRENT_DATE - INTERVAL '7 days'`;
+    case 'month':
+      return sql`AND s.updated_at >= CURRENT_DATE - INTERVAL '30 days'`;
+    case 'year':
+      return sql`AND s.updated_at >= CURRENT_DATE - INTERVAL '365 days'`;
+    default:
+      return sql``;
+  }
+}
+
+function buildPopularityClause(popularity: PopularityBucket | undefined) {
+  switch (popularity) {
+    case 'popular':
+      return sql`AND coalesce((SELECT sum(count)::int FROM skill_download_daily WHERE skill_id = s.id AND date >= CURRENT_DATE - 7), 0) >= 10`;
+    case 'growing':
+      return sql`AND coalesce((SELECT sum(count)::int FROM skill_download_daily WHERE skill_id = s.id AND date >= CURRENT_DATE - 7), 0) BETWEEN 1 AND 9`;
+    case 'new':
+      return sql`AND coalesce((SELECT sum(count)::int FROM skill_download_daily WHERE skill_id = s.id AND date >= CURRENT_DATE - 7), 0) = 0`;
+    default:
+      return sql``;
+  }
+}
+
+function buildReadmeClause(hasReadme: boolean | undefined) {
+  if (hasReadme) return sql`AND sv.readme IS NOT NULL AND sv.readme != ''`;
+  return sql``;
+}
+
 /**
  * Hybrid search combining three strategies:
  *   1. ILIKE on name — partial, prefix, org-scoped matches
@@ -434,7 +470,7 @@ export async function searchSkills(
     params = paramsOrQ;
   }
 
-  const { q, sort, visibility, scoreBucket } = params;
+  const { q, sort, visibility, scoreBucket, freshness, popularity, hasReadme } = params;
   const resolvedPage = params.page;
   const resolvedLimit = params.limit;
 
@@ -445,7 +481,6 @@ export async function searchSkills(
   const visClause = visibilityClause(viewerUserId);
   const offset = (resolvedPage - 1) * resolvedLimit;
 
-  // Determine which aggregation JOINs are needed
   const needsDownloads = sort === 'downloads';
 
   // Pre-aggregated subquery JOINs (only included when needed for sort)
@@ -478,6 +513,9 @@ export async function searchSkills(
   const primarySort = buildPrimarySort(sort, starsTableAvailable);
   const scoreBucketClause = buildScoreBucketClause(scoreBucket);
   const visibilityFilterClause = buildVisibilityFilterClause(visibility);
+  const freshnessClause = buildFreshnessClause(freshness);
+  const popularityClause = buildPopularityClause(popularity);
+  const readmeClause = buildReadmeClause(hasReadme);
 
   if (!q) {
     const results = await db.execute(sql`
@@ -503,6 +541,9 @@ export async function searchSkills(
       WHERE ${visClause}
       ${visibilityFilterClause}
       ${scoreBucketClause}
+      ${freshnessClause}
+      ${popularityClause}
+      ${readmeClause}
       ORDER BY ${primarySort}, s.id ASC
       OFFSET ${offset}
       LIMIT ${resolvedLimit}
@@ -543,6 +584,9 @@ export async function searchSkills(
     AND ${visClause}
     ${visibilityFilterClause}
     ${scoreBucketClause}
+    ${freshnessClause}
+    ${popularityClause}
+    ${readmeClause}
     ORDER BY ${sort !== 'updated' ? sql`${primarySort},` : sql``} (
       CASE WHEN lower(s.name) = lower(${q}) THEN 1000 ELSE 0 END
       + CASE WHEN s.name ILIKE ${q + '%'} THEN 800 ELSE 0 END

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "better-auth": "^1.4.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "drizzle-orm": "^0.45.1",
     "fumadocs-core": "^16.6.5",
     "fumadocs-mdx": "^14.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@opentelemetry/api@1.9.0)(kysely@0.28.11)(postgres@3.4.8)
@@ -3363,6 +3366,12 @@ packages:
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -9320,6 +9329,18 @@ snapshots:
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.2: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
## Summary

- **Cmd+K Command Palette**: Global search across skills (debounced API), 12 doc pages, and quick links. Disables fumadocs built-in search in favor of our CommandMenu.
- **Interactive Navbar**: Animated perspective dropdown menus for "Browse Skills" (All, Popular, Recent, Highest Rated) and "Docs" (7 doc pages). React state-driven hover with 150ms debounce — replaces CSS group-hover which broke under Tailwind v4 cascade layers.
- **Centered Search Bar**: Absolute-positioned search trigger (`left: 50%; transform: translateX(-50%)`) for true viewport centering regardless of left/right content widths. Applied to both homepage and registry headers.
- **Enhanced Filters**: 5 filter sections (Visibility, Security Score, Updated, Downloads, Quality) with `FreshnessBucket` and `PopularityBucket` SQL builders wired into `searchSkills()`.
- **Sort Dropdown**: 5 sort options (Newest, Name A-Z, Most Downloads, Highest Score, Most Stars).
- **Inline Styles**: All layout-critical CSS uses inline styles to avoid Tailwind v4 CSS cascade layer conflicts with fumadocs-ui/shadcn.

## Files Changed (14)
- `apps/web/components/command-menu.tsx` — New: global Cmd+K palette
- `apps/web/components/navbar.tsx` — New: interactive navbar with dropdowns
- `apps/web/components/search-trigger.tsx` — New: wide search bar trigger
- `apps/web/components/ui/command.tsx` — New: shadcn command component (cmdk)
- `apps/web/app/(registry)/skills/skills-sort.tsx` — New: sort dropdown
- `apps/web/app/(registry)/layout.tsx` — Navbar + centered search + sticky glass header
- `apps/web/app/(registry)/skills/page.tsx` — CSS Grid layout, enhanced SkillCard
- `apps/web/app/(registry)/skills/skills-filters.tsx` — 5 filter sections
- `apps/web/app/layout.tsx` — CommandMenu + disabled fumadocs search
- `apps/web/app/page.tsx` — Same navbar/search layout for homepage
- `apps/web/lib/data/skills.ts` — FreshnessBucket, PopularityBucket SQL builders