### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/infra/helm/tank/Chart.yaml
+++ b/infra/helm/tank/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   PostgreSQL, Redis, and MinIO for on-premises installations.
 type: application
 version: 0.1.0
-appVersion: "0.9.0"
+appVersion: "0.9.1"
 home: https://github.com/tankpkg/tank
 sources:
   - https://github.com/tankpkg/tank

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/mcp-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "MCP server for Tank - scan and publish AI agent skills from your editor",
   "type": "module",
   "bin": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/shared",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/web",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Patch release with improved `tank link` and `tank unlink` help output (#112).