### PR TITLE
fix(rescan): increase delays to prevent connection pool exhaustion

### DIFF
--- a/apps/web/app/api/admin/rescan-skills/route.ts
+++ b/apps/web/app/api/admin/rescan-skills/route.ts
@@ -8,8 +8,11 @@ import { rescanVersion } from '@/lib/rescan';
 // Statuses that indicate a version has been scanned and can be rescanned
 const RESCANNABLE_STATUSES = ['completed', 'flagged', 'scan-failed'] as const;
 
-// Delay between scans to prevent database connection pool exhaustion
-const SCAN_DELAY_MS = 500;
+// Process in batches to avoid connection pool exhaustion
+// Supabase free tier has ~15-20 connection limit
+const BATCH_SIZE = 3; // Process 3 scans at a time
+const BATCH_DELAY_MS = 3000; // 3 second pause between batches
+const SCAN_DELAY_MS = 1000; // 1 second between individual scans in a batch
 
 export const dynamic = 'force-dynamic';
 
@@ -49,7 +52,7 @@ async function handler(_req: NextRequest, _context: AdminAuthContext): Promise<N
       });
     }
 
-    // Rescan all versions (in series with delay to prevent connection pool exhaustion)
+    // Rescan all versions in batches to prevent connection pool exhaustion
     const results = {
       total: versionsToScan.length,
       success: 0,
@@ -70,9 +73,15 @@ async function handler(_req: NextRequest, _context: AdminAuthContext): Promise<N
         });
       }
 
-      // Add delay between scans to allow DB connections to be released
+      // Add delay between individual scans
       if (i < versionsToScan.length - 1) {
         await new Promise(resolve => setTimeout(resolve, SCAN_DELAY_MS));
+      }
+
+      // Add longer pause after each batch
+      if ((i + 1) % BATCH_SIZE === 0 && i < versionsToScan.length - 1) {
+        console.log(`[Rescan] Completed batch of ${BATCH_SIZE}, pausing ${BATCH_DELAY_MS}ms...`);
+        await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
       }
     }
 


### PR DESCRIPTION
## Summary
- Increase individual scan delay from 500ms to 1000ms
- Add batch processing: pause 3 seconds every 3 scans
- This gives Supabase connection pool time to release connections

## Problem
Supabase free tier has ~15-20 connection limit. Each scan opens multiple connections:
- Python API storage (psycopg)
- Node.js auth middleware
- Skill version update query
- Session/auth queries

Running many scans quickly exhausts the pool, causing:
```
MaxClientsInSessionMode: max clients reached - in Session mode max clients are limited to pool_size
```

## Solution
Process scans in batches of 3 with longer pauses:
- 1 second between individual scans
- 3 second pause after each batch of 3

## Test Plan
- [ ] Run "rescan all" from admin panel
- [ ] Verify no connection pool errors in logs
- [ ] Confirm all scans complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)