### PR TITLE
fix(hooks): typecheck per-package with shared build prerequisite

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -79,9 +79,25 @@ if [ "$TS_CHANGED" -eq 1 ]; then
     echo "  │  ✓ lint passed"
   fi
 
-  echo "  └─ typecheck"
-  if ! bun tsc -b --noEmit > /dev/null 2>&1; then
-    echo "     ✗ typecheck failed"
+  echo "  ├─ build @internal/shared (typecheck prerequisite)"
+  if ! bun run --filter '@internal/shared' build > /dev/null 2>&1; then
+    echo "  │  ✗ shared build failed"
+    FAILED=1
+  else
+    echo "  │  ✓ shared build passed"
+  fi
+
+  echo "  └─ typecheck (per-package)"
+  TC_FAILED=0
+  for pkg in "${TS_PACKAGES[@]}"; do
+    if [ -f "${pkg}/tsconfig.json" ] && echo "$CHANGED" | grep -q "^${pkg}/"; then
+      if ! bun tsc --noEmit --project "${pkg}/tsconfig.json" > /dev/null 2>&1; then
+        echo "     ✗ typecheck failed: ${pkg}"
+        TC_FAILED=1
+      fi
+    fi
+  done
+  if [ "$TC_FAILED" -ne 0 ]; then
     FAILED=1
   else
     echo "     ✓ typecheck passed"


### PR DESCRIPTION
## Summary

The pre-push hook ran `bun tsc -b --noEmit` from the repo root, producing **510 false-positive type errors** on every push. This forced every contributor (and all 5 agents working on #79, #61, #68, #107, #129) to use `--no-verify`.

**Root cause**: The root `tsconfig.json` has no path mappings for `@/*` (web) or `@internal/shared` (workspace dep). Running a single global typecheck made every package-local import fail.

**Fix**:
1. Build `@internal/shared` before typecheck (generates `.d.ts` files that tsc needs)
2. Typecheck each changed package individually with its own `tsconfig.json` (which has the correct path aliases)

**Result**: 510 errors → 0 errors. Pre-push hook works correctly again.

## Before / After

| | Before | After |
|---|---|---|
| Command | `bun tsc -b --noEmit` (global) | `bun tsc --noEmit --project {pkg}/tsconfig.json` (per-package) |
| Errors | 510 | 0 |
| `--no-verify` needed | Always | Never |