### PR TITLE
fix(web): restore lg header behavior and keep burger mobile-only

### DIFF
--- a/packages/web/app/(registry)/layout.tsx
+++ b/packages/web/app/(registry)/layout.tsx
@@ -51,7 +51,6 @@ export default function RegistryLayout({ children }: { children: React.ReactNode
             <Navbar />
           </div>
           <div
-            className="hidden min-[1200px]:block"
             style={{
               position: 'absolute',
               left: '50%',

--- a/packages/web/app/home-auth-cta.tsx
+++ b/packages/web/app/home-auth-cta.tsx
@@ -22,7 +22,7 @@ export function HomeNavAuthCta() {
           {isLoggedIn ? 'Dashboard' : 'Sign In'}
         </Link>
       </Button>
-      <Button variant="ghost" size="sm" asChild className="hidden min-[1200px]:inline-flex">
+      <Button variant="ghost" size="sm" asChild className="hidden lg:inline-flex">
         <Link href="/docs" onClick={() => trackCtaClick('Docs', '/docs')}>
           Docs
         </Link>

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -190,7 +190,7 @@ export default async function Home() {
               <Navbar />
             </div>
             <div
-              className="hidden min-[1200px]:block"
+              className="hidden lg:block"
               style={{
                 position: 'absolute',
                 left: '50%',

--- a/packages/web/components/navbar.tsx
+++ b/packages/web/components/navbar.tsx
@@ -171,7 +171,6 @@ export function Navbar() {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [mobileSection, setMobileSection] = React.useState<string | null>(null);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-  const desktopNavMediaQuery = '(min-width: 900px)';
 
   const handleMouseEnter = (text: string) => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -183,7 +182,7 @@ export function Navbar() {
   };
 
   React.useEffect(() => {
-    const mq = window.matchMedia(desktopNavMediaQuery);
+    const mq = window.matchMedia('(min-width: 1024px)');
     const handler = () => {
       if (mq.matches) setMobileOpen(false);
     };
@@ -192,7 +191,7 @@ export function Navbar() {
       mq.removeEventListener('change', handler);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [desktopNavMediaQuery]);
+  }, []);
 
   React.useEffect(() => {
     if (mobileOpen) {
@@ -211,7 +210,7 @@ export function Navbar() {
 
   return (
     <>
-      <nav className="hidden min-[900px]:block">
+      <nav className="hidden lg:block">
         <ul style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           {NAV_ITEMS.map((item) => {
             if (item.href && !item.items) {
@@ -288,7 +287,7 @@ export function Navbar() {
 
       <button
         type="button"
-        className="flex items-center justify-center min-[900px]:hidden text-muted-foreground hover:text-foreground transition-colors"
+        className="flex items-center justify-center lg:hidden text-muted-foreground hover:text-foreground transition-colors"
         style={{
           padding: '6px',
           background: 'none',
@@ -309,7 +308,7 @@ export function Navbar() {
         <>
           <button
             type="button"
-            className="min-[900px]:hidden"
+            className="lg:hidden"
             style={{
               position: 'fixed',
               inset: 0,
@@ -323,7 +322,7 @@ export function Navbar() {
             aria-label="Close menu"
           />
           <div
-            className="min-[900px]:hidden border-b border-border bg-background/95 backdrop-blur-xl"
+            className="lg:hidden border-b border-border bg-background/95 backdrop-blur-xl"
             style={{
               position: 'fixed',
               left: 0,


### PR DESCRIPTION
Closes #153

## Summary

This PR restores the original responsive header behavior while preserving the burger visibility fix.

## Changes

- Reverts the custom `900px`/`1200px` header thresholds introduced in `b0d13b6`
- Restores `lg` breakpoint behavior from the original responsive nav implementation
- Preserves the burger visibility fix from `32f4115`

## Verification

Verified with `npx turbo run build --filter=@internal/web`