### PR TITLE
fix(web): add framework and outputDirectory to root vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "outputDirectory": "packages/web/.next",
   "buildCommand": "bun turbo build --filter=@internal/web...",
   "installCommand": "bun install",
   "devCommand": "bun --filter @internal/web run dev",


### PR DESCRIPTION
Vercel build failing — no Next.js detected at root. Adds `framework` and `outputDirectory` so Vercel knows it's a Next.js monorepo.