### PR TITLE
fix(web): restore responsive header and add desktop/mobile e2e

### DIFF
--- a/e2e/homepage-header.spec.ts
+++ b/e2e/homepage-header.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+const baseURL = process.env.E2E_REGISTRY_URL ?? 'http://127.0.0.1:3000';
+
+test.describe('homepage responsive header', () => {
+  test('shows desktop header controls on large screens', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(baseURL, { waitUntil: 'networkidle' });
+
+    await expect(page.getByTestId('desktop-nav')).toBeVisible();
+    await expect(page.getByTestId('search-trigger')).toBeVisible();
+    await expect(page.getByTestId('mobile-menu-toggle')).toBeHidden();
+  });
+
+  test('shows burger menu instead of desktop controls on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto(baseURL, { waitUntil: 'networkidle' });
+
+    await expect(page.getByTestId('mobile-menu-toggle')).toBeVisible();
+    await expect(page.getByTestId('desktop-nav')).toBeHidden();
+    await expect(page.getByTestId('search-trigger')).toBeHidden();
+  });
+});

--- a/packages/web/app/(registry)/layout.tsx
+++ b/packages/web/app/(registry)/layout.tsx
@@ -51,6 +51,7 @@ export default function RegistryLayout({ children }: { children: React.ReactNode
             <Navbar />
           </div>
           <div
+            className="max-lg:hidden"
             style={{
               position: 'absolute',
               left: '50%',

--- a/packages/web/app/home-auth-cta.tsx
+++ b/packages/web/app/home-auth-cta.tsx
@@ -22,7 +22,7 @@ export function HomeNavAuthCta() {
           {isLoggedIn ? 'Dashboard' : 'Sign In'}
         </Link>
       </Button>
-      <Button variant="ghost" size="sm" asChild className="hidden lg:inline-flex">
+      <Button variant="ghost" size="sm" asChild className="max-lg:hidden">
         <Link href="/docs" onClick={() => trackCtaClick('Docs', '/docs')}>
           Docs
         </Link>

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -190,7 +190,7 @@ export default async function Home() {
               <Navbar />
             </div>
             <div
-              className="hidden lg:block"
+              className="max-lg:hidden"
               style={{
                 position: 'absolute',
                 left: '50%',

--- a/packages/web/components/navbar.tsx
+++ b/packages/web/components/navbar.tsx
@@ -210,7 +210,7 @@ export function Navbar() {
 
   return (
     <>
-      <nav className="hidden lg:block">
+      <nav data-testid="desktop-nav" className="max-lg:hidden">
         <ul style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           {NAV_ITEMS.map((item) => {
             if (item.href && !item.items) {
@@ -286,6 +286,7 @@ export function Navbar() {
       </nav>
 
       <button
+        data-testid="mobile-menu-toggle"
         type="button"
         className="flex items-center justify-center lg:hidden text-muted-foreground hover:text-foreground transition-colors"
         style={{

--- a/packages/web/components/search-trigger.tsx
+++ b/packages/web/components/search-trigger.tsx
@@ -16,6 +16,7 @@ export function SearchTrigger() {
 
   return (
     <button
+      data-testid="search-trigger"
       type="button"
       onClick={openCommandMenu}
       className="group flex w-full items-center gap-2 rounded-lg border border-input bg-muted/30 px-3 py-1.5 text-sm text-muted-foreground/70 transition-all hover:border-muted-foreground/25 hover:bg-muted/50 hover:text-muted-foreground">


### PR DESCRIPTION
Closes #155

## Changes

- Replaces `hidden lg:block` / `hidden lg:inline-flex` patterns in header paths with `max-lg:hidden` style logic
- Adds data-testid hooks for stable header assertions
- Adds `e2e/homepage-header.spec.ts` regression test

## Verification

- Verified locally with `E2E_REGISTRY_URL=http://127.0.0.1:3000 bunx playwright test e2e/homepage-header.spec.ts` (2 passed)
- Verified build with `npx turbo run build --filter=@internal/web`

## Files Changed

- `packages/web/components/navbar.tsx`
- `packages/web/components/search-trigger.tsx`
- `packages/web/app/page.tsx`
- `packages/web/app/(registry)/layout.tsx`
- `packages/web/app/home-auth-cta.tsx`
- `e2e/homepage-header.spec.ts` (new)