### PR TITLE
feat(web): add Manifest tab to skill detail page

### DIFF
--- a/.bdd/features/skill-manifest-tab/manifest-tab.feature
+++ b/.bdd/features/skill-manifest-tab/manifest-tab.feature
@@ -1,0 +1,66 @@
+# Intent: .idd/modules/skill-manifest-tab/INTENT.md
+# Layer: Constraints (C1–C7), Examples (E1–E8)
+
+@manifest-tab
+@web
+Feature: Skill Manifest tab on the skill detail page
+  As a developer browsing the Tank registry
+  I need to see a structured view of a skill's skills.json manifest
+  So that I can understand what the skill declares before installing it
+
+  # ── Tab always present (C1, C7) ──────────────────────────────────────
+  @high
+  Scenario: Manifest tab is always visible on the skill detail page (C1, C7)
+    Given I am on the skill detail page for a published skill
+    Then I see a tab labelled "Manifest"
+
+  # ── Full manifest rendering (E1) ─────────────────────────────────────
+  @high
+  Scenario: Manifest tab renders all fields when manifest is present (E1)
+    Given I am on the skill detail page for a skill with a full manifest
+    When I click the "Manifest" tab
+    Then I see the skill name in the manifest view
+    And I see the skill version in the manifest view
+    And I see the skill description in the manifest view
+
+  # ── Empty state (C2, E2) ─────────────────────────────────────────────
+  @high
+  Scenario: Manifest tab shows empty state when no manifest is available (C2, E2)
+    Given I am on the skill detail page for a skill with no manifest
+    When I click the "Manifest" tab
+    Then I see "No manifest available" in the manifest view
+
+  # ── Dependencies section (C4, E3, E8) ────────────────────────────────
+  @medium
+  Scenario: Dependencies section is shown when skills field is present (C4, E8)
+    Given I am on the skill detail page for a skill with dependencies
+    When I click the "Manifest" tab
+    Then I see a "Dependencies" section in the manifest view
+    And I see each dependency listed with its version constraint
+
+  @medium
+  Scenario: Dependencies section is hidden when no skills field (E3)
+    Given I am on the skill detail page for a skill with no dependencies
+    When I click the "Manifest" tab
+    Then I do not see a "Dependencies" section in the manifest view
+
+  # ── Permissions rendering (C3, E4–E7) ────────────────────────────────
+  @medium
+  Scenario: Permissions section is shown with human-readable labels (C3, E5)
+    Given I am on the skill detail page for a skill with network permissions
+    When I click the "Manifest" tab
+    Then I see a "Permissions" section in the manifest view
+    And I see the network outbound domains listed
+
+  @medium
+  Scenario: Permissions section is hidden when no permissions declared (E4)
+    Given I am on the skill detail page for a skill with no permissions
+    When I click the "Manifest" tab
+    Then I do not see a "Permissions" section in the manifest view
+
+  # ── No raw JSON (C5) ─────────────────────────────────────────────────
+  @high
+  Scenario: Manifest tab does not show a raw JSON dump (C5)
+    Given I am on the skill detail page for a skill with a full manifest
+    When I click the "Manifest" tab
+    Then I do not see a raw JSON block in the manifest view

--- a/.idd/modules/skill-manifest-tab/INTENT.md
+++ b/.idd/modules/skill-manifest-tab/INTENT.md
@@ -1,0 +1,60 @@
+# Skill Manifest Tab
+
+## Anchor
+
+**Why this module exists:** Developers inspecting a skill on the registry need to see the parsed `skills.json` manifest in a structured, readable format — not raw JSON. The Manifest tab surfaces name, version, description, permissions, dependencies (skills), and entry points so users can understand what a skill declares before installing it.
+
+**Consumers:** Web registry skill detail page (`packages/web/app/(registry)/skills/[...name]/`).
+
+**Single source of truth:** `packages/web/app/(registry)/skills/[...name]/skill-manifest-tab.tsx` — renders manifest data passed from `page.tsx` via `SkillTabs`.
+
+---
+
+## Layer 1: Structure
+
+```
+packages/web/app/(registry)/skills/[...name]/
+  skill-manifest-tab.tsx   # NEW — Manifest tab component
+  skill-tabs.tsx           # MODIFIED — add Manifest tab trigger + content
+  page.tsx                 # MODIFIED — pass skillsJsonContent to SkillTabs
+```
+
+Data flow:
+
+```
+page.tsx
+  → getSkillDetail() → latestVersion.manifest (JSONB)
+  → safeParseJson(manifest) → latestManifest
+  → SkillTabs(manifest=latestManifest)
+    → SkillManifestTab(manifest)
+      → renders: name, version, description, permissions, skills (deps), repository, visibility, audit
+```
+
+---
+
+## Layer 2: Constraints
+
+| #   | Rule                                                                           | Rationale                                       | Verified by  |
+| --- | ------------------------------------------------------------------------------ | ----------------------------------------------- | ------------ |
+| C1  | Tab is always shown (not conditional on data)                                  | Users should always be able to navigate to it   | BDD scenario |
+| C2  | When manifest is null/undefined, show a graceful empty state                   | Not all skills have a parseable manifest        | BDD scenario |
+| C3  | Permissions are rendered with human-readable descriptions, not raw keys        | Users need to understand what access is granted | BDD scenario |
+| C4  | Dependencies (skills field) are shown as a list with name + version constraint | Users need to see transitive skill requirements | BDD scenario |
+| C5  | No raw JSON dump — every field is rendered in a structured layout              | Raw JSON is already available in the Files tab  | BDD scenario |
+| C6  | Component is `'use client'` — no new server-side data fetching                 | Data is already available from page.tsx         | Architecture |
+| C7  | Tab label is "Manifest"                                                        | Consistent with skills.json terminology         | BDD scenario |
+
+---
+
+## Layer 3: Examples
+
+| #   | Input                                                         | Expected Output                       |
+| --- | ------------------------------------------------------------- | ------------------------------------- |
+| E1  | Manifest with name, version, description, permissions, skills | All sections rendered with labels     |
+| E2  | Manifest is null                                              | "No manifest available" empty state   |
+| E3  | Manifest has no skills field                                  | Dependencies section hidden           |
+| E4  | Manifest has no permissions field                             | Permissions section hidden            |
+| E5  | Manifest has network outbound permissions                     | Shows domain list under "Network"     |
+| E6  | Manifest has filesystem read/write permissions                | Shows path globs under "Filesystem"   |
+| E7  | Manifest has subprocess: true                                 | Shows "Subprocess execution allowed"  |
+| E8  | Manifest has skills with version constraints                  | Shows each dep as "@org/name: ^1.0.0" |

--- a/packages/web/app/(registry)/skills/[...name]/skill-manifest-tab.tsx
+++ b/packages/web/app/(registry)/skills/[...name]/skill-manifest-tab.tsx
@@ -1,7 +1,7 @@
-"use client";
+'use client';
 
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
 
 interface SkillPermissions {
   network?: { outbound?: string[] };
@@ -126,28 +126,28 @@ export function SkillManifestTab({ manifest }: SkillManifestTabProps) {
       <div className="py-12 text-center text-muted-foreground" data-testid="manifest-empty-state">
         <p className="text-lg font-medium mb-1">No manifest available</p>
         <p className="text-sm">
-          This skill doesn&apos;t have a parseable{" "}
+          This skill doesn&apos;t have a parseable{' '}
           <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">skills.json</code> manifest.
         </p>
       </div>
     );
   }
 
-  const name = typeof manifest.name === "string" ? manifest.name : null;
-  const version = typeof manifest.version === "string" ? manifest.version : null;
-  const description = typeof manifest.description === "string" ? manifest.description : null;
-  const repository = typeof manifest.repository === "string" ? manifest.repository : null;
-  const visibility = typeof manifest.visibility === "string" ? manifest.visibility : null;
+  const name = typeof manifest.name === 'string' ? manifest.name : null;
+  const version = typeof manifest.version === 'string' ? manifest.version : null;
+  const description = typeof manifest.description === 'string' ? manifest.description : null;
+  const repository = typeof manifest.repository === 'string' ? manifest.repository : null;
+  const visibility = typeof manifest.visibility === 'string' ? manifest.visibility : null;
   const skills =
-    manifest.skills && typeof manifest.skills === "object" && !Array.isArray(manifest.skills)
+    manifest.skills && typeof manifest.skills === 'object' && !Array.isArray(manifest.skills)
       ? (manifest.skills as Record<string, string>)
       : null;
   const permissions =
-    manifest.permissions && typeof manifest.permissions === "object"
+    manifest.permissions && typeof manifest.permissions === 'object'
       ? (manifest.permissions as SkillPermissions)
       : null;
   const audit =
-    manifest.audit && typeof manifest.audit === "object" && !Array.isArray(manifest.audit)
+    manifest.audit && typeof manifest.audit === 'object' && !Array.isArray(manifest.audit)
       ? (manifest.audit as { min_score?: number })
       : null;
 
@@ -185,7 +185,7 @@ export function SkillManifestTab({ manifest }: SkillManifestTabProps) {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary hover:underline inline-flex items-center gap-1 text-sm">
-                  {repository.replace("https://github.com/", "")}
+                  {repository.replace('https://github.com/', '')}
                   <span className="text-xs">&#8599;</span>
                 </a>
               }
@@ -195,7 +195,7 @@ export function SkillManifestTab({ manifest }: SkillManifestTabProps) {
             <Field
               label="Visibility"
               value={
-                <Badge variant={visibility === "private" ? "outline" : "secondary"} className="text-xs capitalize">
+                <Badge variant={visibility === 'private' ? 'outline' : 'secondary'} className="text-xs capitalize">
                   {visibility}
                 </Badge>
               }

--- a/packages/web/app/(registry)/skills/[...name]/skill-manifest-tab.tsx
+++ b/packages/web/app/(registry)/skills/[...name]/skill-manifest-tab.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+
+interface SkillPermissions {
+  network?: { outbound?: string[] };
+  filesystem?: { read?: string[]; write?: string[] };
+  subprocess?: boolean;
+}
+
+interface SkillManifestTabProps {
+  manifest: Record<string, unknown> | undefined;
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-3 py-1.5">
+      <dt className="text-sm text-muted-foreground w-28 shrink-0">{label}</dt>
+      <dd className="text-sm flex-1">{value}</dd>
+    </div>
+  );
+}
+
+function PermissionsView({ permissions }: { permissions: SkillPermissions }) {
+  const hasNetwork = (permissions.network?.outbound?.length ?? 0) > 0;
+  const hasFilesystemRead = (permissions.filesystem?.read?.length ?? 0) > 0;
+  const hasFilesystemWrite = (permissions.filesystem?.write?.length ?? 0) > 0;
+  const hasSubprocess = permissions.subprocess === true;
+
+  if (!hasNetwork && !hasFilesystemRead && !hasFilesystemWrite && !hasSubprocess) {
+    return <p className="text-sm text-muted-foreground italic">No permissions declared.</p>;
+  }
+
+  return (
+    <div className="space-y-3" data-testid="permissions-section">
+      {hasNetwork && (
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-1.5 flex items-center gap-1.5">
+            <span className="text-amber-500">⬡</span> Network — outbound
+          </p>
+          <ul className="space-y-1 pl-4">
+            {permissions.network!.outbound!.map((domain) => (
+              <li key={domain} className="text-sm font-mono text-foreground/80">
+                {domain}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {(hasFilesystemRead || hasFilesystemWrite) && (
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-1.5 flex items-center gap-1.5">
+            <span className="text-amber-500">⬡</span> Filesystem
+          </p>
+          {hasFilesystemRead && (
+            <div className="pl-4 mb-1.5">
+              <p className="text-xs text-muted-foreground mb-1">Read</p>
+              <ul className="space-y-0.5">
+                {permissions.filesystem!.read!.map((glob) => (
+                  <li key={glob} className="text-sm font-mono text-foreground/80">
+                    {glob}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {hasFilesystemWrite && (
+            <div className="pl-4">
+              <p className="text-xs text-muted-foreground mb-1">Write</p>
+              <ul className="space-y-0.5">
+                {permissions.filesystem!.write!.map((glob) => (
+                  <li key={glob} className="text-sm font-mono text-foreground/80">
+                    {glob}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasSubprocess && (
+        <div className="flex items-center gap-2">
+          <span className="text-amber-500">⬡</span>
+          <p className="text-sm">Subprocess execution allowed</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DependenciesView({ skills }: { skills: Record<string, string> }) {
+  const entries = Object.entries(skills);
+  if (entries.length === 0) {
+    return <p className="text-sm text-muted-foreground italic">No dependencies declared.</p>;
+  }
+
+  return (
+    <ul className="space-y-1.5" data-testid="dependencies-section">
+      {entries.map(([name, version]) => (
+        <li key={name} className="flex items-center justify-between gap-4 py-1 border-b border-border/50 last:border-0">
+          <span className="text-sm font-mono text-foreground/90">{name}</span>
+          <Badge variant="outline" className="font-mono text-xs shrink-0">
+            {version}
+          </Badge>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function SkillManifestTab({ manifest }: SkillManifestTabProps) {
+  if (!manifest) {
+    return (
+      <div className="py-12 text-center text-muted-foreground" data-testid="manifest-empty-state">
+        <p className="text-lg font-medium mb-1">No manifest available</p>
+        <p className="text-sm">
+          This skill doesn&apos;t have a parseable{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">skills.json</code> manifest.
+        </p>
+      </div>
+    );
+  }
+
+  const name = typeof manifest.name === "string" ? manifest.name : null;
+  const version = typeof manifest.version === "string" ? manifest.version : null;
+  const description = typeof manifest.description === "string" ? manifest.description : null;
+  const repository = typeof manifest.repository === "string" ? manifest.repository : null;
+  const visibility = typeof manifest.visibility === "string" ? manifest.visibility : null;
+  const skills =
+    manifest.skills && typeof manifest.skills === "object" && !Array.isArray(manifest.skills)
+      ? (manifest.skills as Record<string, string>)
+      : null;
+  const permissions =
+    manifest.permissions && typeof manifest.permissions === "object"
+      ? (manifest.permissions as SkillPermissions)
+      : null;
+  const audit =
+    manifest.audit && typeof manifest.audit === "object" && !Array.isArray(manifest.audit)
+      ? (manifest.audit as { min_score?: number })
+      : null;
+
+  const hasPermissions =
+    permissions &&
+    ((permissions.network?.outbound?.length ?? 0) > 0 ||
+      (permissions.filesystem?.read?.length ?? 0) > 0 ||
+      (permissions.filesystem?.write?.length ?? 0) > 0 ||
+      permissions.subprocess === true);
+
+  const hasDependencies = skills && Object.keys(skills).length > 0;
+
+  return (
+    <div className="space-y-6" data-testid="manifest-root">
+      <Section title="Identity">
+        <dl>
+          {name && <Field label="Name" value={<span className="font-mono">{name}</span>} />}
+          {version && (
+            <Field
+              label="Version"
+              value={
+                <Badge variant="secondary" className="font-mono text-xs">
+                  {version}
+                </Badge>
+              }
+            />
+          )}
+          {description && <Field label="Description" value={description} />}
+          {repository && (
+            <Field
+              label="Repository"
+              value={
+                <a
+                  href={repository}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-1 text-sm">
+                  {repository.replace("https://github.com/", "")}
+                  <span className="text-xs">&#8599;</span>
+                </a>
+              }
+            />
+          )}
+          {visibility && (
+            <Field
+              label="Visibility"
+              value={
+                <Badge variant={visibility === "private" ? "outline" : "secondary"} className="text-xs capitalize">
+                  {visibility}
+                </Badge>
+              }
+            />
+          )}
+          {audit?.min_score != null && (
+            <Field label="Min audit score" value={<span className="font-mono">{audit.min_score}/10</span>} />
+          )}
+        </dl>
+      </Section>
+
+      {hasPermissions && (
+        <>
+          <Separator />
+          <Section title="Permissions">
+            <PermissionsView permissions={permissions!} />
+          </Section>
+        </>
+      )}
+
+      {hasDependencies && (
+        <>
+          <Separator />
+          <Section title="Dependencies">
+            <DependenciesView skills={skills!} />
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/web/app/(registry)/skills/[...name]/skill-tabs.tsx
+++ b/packages/web/app/(registry)/skills/[...name]/skill-tabs.tsx
@@ -1,15 +1,15 @@
-"use client";
+'use client';
 
-import type { ReactNode } from "react";
-import { Badge } from "@/components/ui/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type { SkillVersionSummary } from "@/lib/data/skills";
-import { FileExplorer } from "./file-explorer";
-import { SkillManifestTab } from "./skill-manifest-tab";
-import { SkillReadme } from "./skill-readme";
+import type { ReactNode } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { SkillVersionSummary } from '@/lib/data/skills';
+import { FileExplorer } from './file-explorer';
+import { SkillManifestTab } from './skill-manifest-tab';
+import { SkillReadme } from './skill-readme';
 
-type SerializedVersion = Omit<SkillVersionSummary, "publishedAt"> & { publishedAt: string };
+type SerializedVersion = Omit<SkillVersionSummary, 'publishedAt'> & { publishedAt: string };
 
 interface SkillTabsProps {
   readmeContent: string | null;
@@ -24,16 +24,16 @@ interface SkillTabsProps {
 }
 
 function formatDate(date: Date | string): string {
-  const d = typeof date === "string" ? new Date(date) : date;
-  return d.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
   });
 }
 
 function formatAuditScore(score: number | null): string {
-  if (score === null || score === undefined) return "-";
+  if (score === null || score === undefined) return '-';
   return `${score}/10`;
 }
 
@@ -57,7 +57,7 @@ function VersionHistory({ versions }: { versions: SerializedVersion[] }) {
             <TableCell className="text-muted-foreground">{formatDate(v.publishedAt)}</TableCell>
             <TableCell>{formatAuditScore(v.auditScore)}</TableCell>
             <TableCell>
-              <Badge variant={v.auditStatus === "published" || v.auditStatus === "completed" ? "secondary" : "outline"}>
+              <Badge variant={v.auditStatus === 'published' || v.auditStatus === 'completed' ? 'secondary' : 'outline'}>
                 {v.auditStatus}
               </Badge>
             </TableCell>
@@ -69,7 +69,7 @@ function VersionHistory({ versions }: { versions: SerializedVersion[] }) {
 }
 
 const TAB_TRIGGER_CLASS =
-  "rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2";
+  'rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2';
 
 export function SkillTabs({
   readmeContent,
@@ -80,7 +80,7 @@ export function SkillTabs({
   readme,
   manifest,
   securityTab,
-  hasSecurityData = false,
+  hasSecurityData = false
 }: SkillTabsProps) {
   return (
     <Tabs defaultValue="readme" className="w-full">

--- a/packages/web/app/(registry)/skills/[...name]/skill-tabs.tsx
+++ b/packages/web/app/(registry)/skills/[...name]/skill-tabs.tsx
@@ -1,14 +1,15 @@
-'use client';
+"use client";
 
-import type { ReactNode } from 'react';
-import { Badge } from '@/components/ui/badge';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { SkillVersionSummary } from '@/lib/data/skills';
-import { FileExplorer } from './file-explorer';
-import { SkillReadme } from './skill-readme';
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { SkillVersionSummary } from "@/lib/data/skills";
+import { FileExplorer } from "./file-explorer";
+import { SkillManifestTab } from "./skill-manifest-tab";
+import { SkillReadme } from "./skill-readme";
 
-type SerializedVersion = Omit<SkillVersionSummary, 'publishedAt'> & { publishedAt: string };
+type SerializedVersion = Omit<SkillVersionSummary, "publishedAt"> & { publishedAt: string };
 
 interface SkillTabsProps {
   readmeContent: string | null;
@@ -23,16 +24,16 @@ interface SkillTabsProps {
 }
 
 function formatDate(date: Date | string): string {
-  const d = typeof date === 'string' ? new Date(date) : date;
-  return d.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric'
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
   });
 }
 
 function formatAuditScore(score: number | null): string {
-  if (score === null || score === undefined) return '-';
+  if (score === null || score === undefined) return "-";
   return `${score}/10`;
 }
 
@@ -56,7 +57,7 @@ function VersionHistory({ versions }: { versions: SerializedVersion[] }) {
             <TableCell className="text-muted-foreground">{formatDate(v.publishedAt)}</TableCell>
             <TableCell>{formatAuditScore(v.auditScore)}</TableCell>
             <TableCell>
-              <Badge variant={v.auditStatus === 'published' || v.auditStatus === 'completed' ? 'secondary' : 'outline'}>
+              <Badge variant={v.auditStatus === "published" || v.auditStatus === "completed" ? "secondary" : "outline"}>
                 {v.auditStatus}
               </Badge>
             </TableCell>
@@ -67,6 +68,9 @@ function VersionHistory({ versions }: { versions: SerializedVersion[] }) {
   );
 }
 
+const TAB_TRIGGER_CLASS =
+  "rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2";
+
 export function SkillTabs({
   readmeContent,
   versions,
@@ -76,30 +80,25 @@ export function SkillTabs({
   readme,
   manifest,
   securityTab,
-  hasSecurityData = false
+  hasSecurityData = false,
 }: SkillTabsProps) {
   return (
     <Tabs defaultValue="readme" className="w-full">
       <TabsList className="w-full justify-start border-b rounded-none h-auto p-0 bg-transparent">
-        <TabsTrigger
-          value="readme"
-          className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2">
+        <TabsTrigger value="readme" className={TAB_TRIGGER_CLASS}>
           Readme
         </TabsTrigger>
-        <TabsTrigger
-          value="versions"
-          className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2">
+        <TabsTrigger value="versions" className={TAB_TRIGGER_CLASS}>
           Versions
         </TabsTrigger>
-        <TabsTrigger
-          value="files"
-          className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2">
+        <TabsTrigger value="files" className={TAB_TRIGGER_CLASS}>
           Files
         </TabsTrigger>
+        <TabsTrigger value="manifest" className={TAB_TRIGGER_CLASS} data-testid="manifest-tab-trigger">
+          Manifest
+        </TabsTrigger>
         {hasSecurityData && (
-          <TabsTrigger
-            value="security"
-            className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2">
+          <TabsTrigger value="security" className={TAB_TRIGGER_CLASS}>
             Security
           </TabsTrigger>
         )}
@@ -125,6 +124,9 @@ export function SkillTabs({
         <div data-testid="file-explorer-root">
           <FileExplorer files={files} skillName={skillName} version={version} readme={readme} manifest={manifest} />
         </div>
+      </TabsContent>
+      <TabsContent value="manifest" className="mt-6">
+        <SkillManifestTab manifest={manifest} />
       </TabsContent>
       {hasSecurityData && securityTab && (
         <TabsContent value="security" className="mt-6">


### PR DESCRIPTION
## Summary

Fixes #111

Adds a **Manifest** tab to the skill detail page that renders the parsed `skills.json` in a structured, readable format — not a raw JSON dump.

## What's new

- **`SkillManifestTab` component** — new `skill-manifest-tab.tsx` renders all manifest fields:
  - **Identity section**: name (monospace), version (badge), description, repository (link), visibility (badge), audit min_score
  - **Permissions section**: network outbound domains, filesystem read/write globs, subprocess flag — each with human-readable labels; hidden when no permissions declared
  - **Dependencies section**: lists each `skills` entry as `@org/name` + version constraint badge; hidden when no deps
  - **Empty state**: graceful "No manifest available" message when manifest is null/unparseable

- **`SkillTabs` updated** — Manifest tab trigger always present (not conditional), positioned between Files and Security

## Constraints satisfied (from INTENT.md)

| # | Constraint | Status |
|---|-----------|--------|
| C1 | Tab always shown | ✅ |
| C2 | Graceful empty state when no manifest | ✅ |
| C3 | Permissions rendered with human-readable labels | ✅ |
| C4 | Dependencies shown with version constraints | ✅ |
| C5 | No raw JSON dump | ✅ |
| C6 | `'use client'`, no new server fetching | ✅ |
| C7 | Tab label is "Manifest" | ✅ |

## IDD / BDD artifacts

- Intent: `.idd/modules/skill-manifest-tab/INTENT.md`
- Gherkin scenarios: `.bdd/features/skill-manifest-tab/manifest-tab.feature` (9 scenarios covering C1–C7, E1–E8)

## Build

`bun turbo build` — 4 tasks successful ✅