### PR TITLE
fix(scanner): parenthesize exception types in snyk_scanner.py

### DIFF
--- a/packages/scanner/lib/scan/snyk_scanner.py
+++ b/packages/scanner/lib/scan/snyk_scanner.py
@@ -65,7 +65,7 @@ def is_snyk_scanner_available() -> bool:
             timeout=5,
         )
         return result.returncode == 0
-    except subprocess.TimeoutExpired, FileNotFoundError:
+    except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
 
 


### PR DESCRIPTION
## Summary
- Fix missed Python 2 syntax in `snyk_scanner.py:68`

## Problem
Previous PR missed this file - still has `except A, B:` instead of `except (A, B):`

## Test Plan
- [ ] Merge this PR
- [ ] Verify Vercel deployment succeeds