### PR TITLE
fix(web): restore desktop header before full search layout

### DIFF
--- a/packages/web/app/(registry)/layout.tsx
+++ b/packages/web/app/(registry)/layout.tsx
@@ -1,9 +1,9 @@
 import { headers } from 'next/headers';
 import Link from 'next/link';
 import { Suspense } from 'react';
-import { Navbar } from '@/components/navbar';
-import { Logo } from '@/components/logo';
 import { Footer } from '@/components/footer';
+import { Logo } from '@/components/logo';
+import { Navbar } from '@/components/navbar';
 import { SearchTrigger } from '@/components/search-trigger';
 import { auth } from '@/lib/auth';
 
@@ -51,6 +51,7 @@ export default function RegistryLayout({ children }: { children: React.ReactNode
             <Navbar />
           </div>
           <div
+            className="hidden min-[1200px]:block"
             style={{
               position: 'absolute',
               left: '50%',

--- a/packages/web/app/home-auth-cta.tsx
+++ b/packages/web/app/home-auth-cta.tsx
@@ -22,7 +22,7 @@ export function HomeNavAuthCta() {
           {isLoggedIn ? 'Dashboard' : 'Sign In'}
         </Link>
       </Button>
-      <Button variant="ghost" size="sm" asChild className="hidden lg:inline-flex">
+      <Button variant="ghost" size="sm" asChild className="hidden min-[1200px]:inline-flex">
         <Link href="/docs" onClick={() => trackCtaClick('Docs', '/docs')}>
           Docs
         </Link>

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -190,7 +190,7 @@ export default async function Home() {
               <Navbar />
             </div>
             <div
-              className="hidden lg:block"
+              className="hidden min-[1200px]:block"
               style={{
                 position: 'absolute',
                 left: '50%',

--- a/packages/web/components/navbar.tsx
+++ b/packages/web/components/navbar.tsx
@@ -171,6 +171,7 @@ export function Navbar() {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [mobileSection, setMobileSection] = React.useState<string | null>(null);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const desktopNavMediaQuery = '(min-width: 900px)';
 
   const handleMouseEnter = (text: string) => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -182,7 +183,7 @@ export function Navbar() {
   };
 
   React.useEffect(() => {
-    const mq = window.matchMedia('(min-width: 1024px)');
+    const mq = window.matchMedia(desktopNavMediaQuery);
     const handler = () => {
       if (mq.matches) setMobileOpen(false);
     };
@@ -191,7 +192,7 @@ export function Navbar() {
       mq.removeEventListener('change', handler);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, []);
+  }, [desktopNavMediaQuery]);
 
   React.useEffect(() => {
     if (mobileOpen) {
@@ -210,7 +211,7 @@ export function Navbar() {
 
   return (
     <>
-      <nav className="hidden lg:block">
+      <nav className="hidden min-[900px]:block">
         <ul style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           {NAV_ITEMS.map((item) => {
             if (item.href && !item.items) {
@@ -287,7 +288,7 @@ export function Navbar() {
 
       <button
         type="button"
-        className="flex items-center justify-center lg:hidden text-muted-foreground hover:text-foreground transition-colors"
+        className="flex items-center justify-center min-[900px]:hidden text-muted-foreground hover:text-foreground transition-colors"
         style={{
           padding: '6px',
           background: 'none',
@@ -308,7 +309,7 @@ export function Navbar() {
         <>
           <button
             type="button"
-            className="lg:hidden"
+            className="min-[900px]:hidden"
             style={{
               position: 'fixed',
               inset: 0,
@@ -322,7 +323,7 @@ export function Navbar() {
             aria-label="Close menu"
           />
           <div
-            className="lg:hidden border-b border-border bg-background/95 backdrop-blur-xl"
+            className="min-[900px]:hidden border-b border-border bg-background/95 backdrop-blur-xl"
             style={{
               position: 'fixed',
               left: 0,


### PR DESCRIPTION
## Summary
Fixes responsive header layout by implementing a two-stage breakpoint strategy:

- **900px breakpoint**: Desktop navigation appears, burger menu hides
- **1200px breakpoint**: Centered search and extra docs action become visible

## Changes
- Desktop nav now appears from 900px
- Burger menu hides at 900px
- Centered search + extra docs action wait until 1200px

## Verification
Build verified with `npx turbo run build --filter=@internal/web`

Closes #151