### PR TITLE
fix(scanner): parenthesize multiple exception types for Python 3

### DIFF
--- a/packages/scanner/lib/scan/cisco_scanner.py
+++ b/packages/scanner/lib/scan/cisco_scanner.py
@@ -65,7 +65,7 @@ def is_skill_scanner_available() -> bool:
             timeout=5,
         )
         return result.returncode == 0
-    except subprocess.TimeoutExpired, FileNotFoundError:
+    except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
 
 

--- a/packages/scanner/lib/scan/dedup.py
+++ b/packages/scanner/lib/scan/dedup.py
@@ -78,7 +78,7 @@ def _is_duplicate(a: dict[str, Any], b: dict[str, Any]) -> bool:
         line_b = int(loc_b.rsplit(":", 1)[1])
         if abs(line_a - line_b) > 3:
             return False
-    except ValueError, IndexError:
+    except (ValueError, IndexError):
         pass  # If no line numbers, check type similarity
 
     # Check keyword overlap in type names

--- a/packages/scanner/lib/scan/sarif.py
+++ b/packages/scanner/lib/scan/sarif.py
@@ -79,7 +79,7 @@ def to_sarif(
                         }
                     }
                 ]
-            except ValueError, IndexError:
+            except (ValueError, IndexError):
                 result["locations"] = [
                     {
                         "physicalLocation": {

--- a/packages/scanner/lib/scan/stage5_supply.py
+++ b/packages/scanner/lib/scan/stage5_supply.py
@@ -424,7 +424,7 @@ def cvss_to_severity(vuln: dict[str, Any]) -> str:
                     if score >= 4.0:
                         return "medium"
                     return "low"
-        except ValueError, IndexError:
+        except (ValueError, IndexError):
             continue
 
     # Fallback to database severity if available


### PR DESCRIPTION
## Summary
- Fix Python 2 syntax `except A, B:` → Python 3 syntax `except (A, B):`

## Problem
Vercel deployment failing with:
```
SyntaxError: multiple exception types must be parenthesized
```

Python 3 requires parentheses around multiple exception types in except clauses.

## Files Fixed
- `cisco_scanner.py:68`
- `dedup.py:81`
- `sarif.py:82`
- `stage5_supply.py:427`

## Test Plan
- [ ] Merge this PR
- [ ] Verify Vercel deployment succeeds