### PR TITLE
chore(release): bump all versions to 0.8.0

### DIFF
--- a/infra/helm/tank/Chart.yaml
+++ b/infra/helm/tank/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   PostgreSQL, Redis, and MinIO for on-premises installations.
 type: application
 version: 0.1.0
-appVersion: "0.6.3"
+appVersion: "0.8.0"
 home: https://github.com/tankpkg/tank
 sources:
   - https://github.com/tankpkg/tank

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.6.3",
+  "version": "0.8.0",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/mcp-server",
-  "version": "0.6.3",
+  "version": "0.8.0",
   "description": "MCP server for Tank - scan and publish AI agent skills from your editor",
   "type": "module",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/shared",
-  "version": "0.6.3",
+  "version": "0.8.0",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/web",
-  "version": "0.6.3",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bump all package.json versions (cli, web, shared, mcp-server) from 0.6.3 to 0.8.0
- Bump Chart.yaml appVersion to 0.8.0
- Needed because v0.6.3 and v0.7.0 tags are already taken by older releases
- After merge, tag v0.8.0 will trigger the new publish.yml workflow (Docker + Helm + smoke test)