### PR TITLE
fix(docker): copy .bdd workspace package.json for bun install

### DIFF
--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -11,6 +11,7 @@ COPY packages/shared/package.json ./packages/shared/
 COPY packages/web/package.json ./packages/web/
 COPY packages/cli/package.json ./packages/cli/
 COPY packages/mcp-server/package.json ./packages/mcp-server/
+COPY .bdd/package.json ./.bdd/
 
 # Install dependencies
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Root `package.json` lists `.bdd` as a workspace, but `packages/web/Dockerfile` didn't copy `.bdd/package.json` into the build context
- This caused `bun install --frozen-lockfile` to fail with `Workspace not found ".bdd"` during Docker image build
- Fix: add `COPY .bdd/package.json ./.bdd/` to the deps stage