### PR TITLE
fix(scanner): export app from index.py for Vercel entrypoint

### DIFF
--- a/packages/scanner/index.py
+++ b/packages/scanner/index.py
@@ -1,1 +1,5 @@
 """Vercel FastAPI entrypoint at root level"""
+
+from api.main import app
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- Fix empty `index.py` - now exports `app` from `api/main.py`

## Problem
Vercel error:
> Missing variable `handler` or `app` in file "index.py"

The entrypoint file was empty (just a docstring).

## Solution
Import and export the FastAPI app:
```python
from api.main import app
```

## Test Plan
- [ ] Merge this PR
- [ ] Verify Vercel deployment succeeds
- [ ] Test scan endpoint works