### PR TITLE
fix(vercel): revert framework/outputDirectory from root vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "outputDirectory": "packages/web/.next",
   "buildCommand": "bun turbo build --filter=@internal/web...",
   "installCommand": "bun install",
   "devCommand": "bun --filter @internal/web run dev",


### PR DESCRIPTION
Reverts the framework/outputDirectory added in #142 — those didn't fix the build. The actual fix was changing the Vercel project Root Directory to `packages/web` via the API, so `packages/web/vercel.json` is now used and Vercel can find Next.js.