### PR TITLE
fix(ci): use correct bun filter syntax in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           node -e "const p=require('./packages/cli/package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./packages/cli/package.json', JSON.stringify(p, null, 2)+'\n')"
 
       - name: Build shared package
-        run: bun --filter @internal/shared run build
+        run: bun run --filter '@internal/shared' build
 
       - name: Build bundle and binary
         working-directory: packages/cli
@@ -286,9 +286,9 @@ jobs:
 
       - name: Build packages
         run: |
-          bun --filter @internal/shared run build
-          bun --filter @tankpkg/cli run build
-          bun --filter @tankpkg/mcp-server run build
+          bun run --filter '@internal/shared' build
+          bun run --filter '@tankpkg/cli' build
+          bun run --filter '@tankpkg/mcp-server' build
 
       - name: Publish CLI to npm
         continue-on-error: true


### PR DESCRIPTION
## Summary
- `bun --filter <name> run <script>` silently fails with "No packages matched the filter"
- Correct syntax is `bun run --filter '<name>' <script>`
- Fixes binary build + npm publish steps in the release workflow
- Also moves shared package build to its own step (from workspace root, not packages/cli)