### PR TITLE
chore: add Discord release notification workflow

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -1,0 +1,26 @@
+name: Discord Release Notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    name: notify-discord
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Post to Discord #releases
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
+          nodetail: true
+          title: "${{ github.event.release.tag_name }} released"
+          description: |
+            **${{ github.event.release.name }}**
+
+            ${{ github.event.release.body }}
+
+            [View release](${{ github.event.release.html_url }}) | [Install](https://tankpkg.dev)
+          color: 0x5EBB4D
+          username: Tank Releases
+          avatar_url: https://avatars.githubusercontent.com/u/211694667


### PR DESCRIPTION
## Summary
- Adds a separate workflow that posts formatted release notifications to the Discord `#releases` channel when a GitHub release is published
- Uses `sarisia/actions-status-discord@v1` for rich embed formatting
- Triggered on `release: published` — decoupled from the build/release pipeline
- The `DISCORD_RELEASES_WEBHOOK` secret has already been configured on the repo