### PR TITLE
fix(rescan): prevent double-insert and add LLM fields

### DIFF
--- a/apps/web/app/api/admin/rescan-skills/route.ts
+++ b/apps/web/app/api/admin/rescan-skills/route.ts
@@ -8,6 +8,9 @@ import { rescanVersion } from '@/lib/rescan';
 // Statuses that indicate a version has been scanned and can be rescanned
 const RESCANNABLE_STATUSES = ['completed', 'flagged', 'scan-failed'] as const;
 
+// Delay between scans to prevent database connection pool exhaustion
+const SCAN_DELAY_MS = 500;
+
 export const dynamic = 'force-dynamic';
 
 async function handler(_req: NextRequest, _context: AdminAuthContext): Promise<NextResponse> {
@@ -46,7 +49,7 @@ async function handler(_req: NextRequest, _context: AdminAuthContext): Promise<N
       });
     }
 
-    // Rescan all versions (in series to avoid overwhelming the scan service)
+    // Rescan all versions (in series with delay to prevent connection pool exhaustion)
     const results = {
       total: versionsToScan.length,
       success: 0,
@@ -54,7 +57,8 @@ async function handler(_req: NextRequest, _context: AdminAuthContext): Promise<N
       errors: [] as Array<{ versionId: string; error: string }>,
     };
 
-    for (const version of versionsToScan) {
+    for (let i = 0; i < versionsToScan.length; i++) {
+      const version = versionsToScan[i];
       const result = await rescanVersion(version);
       if (result.success) {
         results.success++;
@@ -64,6 +68,11 @@ async function handler(_req: NextRequest, _context: AdminAuthContext): Promise<N
           versionId: version.id,
           error: result.error || 'Unknown error',
         });
+      }
+
+      // Add delay between scans to allow DB connections to be released
+      if (i < versionsToScan.length - 1) {
+        await new Promise(resolve => setTimeout(resolve, SCAN_DELAY_MS));
       }
     }
 

--- a/apps/web/lib/rescan.ts
+++ b/apps/web/lib/rescan.ts
@@ -17,6 +17,8 @@ export interface ScanFinding {
   confidence: number | null;
   tool: string | null;
   evidence: string | null;
+  llm_verdict?: string | null;
+  llm_reviewed?: boolean;
 }
 
 export interface ScanResponse {
@@ -132,41 +134,46 @@ export async function rescanVersion(version: RescanVersionInput): Promise<Rescan
         },
       });
 
-      // Store scan results
-      try {
-        const [scanResultRecord] = await db
-          .insert(scanResults)
-          .values({
-            versionId: version.id,
-            verdict: scanResult.verdict,
-            totalFindings: scanResult.findings.length,
-            criticalCount: scanResult.findings.filter(f => f.severity === 'critical').length,
-            highCount: scanResult.findings.filter(f => f.severity === 'high').length,
-            mediumCount: scanResult.findings.filter(f => f.severity === 'medium').length,
-            lowCount: scanResult.findings.filter(f => f.severity === 'low').length,
-            stagesRun: scanResult.stage_results?.map(s => s.stage) || [],
-            durationMs: scanResult.duration_ms || null,
-            fileHashes: scanResult.file_hashes || null,
-          })
-          .returning();
+      // Store scan results (only if Python API didn't already store them)
+      // Python API returns scan_id when it successfully stored results
+      if (!scanResult.scan_id) {
+        try {
+          const [scanResultRecord] = await db
+            .insert(scanResults)
+            .values({
+              versionId: version.id,
+              verdict: scanResult.verdict,
+              totalFindings: scanResult.findings.length,
+              criticalCount: scanResult.findings.filter(f => f.severity === 'critical').length,
+              highCount: scanResult.findings.filter(f => f.severity === 'high').length,
+              mediumCount: scanResult.findings.filter(f => f.severity === 'medium').length,
+              lowCount: scanResult.findings.filter(f => f.severity === 'low').length,
+              stagesRun: scanResult.stage_results?.map(s => s.stage) || [],
+              durationMs: scanResult.duration_ms || null,
+              fileHashes: scanResult.file_hashes || null,
+            })
+            .returning();
 
-        if (scanResultRecord && scanResult.findings.length > 0) {
-          await db.insert(scanFindings).values(
-            scanResult.findings.map(f => ({
-              scanId: scanResultRecord.id,
-              stage: f.stage,
-              severity: f.severity,
-              type: f.type,
-              description: f.description,
-              location: f.location || null,
-              confidence: f.confidence || null,
-              tool: f.tool || null,
-              evidence: f.evidence || null,
-            }))
-          );
+          if (scanResultRecord && scanResult.findings.length > 0) {
+            await db.insert(scanFindings).values(
+              scanResult.findings.map(f => ({
+                scanId: scanResultRecord.id,
+                stage: f.stage,
+                severity: f.severity,
+                type: f.type,
+                description: f.description,
+                location: f.location || null,
+                confidence: f.confidence || null,
+                tool: f.tool || null,
+                evidence: f.evidence || null,
+                llmVerdict: f.llm_verdict || null,
+                llmReviewed: f.llm_reviewed || false,
+              }))
+            );
+          }
+        } catch (dbError) {
+          console.error('Failed to store scan results:', dbError);
         }
-      } catch (dbError) {
-        console.error('Failed to store scan results:', dbError);
       }
 
       // Map verdict to audit status


### PR DESCRIPTION
## Summary
- Skip Node.js storage when Python API already stored results (scan_id present)
- Add `llm_verdict` and `llm_reviewed` fields to ScanFinding interface
- Add 500ms delay between bulk rescans to prevent database connection pool exhaustion

## Problem
1. **Double-insert**: Both Python API and Node.js were storing scan results, creating duplicate entries
2. **Missing LLM fields**: Node.js insert didn't include `llm_verdict`/`llm_reviewed` columns
3. **Connection pool exhaustion**: Bulk "rescan all" exhausted Supabase connection pool

## Solution
- Check if `scan_id` is returned from Python API (indicates storage already done)
- Only store from Node.js if Python didn't store (fallback for local dev)
- Add delay between scans to allow connections to be released

## Test Plan
- [ ] Rescan single package - verify no duplicate scan_results
- [ ] Rescan all - verify no connection pool errors
- [ ] Check skill page shows updated scan data

🤖 Generated with [Claude Code](https://claude.com/claude-code)