### PR TITLE
fix(web): skill detail page 500 — RSC boundary violation in computeQualityChecks

### DIFF
--- a/packages/web/components/security/QualityChecks.tsx
+++ b/packages/web/components/security/QualityChecks.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import { Check, X } from 'lucide-react';
+import type { QualityCategory } from './quality-checks-utils';
 
-export type QualityCategoryName = 'Documentation' | 'Package Hygiene' | 'Permissions' | 'Security Scan';
-
-export interface QualityCategory {
-  name: QualityCategoryName;
-  passed: boolean;
-  details: string;
-}
+export type { QualityCategory, QualityCategoryName } from './quality-checks-utils';
+export { computeQualityChecks } from './quality-checks-utils';
 
 interface QualityChecksProps {
   checks: QualityCategory[];
@@ -42,52 +38,4 @@ export function QualityChecks({ checks, variant = 'compact' }: QualityChecksProp
       ))}
     </div>
   );
-}
-
-/**
- * Compute quality checks from skill data.
- */
-export function computeQualityChecks(input: {
-  readme: string | null;
-  description: string | null;
-  license: string | null;
-  repositoryUrl: string | null;
-  permissions: Record<string, unknown>;
-}): QualityCategory[] {
-  return [
-    {
-      name: 'Documentation',
-      passed:
-        !!(input.readme && input.readme.trim().length > 0) &&
-        !!(input.description && input.description.trim().length > 0),
-      details:
-        input.readme && input.description
-          ? 'README + description'
-          : input.readme
-            ? 'README only'
-            : input.description
-              ? 'Description only'
-              : 'Missing'
-    },
-    {
-      name: 'Package Hygiene',
-      passed: !!(input.license || input.repositoryUrl),
-      details:
-        input.license && input.repositoryUrl
-          ? 'License + repo'
-          : input.license
-            ? 'License only'
-            : input.repositoryUrl
-              ? 'Repo only'
-              : 'Missing'
-    },
-    {
-      name: 'Permissions',
-      passed: Object.keys(input.permissions).length > 0,
-      details:
-        Object.keys(input.permissions).length > 0
-          ? `${Object.keys(input.permissions).length} declared`
-          : 'None declared'
-    }
-  ];
 }

--- a/packages/web/components/security/quality-checks-utils.ts
+++ b/packages/web/components/security/quality-checks-utils.ts
@@ -1,0 +1,52 @@
+export type QualityCategoryName = 'Documentation' | 'Package Hygiene' | 'Permissions' | 'Security Scan';
+
+export interface QualityCategory {
+  name: QualityCategoryName;
+  passed: boolean;
+  details: string;
+}
+
+export function computeQualityChecks(input: {
+  readme: string | null;
+  description: string | null;
+  license: string | null;
+  repositoryUrl: string | null;
+  permissions: Record<string, unknown>;
+}): QualityCategory[] {
+  return [
+    {
+      name: 'Documentation',
+      passed:
+        !!(input.readme && input.readme.trim().length > 0) &&
+        !!(input.description && input.description.trim().length > 0),
+      details:
+        input.readme && input.description
+          ? 'README + description'
+          : input.readme
+            ? 'README only'
+            : input.description
+              ? 'Description only'
+              : 'Missing'
+    },
+    {
+      name: 'Package Hygiene',
+      passed: !!(input.license || input.repositoryUrl),
+      details:
+        input.license && input.repositoryUrl
+          ? 'License + repo'
+          : input.license
+            ? 'License only'
+            : input.repositoryUrl
+              ? 'Repo only'
+              : 'Missing'
+    },
+    {
+      name: 'Permissions',
+      passed: Object.keys(input.permissions).length > 0,
+      details:
+        Object.keys(input.permissions).length > 0
+          ? `${Object.keys(input.permissions).length} declared`
+          : 'None declared'
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- Skill detail pages (`/skills/@tank/tailscale-expert` etc.) throw 500 with `Attempted to call computeQualityChecks() from the server`
- Root cause: pure function lived in a `'use client'` file → Turbopack proxied it as a client reference → explodes on SSR
- Fix: extract `computeQualityChecks` + types into `quality-checks-utils.ts` (no client directive), re-export from barrel for compatibility

Note: `computeQualityChecks` is exported but never called — it's dead code. Consider removing entirely.