### PR TITLE
fix(scan): use scan timestamp and add LLM debug logging

### DIFF
--- a/apps/web/app/(registry)/skills/[...name]/page.tsx
+++ b/apps/web/app/(registry)/skills/[...name]/page.tsx
@@ -242,7 +242,7 @@ export default async function SkillDetailPage({
         score={data.latestVersion?.auditScore ?? null}
         verdict={scanDetails?.verdict ?? null}
         durationMs={scanDetails?.durationMs ?? null}
-        scannedAt={data.latestVersion?.publishedAt ? String(data.latestVersion.publishedAt) : null}
+        scannedAt={scanDetails?.scannedAt ? String(scanDetails.scannedAt) : null}
         criticalCount={scanDetails?.criticalCount ?? 0}
         highCount={scanDetails?.highCount ?? 0}
         mediumCount={scanDetails?.mediumCount ?? 0}

--- a/apps/web/lib/data/skills.ts
+++ b/apps/web/lib/data/skills.ts
@@ -49,6 +49,7 @@ export interface ScanDetails {
   verdict: string | null;
   stagesRun: string[];
   durationMs: number | null;
+  scannedAt: Date | null;
   findings: ScanFinding[];
   criticalCount: number;
   highCount: number;
@@ -245,7 +246,8 @@ export async function getSkillDetail(
       (SELECT row_to_json(t) FROM (
         SELECT sr.verdict, sr.stages_run AS "stagesRun", sr.duration_ms AS "durationMs",
                sr.critical_count AS "criticalCount", sr.high_count AS "highCount",
-               sr.medium_count AS "mediumCount", sr.low_count AS "lowCount"
+               sr.medium_count AS "mediumCount", sr.low_count AS "lowCount",
+               sr.created_at AS "scannedAt"
         FROM scan_results sr WHERE sr.version_id = sv.id
         ORDER BY sr.created_at DESC LIMIT 1
       ) t) AS "scanResult",
@@ -293,6 +295,7 @@ export async function getSkillDetail(
         verdict: scanResultJson.verdict as string | null,
         stagesRun: (scanResultJson.stagesRun as string[]) || [],
         durationMs: scanResultJson.durationMs as number | null,
+        scannedAt: scanResultJson.scannedAt ? new Date(scanResultJson.scannedAt as string) : null,
         findings: scanFindingsJson || [],
         criticalCount: Number(scanResultJson.criticalCount) || 0,
         highCount: Number(scanResultJson.highCount) || 0,
@@ -300,7 +303,7 @@ export async function getSkillDetail(
         lowCount: Number(scanResultJson.lowCount) || 0,
       }
     : {
-        verdict: null, stagesRun: [], durationMs: null, findings: [],
+        verdict: null, stagesRun: [], durationMs: null, scannedAt: null, findings: [],
         criticalCount: 0, highCount: 0, mediumCount: 0, lowCount: 0,
       };
 


### PR DESCRIPTION
## Summary
- Fix scan timestamp to use `scan_results.created_at` instead of version's `publishedAt`
- Add debug logging to LLM analyzer to diagnose why env vars aren't being detected
- Add `scannedAt` field to `ScanDetails` interface

## Problem
1. **Wrong scan time**: The UI showed "Scanned 1d ago" using the version's publish date instead of the actual scan timestamp from `scan_results.created_at`
2. **LLM providers not detected**: Added debug logging to help diagnose why `Groq_api_key` and `openrouter_api_key` aren't being picked up

## Solution
- Added `scannedAt` to SQL query and TypeScript interface
- Pass `scanDetails.scannedAt` to SecurityOverview component
- Add debug logging in LLM analyzer to show which env vars are present

## Test Plan
- [ ] Rescan a package
- [ ] Verify "Scanned X ago" shows actual scan time
- [ ] Check Python API logs for LLM env var debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)