### PR TITLE
fix(scanner): parenthesize except clause in snyk_scanner.py for Python 3.12

### DIFF
--- a/packages/scanner/lib/scan/snyk_scanner.py
+++ b/packages/scanner/lib/scan/snyk_scanner.py
@@ -65,7 +65,7 @@ def is_snyk_scanner_available() -> bool:
             timeout=5,
         )
         return result.returncode == 0
-    except subprocess.TimeoutExpired, FileNotFoundError:
+    except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
 
 


### PR DESCRIPTION
## Summary
- Fix the one remaining Python 2 style `except A, B:` that PR #135 missed

## Problem
Vercel `python-api` deployment is returning **500 on every request**. The import chain crashes at startup:

```
index.py → api/main.py → api/analyze/rescan.py → lib/scan/stage3_injection.py → lib/scan/snyk_scanner.py
```

```
SyntaxError: multiple exception types must be parenthesized
  File "/var/task/lib/scan/snyk_scanner.py", line 68
    except subprocess.TimeoutExpired, FileNotFoundError:
```

## Root Cause
PR #135 fixed `cisco_scanner.py:68`, `dedup.py:81`, `sarif.py:82`, and `stage5_supply.py:427` but **missed `snyk_scanner.py:68`** — the file that's actually in Vercel's import chain.

### Why CI didn't catch it
- **Local/CI Python**: 3.14 — accepts `except A, B:` via [PEP 758](https://peps.python.org/pep-0758/)
- **Vercel Python**: 3.12 (per `.python-version` and `runtime.txt`) — **SyntaxError**
- CI only runs `pytest lib/scan/test_llm_analyzer.py`, never importing `snyk_scanner.py`

## Fix
```diff
-    except subprocess.TimeoutExpired, FileNotFoundError:
+    except (subprocess.TimeoutExpired, FileNotFoundError):
```

## Verification
- ✅ 12/12 `test_snyk_scanner.py` tests pass
- ✅ Full app import chain succeeds: `from api.main import app`
- ✅ No other un-parenthesized `except` clauses remain on `main`

## Test Plan
- [x] Tests pass locally
- [ ] Vercel deployment succeeds
- [ ] `GET /health` returns scanner healthy