### PR TITLE
fix(docker): conditionally enable standalone output for Docker builds

### DIFF
--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -35,6 +35,7 @@ RUN bun run --filter=@internal/shared build
 # Build web app
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
+ENV STANDALONE=true
 RUN bun run --filter=@internal/web build
 
 # Stage 3: Production image

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,7 +1,10 @@
 import { createMDX } from 'fumadocs-mdx/next';
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  // Enable standalone output for Docker builds (incompatible with Vercel serverless)
+  ...(process.env.STANDALONE === 'true' && { output: 'standalone' })
+};
 
 const withMDX = createMDX({
   configPath: 'source.config.ts',


### PR DESCRIPTION
## Summary
- Next.js `output: 'standalone'` was removed in PR #145 (breaks Vercel serverless)
- But the web Dockerfile relies on `.next/standalone` output
- Fix: set `output: 'standalone'` conditionally via `STANDALONE=true` env var
- Dockerfile sets `ENV STANDALONE=true` in builder stage
- Vercel builds are unaffected (no STANDALONE env var set)