### PR TITLE
fix(web): use clean URLs for scoped skill names

### DIFF
--- a/apps/web/app/(admin)/admin/orgs/[orgId]/page.tsx
+++ b/apps/web/app/(admin)/admin/orgs/[orgId]/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { encodeSkillName } from '@tank/shared';
 import { headers } from 'next/headers';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -131,7 +132,7 @@ export default async function AdminOrgDetailPage({
                   key={pkg.id}
                   className="rounded-md border p-3 flex items-center justify-between gap-3"
                 >
-                  <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="font-medium">
+                  <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="font-medium">
                     {pkg.name}
                   </Link>
                   <Badge variant="outline">{pkg.status}</Badge>

--- a/apps/web/app/(admin)/admin/packages/page.tsx
+++ b/apps/web/app/(admin)/admin/packages/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { encodeSkillName } from '@tank/shared';
 import { headers } from 'next/headers';
 import { Suspense } from 'react';
 import { Badge } from '@/components/ui/badge';
@@ -270,7 +271,7 @@ async function PackagesTable({ searchParams }: { searchParams: SearchParams }) {
                 data.packages.map((pkg) => (
                   <TableRow key={pkg.id} className="hover:bg-muted/40">
                     <TableCell>
-                      <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="block">
+                      <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="block">
                         <div className="font-medium text-foreground">{pkg.name}</div>
                         {pkg.description && (
                           <div className="text-xs text-muted-foreground truncate max-w-xs">
@@ -280,14 +281,14 @@ async function PackagesTable({ searchParams }: { searchParams: SearchParams }) {
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="block">
+                      <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="block">
                         <Badge variant={statusVariant(pkg.status)}>
                           {pkg.status}
                         </Badge>
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="block">
+                      <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="block">
                         {pkg.featured ? (
                           <Badge variant="default">Featured</Badge>
                         ) : (
@@ -296,22 +297,22 @@ async function PackagesTable({ searchParams }: { searchParams: SearchParams }) {
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="block text-muted-foreground">
+                      <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="block text-muted-foreground">
                         {pkg.publisher?.name ?? pkg.publisher?.email ?? 'Unknown'}
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="block text-muted-foreground">
+                      <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="block text-muted-foreground">
                         {pkg.versionCount}
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="block text-muted-foreground">
+                      <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="block text-muted-foreground">
                         {formatNumber(pkg.downloadCount)}
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <Link href={`/admin/packages/${encodeURIComponent(pkg.name)}`} className="block text-muted-foreground">
+                      <Link href={`/admin/packages/${encodeSkillName(pkg.name)}`} className="block text-muted-foreground">
                         {formatDate(pkg.createdAt)}
                       </Link>
                     </TableCell>

--- a/apps/web/app/(admin)/admin/page.tsx
+++ b/apps/web/app/(admin)/admin/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { encodeSkillName } from '@tank/shared';
 import { count, desc, eq, inArray } from 'drizzle-orm';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -141,7 +142,7 @@ export default async function AdminDashboardPage() {
                 >
                   <div>
                     <Link
-                      href={`/admin/packages/${encodeURIComponent(pkg.name)}`}
+                      href={`/admin/packages/${encodeSkillName(pkg.name)}`}
                       className="font-medium"
                     >
                       {pkg.name}

--- a/apps/web/app/(registry)/skills/[...name]/page.tsx
+++ b/apps/web/app/(registry)/skills/[...name]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { encodeSkillName } from '@tank/shared';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { unstable_noStore as noStore } from 'next/cache';
@@ -171,8 +172,8 @@ export async function generateMetadata({ params }: SkillDetailPageProps): Promis
   const title = version ? `${skillName}@${version}` : skillName;
   const description = data.description
     ?? `AI agent skill published on Tank by ${data.publisher.name}.`;
-  const url = `https://tankpkg.dev/skills/${encodeURIComponent(skillName)}`;
-  const ogImageUrl = `https://tankpkg.dev/api/og/${encodeURIComponent(skillName)}`;
+  const url = `https://tankpkg.dev/skills/${encodeSkillName(skillName)}`;
+  const ogImageUrl = `https://tankpkg.dev/api/og/${encodeSkillName(skillName)}`;
 
   return {
     title,
@@ -317,7 +318,7 @@ export default async function SkillDetailPage({
         '@type': 'SoftwareSourceCode',
         name: data.name,
         description: data.description ?? undefined,
-        url: `https://tankpkg.dev/skills/${encodeURIComponent(data.name)}`,
+        url: `https://tankpkg.dev/skills/${encodeSkillName(data.name)}`,
         codeRepository: data.repositoryUrl ?? undefined,
         version: data.latestVersion?.version ?? undefined,
         datePublished: data.createdAt.toISOString(),
@@ -347,7 +348,7 @@ export default async function SkillDetailPage({
         itemListElement: [
           { '@type': 'ListItem', position: 1, name: 'Tank', item: 'https://tankpkg.dev' },
           { '@type': 'ListItem', position: 2, name: 'Skills', item: 'https://tankpkg.dev/skills' },
-          { '@type': 'ListItem', position: 3, name: data.name, item: `https://tankpkg.dev/skills/${encodeURIComponent(data.name)}` },
+          { '@type': 'ListItem', position: 3, name: data.name, item: `https://tankpkg.dev/skills/${encodeSkillName(data.name)}` },
         ],
       },
     ],

--- a/apps/web/app/(registry)/skills/page.tsx
+++ b/apps/web/app/(registry)/skills/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { encodeSkillName } from '@tank/shared';
 import Link from 'next/link';
 import { unstable_noStore as noStore } from 'next/cache';
 import { Download, Lock, Star } from 'lucide-react';
@@ -206,7 +207,7 @@ function SkillCard({
   isLoggedIn: boolean;
 }) {
   return (
-    <Link href={`/skills/${encodeURIComponent(skill.name)}`}>
+    <Link href={`/skills/${encodeSkillName(skill.name)}`}>
       <Card className="h-full cursor-pointer transition-colors hover:border-primary/50">
         <CardHeader className="pb-2">
           <div className="flex items-start justify-between gap-2">

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/db';
 import { skills } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import type { MetadataRoute } from 'next';
+import { encodeSkillName } from '@tank/shared';
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://tankpkg.dev';
 
@@ -25,7 +26,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       .where(eq(skills.visibility, 'public'));
 
     skillPages = publicSkills.map((skill) => ({
-      url: `${BASE_URL}/skills/${encodeURIComponent(skill.name)}`,
+      url: `${BASE_URL}/skills/${encodeSkillName(skill.name)}`,
       lastModified: skill.updatedAt,
       changeFrequency: 'weekly' as const,
       priority: 0.7,

--- a/packages/shared/src/__tests__/url.test.ts
+++ b/packages/shared/src/__tests__/url.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { encodeSkillName } from '../lib/url.js';
+
+describe('encodeSkillName', () => {
+  it('keeps @ and / unencoded for scoped names', () => {
+    expect(encodeSkillName('@tank/bulletproof')).toBe('@tank/bulletproof');
+  });
+
+  it('keeps @ and / for deeply scoped names', () => {
+    expect(encodeSkillName('@org/some-skill')).toBe('@org/some-skill');
+  });
+
+  it('encodes spaces', () => {
+    expect(encodeSkillName('my skill')).toBe('my%20skill');
+  });
+
+  it('encodes query-string characters', () => {
+    expect(encodeSkillName('skill?v=1')).toBe('skill%3Fv%3D1');
+  });
+
+  it('encodes hash characters', () => {
+    expect(encodeSkillName('skill#readme')).toBe('skill%23readme');
+  });
+
+  it('handles unscoped names unchanged', () => {
+    expect(encodeSkillName('simple-skill')).toBe('simple-skill');
+  });
+
+  it('handles names with multiple @ and /', () => {
+    expect(encodeSkillName('@org/sub/path')).toBe('@org/sub/path');
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,3 +16,6 @@ export { PERMISSION_CATEGORIES, DEFAULT_PERMISSIONS, type PermissionCategory } f
 
 // Resolver
 export { resolve, sortVersions } from './lib/resolver.js';
+
+// URL helpers
+export { encodeSkillName } from './lib/url.js';

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -1,0 +1,14 @@
+/**
+ * Encode a skill/package name for use in URLs.
+ *
+ * Like `encodeURIComponent` but keeps `@` and `/` unencoded so scoped
+ * package names produce clean, human-readable paths:
+ *
+ *   encodeSkillName('@tank/bulletproof')  → '@tank/bulletproof'
+ *   encodeSkillName('my skill')           → 'my%20skill'
+ */
+export function encodeSkillName(name: string): string {
+  return encodeURIComponent(name)
+    .replace(/%40/g, '@')
+    .replace(/%2F/gi, '/');
+}


### PR DESCRIPTION
## Summary

- Add `encodeSkillName()` utility to `@tank/shared` that URL-encodes skill names while preserving `@` and `/` for clean, readable URLs
- Replace `encodeURIComponent` with `encodeSkillName` across all page links, sitemap, canonical URLs, OG/Twitter metadata, and JSON-LD structured data

**Before:** `https://tankpkg.dev/skills/%40tank%2Fbulletproof`
**After:** `https://tankpkg.dev/skills/@tank/bulletproof`

## Changes

| File | What changed |
|------|-------------|
| `packages/shared/src/lib/url.ts` | New `encodeSkillName()` — encodes everything except `@` and `/` |
| `packages/shared/src/__tests__/url.test.ts` | 7 test cases (scoped names, spaces, query chars, hash, multi-slash) |
| `packages/shared/src/index.ts` | Export `encodeSkillName` from barrel |
| `apps/web/app/sitemap.ts` | Sitemap URLs |
| `apps/web/app/(registry)/skills/[...name]/page.tsx` | Canonical URL, OG image, JSON-LD url, breadcrumb item |
| `apps/web/app/(registry)/skills/page.tsx` | Skill card link hrefs |
| `apps/web/app/(admin)/admin/page.tsx` | Admin dashboard package links |
| `apps/web/app/(admin)/admin/packages/page.tsx` | All 7 table cell links |
| `apps/web/app/(admin)/admin/orgs/[orgId]/page.tsx` | Org package links |

> **Note:** `encodeURIComponent` is intentionally kept in API fetch calls (`file-explorer`, `star-button`, `download-button`, admin components) — those hit single-segment `[name]` routes that require `/` to be encoded.

Fixes #88