### PR TITLE
fix(web): responsive mobile nav with hamburger menu

### DIFF
--- a/packages/web/app/home-auth-cta.tsx
+++ b/packages/web/app/home-auth-cta.tsx
@@ -22,7 +22,7 @@ export function HomeNavAuthCta() {
           {isLoggedIn ? 'Dashboard' : 'Sign In'}
         </Link>
       </Button>
-      <Button variant="ghost" size="sm" asChild>
+      <Button variant="ghost" size="sm" asChild className="hidden lg:inline-flex">
         <Link href="/docs" onClick={() => trackCtaClick('Docs', '/docs')}>
           Docs
         </Link>

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -190,6 +190,7 @@ export default async function Home() {
               <Navbar />
             </div>
             <div
+              className="hidden lg:block"
               style={{
                 position: 'absolute',
                 left: '50%',

--- a/packages/web/components/navbar.tsx
+++ b/packages/web/components/navbar.tsx
@@ -4,6 +4,7 @@ import {
   BookOpenIcon,
   CloudIcon,
   FileTextIcon,
+  MenuIcon,
   PackageSearchIcon,
   RocketIcon,
   ServerIcon,
@@ -11,7 +12,8 @@ import {
   SparklesIcon,
   TerminalIcon,
   TrendingUpIcon,
-  WrenchIcon
+  WrenchIcon,
+  XIcon
 } from 'lucide-react';
 import Link from 'next/link';
 import * as React from 'react';
@@ -166,6 +168,8 @@ function ChevronIcon() {
 
 export function Navbar() {
   const [openMenu, setOpenMenu] = React.useState<string | null>(null);
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [mobileSection, setMobileSection] = React.useState<string | null>(null);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleMouseEnter = (text: string) => {
@@ -178,85 +182,246 @@ export function Navbar() {
   };
 
   React.useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1024px)');
+    const handler = () => {
+      if (mq.matches) setMobileOpen(false);
+    };
+    mq.addEventListener('change', handler);
     return () => {
+      mq.removeEventListener('change', handler);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, []);
 
+  React.useEffect(() => {
+    if (mobileOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [mobileOpen]);
+
+  const toggleMobileSection = (text: string) => {
+    setMobileSection((prev) => (prev === text ? null : text));
+  };
+
   return (
-    <nav>
-      <ul style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-        {NAV_ITEMS.map((item) => {
-          if (item.href && !item.items) {
+    <>
+      <nav className="hidden lg:block">
+        <ul style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+          {NAV_ITEMS.map((item) => {
+            if (item.href && !item.items) {
+              return (
+                <li key={item.text}>
+                  <Link
+                    href={item.href}
+                    style={{ display: 'block', borderRadius: '6px', padding: '8px 12px', fontSize: '14px' }}
+                    className="text-muted-foreground transition-colors hover:text-foreground">
+                    {item.text}
+                  </Link>
+                </li>
+              );
+            }
+
+            const isOpen = openMenu === item.text;
+
             return (
-              <li key={item.text}>
-                <Link
-                  href={item.href}
-                  style={{ display: 'block', borderRadius: '6px', padding: '8px 12px', fontSize: '14px' }}
+              <li
+                key={item.text}
+                style={{ position: 'relative', perspective: '2000px' }}
+                onMouseEnter={() => handleMouseEnter(item.text)}
+                onMouseLeave={handleMouseLeave}>
+                <button
+                  type="button"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    borderRadius: '6px',
+                    padding: '8px 12px',
+                    fontSize: '14px'
+                  }}
                   className="text-muted-foreground transition-colors hover:text-foreground">
                   {item.text}
-                </Link>
+                  {item.items && <ChevronIcon />}
+                </button>
+
+                {item.items && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      left: '-12px',
+                      top: '100%',
+                      zIndex: 50,
+                      width: '280px',
+                      paddingTop: '8px',
+                      transformOrigin: 'top left',
+                      transition: 'opacity 200ms ease, transform 200ms ease',
+                      opacity: isOpen ? 1 : 0,
+                      pointerEvents: isOpen ? 'auto' : 'none',
+                      transform: isOpen ? 'rotateX(0deg) scale(1)' : 'rotateX(-15deg) scale(0.95)'
+                    }}>
+                    <ul
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '2px',
+                        borderRadius: '12px',
+                        padding: '8px'
+                      }}
+                      className="border border-border bg-popover shadow-lg">
+                      {item.items.map((dropdownItem) => (
+                        <NavDropdownItem key={dropdownItem.href} {...dropdownItem} />
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </li>
             );
-          }
+          })}
+        </ul>
+      </nav>
 
-          const isOpen = openMenu === item.text;
+      <button
+        type="button"
+        className="lg:hidden text-muted-foreground hover:text-foreground transition-colors"
+        style={{
+          padding: '6px',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}
+        onClick={() => setMobileOpen(!mobileOpen)}
+        aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={mobileOpen}>
+        {mobileOpen ? (
+          <XIcon style={{ width: '20px', height: '20px' }} />
+        ) : (
+          <MenuIcon style={{ width: '20px', height: '20px' }} />
+        )}
+      </button>
 
-          return (
-            <li
-              key={item.text}
-              style={{ position: 'relative', perspective: '2000px' }}
-              onMouseEnter={() => handleMouseEnter(item.text)}
-              onMouseLeave={handleMouseLeave}>
-              <button
-                type="button"
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  borderRadius: '6px',
-                  padding: '8px 12px',
-                  fontSize: '14px'
-                }}
-                className="text-muted-foreground transition-colors hover:text-foreground">
-                {item.text}
-                {item.items && <ChevronIcon />}
-              </button>
-
-              {item.items && (
-                <div
-                  style={{
-                    position: 'absolute',
-                    left: '-12px',
-                    top: '100%',
-                    zIndex: 50,
-                    width: '280px',
-                    paddingTop: '8px',
-                    transformOrigin: 'top left',
-                    transition: 'opacity 200ms ease, transform 200ms ease',
-                    opacity: isOpen ? 1 : 0,
-                    pointerEvents: isOpen ? 'auto' : 'none',
-                    transform: isOpen ? 'rotateX(0deg) scale(1)' : 'rotateX(-15deg) scale(0.95)'
-                  }}>
-                  <ul
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: '2px',
-                      borderRadius: '12px',
-                      padding: '8px'
-                    }}
-                    className="border border-border bg-popover shadow-lg">
-                    {item.items.map((dropdownItem) => (
-                      <NavDropdownItem key={dropdownItem.href} {...dropdownItem} />
-                    ))}
-                  </ul>
+      {mobileOpen && (
+        <>
+          <button
+            type="button"
+            className="lg:hidden"
+            style={{
+              position: 'fixed',
+              inset: 0,
+              top: '4rem',
+              backgroundColor: 'rgba(0, 0, 0, 0.4)',
+              zIndex: 40,
+              border: 'none',
+              cursor: 'default'
+            }}
+            onClick={() => setMobileOpen(false)}
+            aria-label="Close menu"
+          />
+          <div
+            className="lg:hidden border-b border-border bg-background/95 backdrop-blur-xl"
+            style={{
+              position: 'fixed',
+              left: 0,
+              right: 0,
+              top: '4rem',
+              zIndex: 50,
+              maxHeight: 'calc(100vh - 4rem)',
+              overflowY: 'auto'
+            }}>
+            <nav style={{ padding: '4px 16px 16px' }}>
+              {NAV_ITEMS.map((item) => (
+                <div key={item.text}>
+                  {item.items ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => toggleMobileSection(item.text)}
+                        style={{
+                          display: 'flex',
+                          width: '100%',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          padding: '10px 0',
+                          fontSize: '14px',
+                          background: 'none',
+                          border: 'none',
+                          cursor: 'pointer',
+                          color: 'inherit'
+                        }}
+                        className="text-muted-foreground hover:text-foreground transition-colors">
+                        {item.text}
+                        <svg
+                          width="10"
+                          height="6"
+                          viewBox="0 0 10 6"
+                          fill="none"
+                          style={{
+                            width: '10px',
+                            height: '6px',
+                            opacity: 0.6,
+                            transform: mobileSection === item.text ? 'rotate(180deg)' : 'rotate(0deg)',
+                            transition: 'transform 200ms ease'
+                          }}
+                          aria-hidden="true">
+                          <path
+                            d="M1 1L5 5L9 1"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </button>
+                      {mobileSection === item.text && (
+                        <ul style={{ paddingBottom: '8px', paddingLeft: '4px' }}>
+                          {item.items.map((sub) => (
+                            <li key={sub.href}>
+                              <Link
+                                href={sub.href}
+                                onClick={() => setMobileOpen(false)}
+                                style={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  gap: '10px',
+                                  borderRadius: '6px',
+                                  padding: '8px 10px',
+                                  fontSize: '14px'
+                                }}
+                                className="text-muted-foreground hover:text-foreground hover:bg-accent transition-colors">
+                                {sub.icon}
+                                <span>{sub.text}</span>
+                              </Link>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </>
+                  ) : (
+                    <Link
+                      href={item.href!}
+                      onClick={() => setMobileOpen(false)}
+                      style={{
+                        display: 'block',
+                        padding: '10px 0',
+                        fontSize: '14px'
+                      }}
+                      className="text-muted-foreground hover:text-foreground transition-colors">
+                      {item.text}
+                    </Link>
+                  )}
                 </div>
-              )}
-            </li>
-          );
-        })}
-      </ul>
-    </nav>
+              ))}
+            </nav>
+          </div>
+        </>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Replace desktop nav links ("Browse Skills", "Docs") with a hamburger menu on viewports < 1024px
- Hamburger opens a slide-down panel with collapsible sections for all nav items
- Hide search bar and standalone "Docs" CTA button on mobile to prevent content overlap
- Body scroll lock when mobile menu is open, auto-close on resize to desktop

## Changed Files

- `packages/web/components/navbar.tsx` — added mobile hamburger + menu panel, desktop nav hidden below `lg`
- `packages/web/app/page.tsx` — hide center search trigger below `lg`
- `packages/web/app/home-auth-cta.tsx` — hide standalone "Docs" button below `lg`

Closes #140