### PR TITLE
fix(web): remove output standalone — fixes /docs 404 on Vercel

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,9 +1,7 @@
 import { createMDX } from 'fumadocs-mdx/next';
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {
-  output: 'standalone'
-};
+const nextConfig: NextConfig = {};
 
 const withMDX = createMDX({
   configPath: 'source.config.ts',


### PR DESCRIPTION
## Problem
All `/docs` routes return 404 in production. The homepage works because it's CDN-cached, but any route requiring Next.js server routing (including pre-rendered catch-all `[[...slug]]`) fails silently.

## Root Cause
`output: 'standalone'` in `next.config.ts` is incompatible with Vercel's deployment model. Vercel deploys Next.js apps as individual serverless functions — standalone mode instead outputs a single Node.js server bundle that Vercel can't route correctly.

## Fix
Remove `output: 'standalone'`. Vercel's native Next.js adapter handles everything correctly without it.

## Verification
After merge, `/docs`, `/docs/cli`, `/docs/api`, etc. will return 200.