### PR TITLE
fix(ci): make Windows installer step non-blocking in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,15 +92,15 @@ jobs:
 
       - name: Build Windows installer
         if: runner.os == 'Windows'
+        continue-on-error: true
         shell: pwsh
         run: |
-          # Generate icon from favicon
+          if (!(Test-Path "installer/windows/create-icon.ps1")) {
+            Write-Host "Installer scripts not found, skipping .exe installer build"
+            exit 0
+          }
           powershell -ExecutionPolicy Bypass -File installer/windows/create-icon.ps1
-
-          # Install Inno Setup
           choco install innosetup -y --no-progress
-
-          # Build installer with version from tag
           $version = "${{ github.ref_name }}".TrimStart("v")
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DVERSION=$version installer\windows\tank-installer.iss
 
@@ -123,7 +123,7 @@ jobs:
             apps/cli/build/${{ matrix.output }}
             apps/cli/build/tank-windows-x64.zip
             apps/cli/build/tank-windows-x64-setup.exe
-          if-no-files-found: error
+          if-no-files-found: warn
 
   release:
     name: create-release
@@ -177,7 +177,7 @@ jobs:
 
       - name: Generate checksums
         working-directory: release
-        run: sha256sum tank-* *.deb *.exe 2>/dev/null | sort > SHA256SUMS
+        run: sha256sum tank-* *.deb *.exe 2>/dev/null | sort > SHA256SUMS || true
 
       - name: Update in-repo Homebrew formula
         continue-on-error: true


### PR DESCRIPTION
## Summary
- The release workflow references `installer/windows/create-icon.ps1` and `tank-installer.iss` which were never created (PR #81 added the workflow steps but not the files)
- This caused the v0.7.0 release to fail on the Windows build job
- Makes the installer step `continue-on-error: true` with a file existence check
- Changes `if-no-files-found` from `error` to `warn` for Windows artifacts (setup exe is optional)

Once merged, will delete and re-push the v0.7.0 tag to retrigger the release.