### PR TITLE
fix(publish): track .env.example.onprem and add helm repo setup

### DIFF
--- a/.env.example.onprem
+++ b/.env.example.onprem
@@ -1,0 +1,112 @@
+# Tank On-Premises Configuration
+# Copy this file to .env and fill in the required values
+#
+# ============================================================================
+# REQUIRED - These must be set for the application to start
+# ============================================================================
+
+# Auth secret - generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=your-secret-key-here-change-me
+
+# Public URL of your Tank instance (used for redirects, emails, etc.)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+BETTER_AUTH_URL=http://localhost:3000
+
+# First admin email (optional - if set, this user becomes admin on first login)
+FIRST_ADMIN_EMAIL=admin@yourcompany.com
+
+# ============================================================================
+# DATABASE - PostgreSQL connection
+# ============================================================================
+
+POSTGRES_USER=tank
+POSTGRES_PASSWORD=change-this-password
+POSTGRES_DB=tank
+
+# Full database URL (automatically constructed from above in docker-compose)
+# DATABASE_URL=postgresql://tank:change-this-password@postgres:5432/tank
+
+# ============================================================================
+# STORAGE - Where skill packages are stored
+# ============================================================================
+
+# Storage backend: "s3" (MinIO/AWS) or "supabase" (if using Supabase)
+STORAGE_BACKEND=s3
+
+# S3/MinIO configuration (when STORAGE_BACKEND=s3)
+S3_BUCKET=packages
+S3_REGION=us-east-1
+# S3_ENDPOINT is set automatically in docker-compose for MinIO
+# S3_ACCESS_KEY and S3_SECRET_KEY come from MINIO_ROOT_USER/PASSWORD
+
+# MinIO credentials (used when STORAGE_BACKEND=s3 with MinIO)
+MINIO_ROOT_USER=tank
+MINIO_ROOT_PASSWORD=change-this-password-too
+
+# If using Supabase storage instead:
+# SUPABASE_URL=https://your-project.supabase.co
+# SUPABASE_SERVICE_KEY=your-service-role-key
+
+# ============================================================================
+# AUTH - Authentication providers
+# ============================================================================
+
+# Available providers (comma-separated): credentials, github, oidc
+AUTH_PROVIDERS=credentials
+NEXT_PUBLIC_AUTH_PROVIDERS=credentials
+
+# GitHub OAuth (optional - enable if using GitHub)
+# GITHUB_CLIENT_ID=your-github-client-id
+# GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# OIDC SSO (optional - for enterprise SSO)
+# OIDC_PROVIDER_ID=enterprise-oidc
+# NEXT_PUBLIC_OIDC_PROVIDER_ID=enterprise-oidc
+# OIDC_DISCOVERY_URL=https://your-company.okta.com/oauth2/default/.well-known/openid-configuration
+# OIDC_CLIENT_ID=your-oidc-client-id
+# OIDC_CLIENT_SECRET=your-oidc-client-secret
+# Optional manual endpoints if discovery is unavailable:
+# OIDC_AUTHORIZATION_URL=https://idp.example.com/oauth2/authorize
+# OIDC_TOKEN_URL=https://idp.example.com/oauth2/token
+# OIDC_USER_INFO_URL=https://idp.example.com/oauth2/userinfo
+
+# Email verification (required for credentials auth)
+# Option 1: SMTP
+# SMTP_HOST=smtp.yourcompany.com
+# SMTP_PORT=587
+# SMTP_USER=your-smtp-user
+# SMTP_PASSWORD=your-smtp-password
+# SMTP_FROM=noreply@yourcompany.com
+
+# Option 2: Resend (https://resend.com)
+# RESEND_API_KEY=re_your-resend-api-key
+# EMAIL_FROM=no-reply@yourcompany.com
+
+# ============================================================================
+# SESSION - Session storage
+# ============================================================================
+
+# Session store: "memory" (single instance) or "redis" (multi-instance)
+SESSION_STORE=redis
+
+# Redis URL (automatically set in docker-compose)
+# REDIS_URL=redis://redis:6379
+
+# ============================================================================
+# OPTIONAL - Advanced configuration
+# ============================================================================
+
+# Application port (default: 3000)
+APP_PORT=3000
+
+# MinIO console port (default: 9001)
+MINIO_CONSOLE_PORT=9001
+
+# Python scanner URL (automatically set in docker-compose)
+# PYTHON_API_URL=http://scanner:8000
+
+# Disable telemetry
+NEXT_TELEMETRY_DISABLED=1
+
+# Log level (debug, info, warn, error)
+LOG_LEVEL=info

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,6 +133,12 @@ jobs:
         run: |
           sed -i "s|tag: \"\"|tag: \"${{ steps.version.outputs.version }}\"|" infra/helm/tank/values.yaml
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add minio https://charts.min.io/
+          helm repo update
+
       - name: Build Helm dependencies
         run: helm dependency build infra/helm/tank/
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ out/
 .env
 .env.*
 !.env.example
+!.env.example.onprem
 
 # IDE
 .idea/


### PR DESCRIPTION
## Summary
Fixes two publish workflow failures:
1. **Smoke test 404**: `.env.example.onprem` was gitignored by `.env.*` pattern — added `!.env.example.onprem` exception and tracked the file
2. **Helm dependency build**: added `helm repo add` for bitnami and minio before `helm dependency build`