### PR TITLE
fix: improve tank link and unlink help output

### DIFF
--- a/packages/cli/src/bin/tank.ts
+++ b/packages/cli/src/bin/tank.ts
@@ -266,7 +266,30 @@ program
 program
   .command('link')
   .alias('ln')
-  .description('Link current skill directory to AI agent directories (for development)')
+  .description('Link current skill to all detected AI agents for local development')
+  .addHelpText(
+    'after',
+    `
+Creates symlinks from each agent's skills directory to this skill source,
+so changes are reflected immediately without re-publishing.
+
+Must be run from a directory containing a valid tank.json.
+
+Supported agents:
+  Claude Code    ~/.claude/skills
+  OpenCode       ~/.config/opencode/skills
+  Cursor         ~/.cursor/skills
+  Codex          ~/.codex/skills
+  OpenClaw       ~/.openclaw/skills
+  Universal      ~/.agents/skills
+
+Examples:
+  $ cd my-skill && tank link     Link to all detected agents
+  $ tank doctor                  Verify link health
+  $ tank unlink                  Remove all symlinks
+
+See also: tank unlink, tank doctor`
+  )
   .action(async () => {
     try {
       await linkCommand();
@@ -279,7 +302,18 @@ program
 
 program
   .command('unlink')
-  .description('Remove skill symlinks from AI agent directories')
+  .description('Remove skill symlinks from all AI agent directories')
+  .addHelpText(
+    'after',
+    `
+Removes the symlinks created by \`tank link\` from every detected agent.
+Must be run from the same skill directory that was originally linked.
+
+Examples:
+  $ cd my-skill && tank unlink   Remove links for this skill
+
+See also: tank link, tank doctor`
+  )
   .action(async () => {
     try {
       await unlinkCommand();

--- a/packages/web/content/docs/cli.mdx
+++ b/packages/web/content/docs/cli.mdx
@@ -243,7 +243,7 @@ tank scan
 
 ## tank link
 
-Link current skill directory to AI agent directories (for development)
+Link current skill to all detected AI agents for local development
 
 **Aliases:** `ln`
 
@@ -254,7 +254,7 @@ tank link
 
 ## tank unlink
 
-Remove skill symlinks from AI agent directories
+Remove skill symlinks from all AI agent directories
 
 ```bash
 tank unlink
@@ -319,8 +319,8 @@ tank upgrade [version]
 | `tank info` | `show` | Show detailed information about a skill |
 | `tank audit` | — | Display security audit results for installed skills |
 | `tank scan` | — | Scan a local skill for security issues without publishing |
-| `tank link` | `ln` | Link current skill directory to AI agent directories (for development) |
-| `tank unlink` | — | Remove skill symlinks from AI agent directories |
+| `tank link` | `ln` | Link current skill to all detected AI agents for local development |
+| `tank unlink` | — | Remove skill symlinks from all AI agent directories |
 | `tank doctor` | — | Diagnose agent integration health |
 | `tank migrate` | — | Migrate skills.json → tank.json and skills.lock → tank.lock |
 | `tank upgrade` | — | Update tank to the latest version |

--- a/packages/web/public/llms-full.txt
+++ b/packages/web/public/llms-full.txt
@@ -1323,7 +1323,7 @@ tank scan
 
 ## tank link
 
-Link current skill directory to AI agent directories (for development)
+Link current skill to all detected AI agents for local development
 
 **Aliases:** `ln`
 
@@ -1334,7 +1334,7 @@ tank link
 
 ## tank unlink
 
-Remove skill symlinks from AI agent directories
+Remove skill symlinks from all AI agent directories
 
 ```bash
 tank unlink
@@ -1399,8 +1399,8 @@ tank upgrade [version]
 | `tank info` | `show` | Show detailed information about a skill |
 | `tank audit` | — | Display security audit results for installed skills |
 | `tank scan` | — | Scan a local skill for security issues without publishing |
-| `tank link` | `ln` | Link current skill directory to AI agent directories (for development) |
-| `tank unlink` | — | Remove skill symlinks from AI agent directories |
+| `tank link` | `ln` | Link current skill to all detected AI agents for local development |
+| `tank unlink` | — | Remove skill symlinks from all AI agent directories |
 | `tank doctor` | — | Diagnose agent integration health |
 | `tank migrate` | — | Migrate skills.json → tank.json and skills.lock → tank.lock |
 | `tank upgrade` | — | Update tank to the latest version |


### PR DESCRIPTION
## Summary
- Adds detailed help text to `tank link` and `tank unlink` commands
- Documents supported agents and their config directories
- Adds usage examples and cross-references to related commands
- Regenerates CLI docs and llms-full.txt

Closes #112

### Before
```
Usage: tank link|ln [options]
Link current skill directory to AI agent directories (for development)
```

### After
```
Usage: tank link|ln [options]
Link current skill to all detected AI agents for local development

Creates symlinks from each agent's skills directory to this skill source,
so changes are reflected immediately without re-publishing.

Must be run from a directory containing a valid tank.json.

Supported agents:
  Claude Code    ~/.claude/skills
  OpenCode       ~/.config/opencode/skills
  Cursor         ~/.cursor/skills
  Codex          ~/.codex/skills
  OpenClaw       ~/.openclaw/skills
  Universal      ~/.agents/skills

Examples:
  $ cd my-skill && tank link     Link to all detected agents
  $ tank doctor                  Verify link health
  $ tank unlink                  Remove all symlinks
```