### PR TITLE
fix(docker): copy root tsconfig.json to builder stage

### DIFF
--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -20,10 +20,9 @@ RUN bun install --frozen-lockfile
 FROM oven/bun:1 AS builder
 WORKDIR /app
 
-COPY package.json bun.lock ./
+COPY package.json bun.lock tsconfig.json turbo.json ./
 COPY packages/shared ./packages/shared
 COPY packages/web ./packages/web
-COPY turbo.json ./
 
 # Copy node_modules from deps
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
- `@internal/shared` build needs root `tsconfig.json` (shared's tsconfig extends `../../tsconfig.json`)
- Builder stage was missing this file, causing `File '../../tsconfig.json' not found` during Docker image build
- Fix: add `tsconfig.json` to the COPY line in the builder stage