### PR TITLE
fix: align canonical URLs with www subdomain to unblock Google indexing

### DIFF
--- a/packages/web/app/(registry)/skills/[...name]/page.tsx
+++ b/packages/web/app/(registry)/skills/[...name]/page.tsx
@@ -23,6 +23,8 @@ import { StarButton } from './star-button';
 // ISR: cache page at CDN for 60s, survives serverless cold starts (PERF-005/006)
 export const revalidate = 60;
 
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev';
+
 function formatDate(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date;
   return d.toLocaleDateString('en-US', {
@@ -152,8 +154,8 @@ export async function generateMetadata({ params }: SkillDetailPageProps): Promis
   const version = data.latestVersion?.version;
   const title = version ? `${skillName}@${version}` : skillName;
   const description = data.description ?? `AI agent skill published on Tank by ${data.publisher.name}.`;
-  const url = `https://tankpkg.dev/skills/${encodeSkillName(skillName)}`;
-  const ogImageUrl = `https://tankpkg.dev/api/og/${encodeSkillName(skillName)}`;
+  const url = `${BASE_URL}/skills/${encodeSkillName(skillName)}`;
+  const ogImageUrl = `${BASE_URL}/api/og/${encodeSkillName(skillName)}`;
 
   return {
     title,
@@ -445,7 +447,7 @@ export default async function SkillDetailPage({ params }: SkillDetailPageProps) 
         '@type': 'SoftwareSourceCode',
         name: data.name,
         description: data.description ?? undefined,
-        url: `https://tankpkg.dev/skills/${encodeSkillName(data.name)}`,
+        url: `${BASE_URL}/skills/${encodeSkillName(data.name)}`,
         codeRepository: data.repositoryUrl ?? undefined,
         version: data.latestVersion?.version ?? undefined,
         datePublished: data.createdAt.toISOString(),
@@ -471,13 +473,13 @@ export default async function SkillDetailPage({ params }: SkillDetailPageProps) 
       {
         '@type': 'BreadcrumbList',
         itemListElement: [
-          { '@type': 'ListItem', position: 1, name: 'Tank', item: 'https://tankpkg.dev' },
-          { '@type': 'ListItem', position: 2, name: 'Skills', item: 'https://tankpkg.dev/skills' },
+          { '@type': 'ListItem', position: 1, name: 'Tank', item: BASE_URL },
+          { '@type': 'ListItem', position: 2, name: 'Skills', item: `${BASE_URL}/skills` },
           {
             '@type': 'ListItem',
             position: 3,
             name: data.name,
-            item: `https://tankpkg.dev/skills/${encodeSkillName(data.name)}`
+            item: `${BASE_URL}/skills/${encodeSkillName(data.name)}`
           }
         ]
       }

--- a/packages/web/app/(registry)/skills/page.tsx
+++ b/packages/web/app/(registry)/skills/page.tsx
@@ -24,15 +24,17 @@ import { SkillsSort } from './skills-sort';
 
 export const revalidate = 60;
 
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev';
+
 export const metadata: Metadata = {
   title: 'Browse AI Agent Skills',
   description:
     'Discover, compare, and install security-verified AI agent skills. Every skill is scanned for credential theft, prompt injection, and supply chain attacks.',
-  alternates: { canonical: 'https://tankpkg.dev/skills' },
+  alternates: { canonical: `${BASE_URL}/skills` },
   openGraph: {
     title: 'Browse AI Agent Skills — Tank',
     description: 'Discover, compare, and install security-verified AI agent skills.',
-    url: 'https://tankpkg.dev/skills',
+    url: `${BASE_URL}/skills`,
     type: 'website',
     siteName: 'Tank'
   }

--- a/packages/web/app/docs/[[...slug]]/page.tsx
+++ b/packages/web/app/docs/[[...slug]]/page.tsx
@@ -7,7 +7,7 @@ import { CopyToLLMButton } from '@/components/copy-to-llm-button';
 import { source } from '@/lib/source';
 import { getMDXComponents } from '@/mdx-components';
 
-const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://tankpkg.dev';
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev';
 
 async function getRawContent(slug: string[]): Promise<string> {
   try {

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -8,18 +8,10 @@ import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
 
-export const viewport: Viewport = {
-  width: 'device-width',
-  initialScale: 1,
-  maximumScale: 5,
-  themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
-    { media: '(prefers-color-scheme: dark)', color: '#1a1a2e' }
-  ]
-};
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev';
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://tankpkg.dev'),
+  metadataBase: new URL(BASE_URL),
   title: {
     default: 'Tank — Security-first package manager for AI agent skills',
     template: '%s | Tank'
@@ -58,7 +50,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://tankpkg.dev',
+    url: BASE_URL,
     siteName: 'Tank',
     title: 'Tank — Security-first package manager for AI agent skills',
     description: 'Publish, install, and audit AI agent skills with integrity verification and security scanning.',
@@ -79,7 +71,7 @@ export const metadata: Metadata = {
     creator: '@tankpkg'
   },
   alternates: {
-    canonical: 'https://tankpkg.dev'
+    canonical: BASE_URL
   },
   icons: {
     icon: [

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -24,6 +24,7 @@ import { CopyInstallButton } from './copy-install-button';
 import { HomeNavAuthCta, HomePrimaryAuthCta } from './home-auth-cta';
 
 const GITHUB_REPO = 'tankpkg/tank';
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev';
 
 async function getGitHubStars(): Promise<number | null> {
   try {
@@ -119,8 +120,8 @@ function buildHomepageJsonLd(_skillCount: number) {
       {
         '@type': 'Organization',
         name: 'Tank',
-        url: 'https://tankpkg.dev',
-        logo: 'https://tankpkg.dev/logo.png',
+        url: BASE_URL,
+        logo: `${BASE_URL}/logo.png`,
         description:
           'Security-first package registry for AI agent skills. Prevent credential exfiltration and supply chain attacks with mandatory security scanning.',
         sameAs: ['https://github.com/tankpkg', 'https://x.com/tankpkg']
@@ -128,10 +129,10 @@ function buildHomepageJsonLd(_skillCount: number) {
       {
         '@type': 'WebSite',
         name: 'Tank',
-        url: 'https://tankpkg.dev',
+        url: BASE_URL,
         potentialAction: {
           '@type': 'SearchAction',
-          target: 'https://tankpkg.dev/skills?q={search_term_string}',
+          target: `${BASE_URL}/skills?q={search_term_string}`,
           'query-input': 'required name=search_term_string'
         }
       },

--- a/packages/web/app/robots.ts
+++ b/packages/web/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
 
-const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://tankpkg.dev';
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev';
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -5,7 +5,7 @@ import { db } from '@/lib/db';
 import { skills } from '@/lib/db/schema';
 import { source } from '@/lib/source';
 
-const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://tankpkg.dev';
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 3600;

--- a/packages/web/components/footer.tsx
+++ b/packages/web/components/footer.tsx
@@ -31,7 +31,7 @@ export function Footer() {
         <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
           <span>Powered by</span>
           <Link
-            href="https://tankpkg.dev"
+            href={process.env.NEXT_PUBLIC_APP_URL || 'https://www.tankpkg.dev'}
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium text-emerald-400 hover:text-emerald-300 transition-colors">


### PR DESCRIPTION
## Summary

Fixes #172 — Google Search Console shows 81 URLs submitted via sitemap, **0 indexed**. All pages stuck in "Discovered - currently not indexed" status.

## Root Cause

Canonical URL mismatch creates a circular redirect that confuses Googlebot:

| Signal | Points To |
|--------|-----------|
| **Sitemap** (`sitemap.ts`) | `https://www.tankpkg.dev/...` ✅ |
| **Canonical tags** (hardcoded) | `https://tankpkg.dev/...` (no www) ❌ |
| **DNS redirect** | `tankpkg.dev` → 307 → `www.tankpkg.dev` |

Google sees `www.tankpkg.dev` pages declaring their canonical as `tankpkg.dev`, which redirects back to `www.tankpkg.dev` — loop.

## Changes

Replace all hardcoded `https://tankpkg.dev` with a `BASE_URL` constant that reads from `NEXT_PUBLIC_APP_URL` (resolves to `https://www.tankpkg.dev` in production):

- **`layout.tsx`** — `metadataBase`, `openGraph.url`, `alternates.canonical`
- **`page.tsx`** — Homepage JSON-LD (Organization, WebSite, SearchAction)
- **`skills/page.tsx`** — Browse page canonical + OG URL
- **`skills/[...name]/page.tsx`** — Skill detail metadata + JSON-LD breadcrumbs
- **`footer.tsx`** — "Powered by Tank" link
- **`sitemap.ts`, `robots.ts`, `docs/page.tsx`** — Aligned fallback from `tankpkg.dev` → `www.tankpkg.dev`

## Verification

- `grep -r 'https://tankpkg.dev' packages/web/app/ packages/web/components/ --include='*.ts' --include='*.tsx'` → **0 matches** (only `llms.txt` content files remain, which are documentation, not SEO signals)

## Post-Deploy TODO

1. Change Vercel `tankpkg.dev` → `www.tankpkg.dev` redirect from **307 → 301** (permanent)
2. Use GSC "Request Indexing" on top 15 URLs to accelerate re-crawling