### PR TITLE
fix(python-api): make stage3 async and add missing SARIF dependency

### DIFF
--- a/python-api/api/analyze/rescan.py
+++ b/python-api/api/analyze/rescan.py
@@ -213,7 +213,8 @@ async def rescan_version(version: Dict[str, Any]) -> Dict[str, Any]:
                 ))
 
                 # Stage 3
-                stage_results.append(stage3_detect_injection(ingest))
+                stage3_result, _ = await stage3_detect_injection(ingest)
+                stage_results.append(stage3_result)
 
                 # Stage 4
                 stage_results.append(stage4_scan_secrets(ingest))

--- a/python-api/api/analyze/scan.py
+++ b/python-api/api/analyze/scan.py
@@ -259,7 +259,7 @@ async def run_scan_pipeline(request: ScanRequest) -> ScanResponse:
         remaining_budget = MAX_SCAN_DURATION_MS - elapsed
         if remaining_budget > 5000:
             try:
-                result, llm_analysis = stage3_detect_injection(ingest_result, llm_analysis)
+                result, llm_analysis = await stage3_detect_injection(ingest_result, llm_analysis)
                 stage_results.append(result)
             except Exception as e:
                 stage_results.append(StageResult(

--- a/python-api/lib/scan/stage3_injection.py
+++ b/python-api/lib/scan/stage3_injection.py
@@ -306,7 +306,7 @@ def analyze_markdown_file(temp_dir: str, file_path: str) -> List[Finding]:
     return findings
 
 
-def stage3_detect_injection(
+async def stage3_detect_injection(
     ingest_result: IngestResult,
     llm_analysis: Optional[LLMAnalysis] = None,
 ) -> Tuple[StageResult, Optional[LLMAnalysis]]:
@@ -385,9 +385,7 @@ def stage3_detect_injection(
         if ambiguous_findings:
             try:
                 # Run async LLM analysis
-                llm_result = asyncio.run(
-                    llm_analyzer.analyze_findings(ambiguous_findings, temp_dir)
-                )
+                llm_result = await llm_analyzer.analyze_findings(ambiguous_findings, temp_dir)
 
                 # Update metadata
                 llm_analysis.provider_used = llm_result.provider_used

--- a/python-api/pyproject.toml
+++ b/python-api/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "detect-secrets>=1.5.0",
     "pip-audit>=2.7.0",
     "sarif-om>=1.0.0",
+    "jschema-to-python>=1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/python-api/requirements.txt
+++ b/python-api/requirements.txt
@@ -32,3 +32,4 @@ pip-audit>=2.7.0
 
 # SARIF output support (required by skill-scanner)
 sarif-om>=1.0.0
+jschema-to-python>=1.2.0


### PR DESCRIPTION
## Summary
- Make `stage3_detect_injection` async to properly await LLM analysis
- Update `scan.py` and `rescan.py` to await the async stage3 function
- Add `jschema-to-python` dependency for SARIF support

## Problem
1. **RuntimeWarning**: `coroutine 'LLMAnalyzer.analyze_findings' was never awaited` - stage3 was using `asyncio.run()` inside an async context
2. **ModuleNotFoundError**: `No module named 'jschema_to_python'` - missing dependency for skill-scanner SARIF output
3. **Rescan returning HTML** - Python API was crashing due to async issue, causing Vercel to return error page

## Solution
- Changed `stage3_detect_injection` from sync to async
- Changed `asyncio.run(llm_analyzer.analyze_findings(...))` to `await llm_analyzer.analyze_findings(...)`
- Added `jschema-to-python>=1.2.0` to dependencies

## Test Plan
- [ ] Merge and redeploy Python API
- [ ] Run rescan - should no longer see RuntimeWarning
- [ ] Verify SARIF loading works (no jschema_to_python error)
- [ ] Verify rescan returns JSON, not HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)