### PR TITLE
fix(ci): use npm registry fallback for bun install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  # Fall back to npm registry when Bun's CDN (registry.bun.sh) is down
+  BUN_CONFIG_REGISTRY: https://registry.npmjs.org/
+
 jobs:
   deploy-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -13,6 +13,9 @@ on:
       - "packages/web/app/api/**/*.ts"
       - "packages/web/content/docs/**"
 
+env:
+  BUN_CONFIG_REGISTRY: https://registry.npmjs.org/
+
 jobs:
   check-docs-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+env:
+  # Fall back to npm registry when Bun's CDN (registry.bun.sh) is down
+  BUN_CONFIG_REGISTRY: https://registry.npmjs.org/
+
 jobs:
   build:
     name: build-${{ matrix.platform }}


### PR DESCRIPTION
## Summary

Bun's CDN (`registry.bun.sh`) went down, causing all v0.9.1 release builds to hang at `bun install` for 6 hours until GitHub Actions timeout. `tank upgrade` returns 404 because no binaries were uploaded.

**Fix:** Set `BUN_CONFIG_REGISTRY=https://registry.npmjs.org/` in all workflows that run `bun install` (ci.yml, release.yml, docs-drift.yml). npm registry is the canonical source — bun's registry is just a CDN layer on top.

After merge: delete v0.9.1 tag/release, re-tag to trigger release with the fix.