### PR TITLE
fix(ci): run bun --filter from workspace root in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,15 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           node -e "const p=require('./packages/cli/package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./packages/cli/package.json', JSON.stringify(p, null, 2)+'\n')"
 
+      - name: Build shared package
+        run: bun --filter @internal/shared run build
+
       - name: Build bundle and binary
         working-directory: packages/cli
         env:
           TARGET: ${{ matrix.target }}
           OUTPUT_NAME: ${{ matrix.output }}
         run: |
-          bun --filter @internal/shared run build
           bun run build
           bun run build:bundle
           bun run build:sea


### PR DESCRIPTION
## Summary
- `bun --filter @internal/shared run build` was running inside `working-directory: packages/cli`, where bun can't resolve workspace packages
- Split into its own step at workspace root, fixing all 5 platform builds
- Pre-existing issue since v0.8.0 (pnpm→bun migration) — all v0.8.0 release attempts failed with the same error