### PR TITLE
feat(cli): add content-addressable tarball cache for install

### DIFF
--- a/.bdd/features/install/tarball-cache.feature
+++ b/.bdd/features/install/tarball-cache.feature
@@ -1,0 +1,30 @@
+Feature: Content-addressable tarball cache for install
+
+  Scenario: Cache hit skips tarball download
+    Given a lockfile entry for "@test-org/my-skill@2.0.0" with integrity "sha512-<valid>"
+    And a cached tarball exists at "~/.tank/cache/<sha512-hex>.tgz"
+    When install runs from lockfile
+    Then the tarball download URL is not fetched
+    And the skill is extracted from the cached tarball
+
+  Scenario: Cache miss downloads and persists tarball
+    Given a lockfile entry for "@test-org/my-skill@2.0.0" with integrity "sha512-<valid>"
+    And no tarball exists in "~/.tank/cache/" for that integrity
+    When install runs from lockfile
+    Then the tarball is downloaded once
+    And the tarball is stored as "~/.tank/cache/<sha512-hex>.tgz"
+    And the skill is extracted successfully
+
+  Scenario: Corrupted cached tarball is invalidated and re-downloaded
+    Given a lockfile entry for "@test-org/my-skill@2.0.0" with integrity "sha512-<valid>"
+    And a cached tarball exists at "~/.tank/cache/<sha512-hex>.tgz"
+    And extraction from that cached tarball fails
+    When install runs from lockfile
+    Then the cached tarball is removed
+    And the tarball is downloaded again
+    And extraction succeeds from the re-downloaded tarball
+
+  Scenario: Cache clean removes global tarball cache
+    Given cached tarballs exist under "~/.tank/cache/"
+    When I run "tank cache clean"
+    Then "~/.tank/cache/" does not exist

--- a/.bdd/qa/findings/2026-03-16-issue-114-red.md
+++ b/.bdd/qa/findings/2026-03-16-issue-114-red.md
@@ -1,0 +1,8 @@
+# Issue #114 RED Findings
+
+- Added BDD feature scenarios at `.bdd/features/install/tarball-cache.feature` before implementation.
+- Added failing tests for cache hit/miss/corruption and cache clean in:
+  - `packages/cli/src/__tests__/install.test.ts`
+  - `packages/cli/src/__tests__/cache.test.ts`
+- Initial RED run failed as expected due missing `cache` command/module and missing cache behavior in install flows.
+- Additional setup issue observed: `@internal/shared` must be built before CLI tests in this workspace.

--- a/.bdd/qa/resolutions/2026-03-16-issue-114-green.md
+++ b/.bdd/qa/resolutions/2026-03-16-issue-114-green.md
@@ -1,0 +1,18 @@
+# Issue #114 Resolution (GREEN)
+
+## What was fixed
+
+- Implemented content-addressable tarball cache at `~/.tank/cache/{sha512-hex}.tgz` for install flows.
+- `tank install` and `installFromLockfile` now:
+  - check cache first (hit = skip network tarball download),
+  - write to cache on miss after integrity verification,
+  - invalidate and re-download on cached extraction failure.
+- Added verbose cache hit/miss logging under `TANK_DEBUG=1|true`.
+- Added `tank cache clean` command to recursively clear `~/.tank/cache`.
+
+## Verification
+
+- `bun run --filter '@internal/shared' build`
+- `bun run --filter '@tankpkg/cli' build`
+- `bun run --filter '@tankpkg/cli' test -- --run`
+- Result: pass (`32` files, `476` tests).

--- a/.idd/modules/install/INTENT.md
+++ b/.idd/modules/install/INTENT.md
@@ -75,15 +75,20 @@ web/app/api/v1/skills/
 
 ## Layer 2 Addendum: Interactive Permission Budget Expansion (Issue #169)
 
-| #   | Rule                                                                                                                              | Rationale                                                                      | Verified by |
-| --- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----------- |
-| C12 | When a skill's permissions exceed the project budget in interactive mode, prompt the user to expand the budget instead of failing | Reduces friction — users shouldn't need to hand-edit tank.json for permissions | Unit test   |
-| C13 | All violations are collected before prompting — never prompt one-by-one per violation                                             | Single decision point; user sees the full security impact at once              | Unit test   |
-| C14 | If the user accepts, tank.json permissions are merged (additive) and the install continues                                        | Expanding budget is an explicit, auditable user decision                       | Unit test   |
-| C15 | If the user declines, install fails with the same error as today                                                                  | Declining = current behavior preserved                                         | Unit test   |
-| C16 | With `--yes` flag, violations are auto-accepted and tank.json is updated without prompting                                        | Enables scripted/automated installs that accept permission expansion           | Unit test   |
-| C17 | In non-interactive environments (CI, no TTY) without `--yes`, install fails as today — no prompt                                  | CI pipelines must not hang on stdin; explicit opt-in only                      | Unit test   |
-| C18 | The prompt displays which skill requests which permission type and value                                                          | User must understand what they're granting before accepting                    | Unit test   |
+| #   | Rule                                                                                                                              | Rationale                                                                      | Verified by  |
+| --- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------ |
+| C12 | When a skill's permissions exceed the project budget in interactive mode, prompt the user to expand the budget instead of failing | Reduces friction — users shouldn't need to hand-edit tank.json for permissions | Unit test    |
+| C13 | All violations are collected before prompting — never prompt one-by-one per violation                                             | Single decision point; user sees the full security impact at once              | Unit test    |
+| C14 | If the user accepts, tank.json permissions are merged (additive) and the install continues                                        | Expanding budget is an explicit, auditable user decision                       | Unit test    |
+| C15 | If the user declines, install fails with the same error as today                                                                  | Declining = current behavior preserved                                         | Unit test    |
+| C16 | With `--yes` flag, violations are auto-accepted and tank.json is updated without prompting                                        | Enables scripted/automated installs that accept permission expansion           | Unit test    |
+| C17 | In non-interactive environments (CI, no TTY) without `--yes`, install fails as today — no prompt                                  | CI pipelines must not hang on stdin; explicit opt-in only                      | Unit test    |
+| C18 | The prompt displays which skill requests which permission type and value                                                          | User must understand what they're granting before accepting                    | Unit test    |
+| C19 | Install uses a global tarball cache at `~/.tank/cache/` keyed by SHA-512 content hash (`{sha512-hex}.tgz`)                        | Avoid redundant downloads across projects and repeated installs                | BDD scenario |
+| C20 | On cache hit, install skips network tarball download and extracts from cached file                                                | Performance + reduced registry/storage traffic                                 | BDD scenario |
+| C21 | On cache miss, install downloads tarball, verifies integrity, writes cache entry, then extracts                                   | Preserves security guarantees while populating cache                           | BDD scenario |
+| C22 | If a cache entry is corrupted and extraction fails, install invalidates that entry and re-downloads once                          | Self-healing cache; no persistent bad state                                    | BDD scenario |
+| C23 | `tank cache clean` deletes `~/.tank/cache/` recursively                                                                           | Operational control for disk cleanup and recovery                              | BDD scenario |
 
 ## Layer 3 Addendum: Interactive Permission Budget Expansion
 
@@ -95,3 +100,7 @@ web/app/api/v1/skills/
 | E14 | Install skill requesting `network.outbound: ["api.example.com"]`, CI=true, no `--yes`    | Install fails with "Permission denied" — no prompt shown                                 |
 | E15 | Install skill requesting both `filesystem.read` and `network.outbound` outside budget    | Single prompt listing both violations; user accepts → both merged into tank.json         |
 | E16 | Install skill whose permissions are within budget                                        | No prompt shown; install proceeds normally (existing behavior unchanged)                 |
+| E17 | Install skill where tarball hash is already cached in `~/.tank/cache/`                   | Cache hit; no tarball download request; extraction succeeds from cache                   |
+| E18 | Install skill where cache file is missing                                                | Cache miss; tarball downloaded, verified, stored as `{sha512-hex}.tgz`, then extracted   |
+| E19 | Install skill where cached file exists but extraction fails                              | Cache entry removed; tarball re-downloaded and extracted successfully                    |
+| E20 | Run `tank cache clean`                                                                   | `~/.tank/cache/` is removed recursively                                                  |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,7 @@ Current `tank` CLI surface, key flows, and repo-specific behavior.
 
 ## Commands
 
-The CLI currently exposes 18 commands from `packages/cli/src/bin/tank.ts`.
+The CLI currently exposes 19 commands from `packages/cli/src/bin/tank.ts`.
 
 - `login`
 - `logout`
@@ -19,6 +19,7 @@ The CLI currently exposes 18 commands from `packages/cli/src/bin/tank.ts`.
 - `search`
 - `info`
 - `audit`
+- `cache` (`cache clean`)
 - `scan`
 - `link`
 - `unlink`
@@ -38,6 +39,14 @@ The CLI currently exposes 18 commands from `packages/cli/src/bin/tank.ts`.
 7. enforce optional audit threshold
 8. extract safely into `.tank/skills/...` or `~/.tank/skills/...`
 9. update `skills.lock`
+
+Tarball cache behavior:
+
+- global cache directory: `~/.tank/cache/`
+- cache key format: `{sha512-hex}.tgz`
+- cache hit: tarball download is skipped
+- cache miss: tarball is downloaded, verified, cached, then extracted
+- corrupted cache entry (extract failure): cache is invalidated and tarball is re-downloaded
 
 Flags:
 

--- a/packages/cli/src/__tests__/cache.test.ts
+++ b/packages/cli/src/__tests__/cache.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("cache clean command", () => {
+  let fakeHome: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "tank-cache-test-"));
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+    logSpy.mockRestore();
+  });
+
+  it("removes ~/.tank/cache recursively when running clean", async () => {
+    const { cacheCleanCommand } = await import("../commands/cache.js");
+    const cacheDir = path.join(fakeHome, ".tank", "cache");
+    fs.mkdirSync(path.join(cacheDir, "nested"), { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, "abc.tgz"), "tarball");
+    fs.writeFileSync(path.join(cacheDir, "nested", "def.tgz"), "tarball");
+
+    await cacheCleanCommand({ homedir: fakeHome });
+
+    expect(fs.existsSync(cacheDir)).toBe(false);
+  });
+});

--- a/packages/cli/src/__tests__/cache.test.ts
+++ b/packages/cli/src/__tests__/cache.test.ts
@@ -1,15 +1,15 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe("cache clean command", () => {
+describe('cache clean command', () => {
   let fakeHome: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "tank-cache-test-"));
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-cache-test-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -17,12 +17,12 @@ describe("cache clean command", () => {
     logSpy.mockRestore();
   });
 
-  it("removes ~/.tank/cache recursively when running clean", async () => {
-    const { cacheCleanCommand } = await import("../commands/cache.js");
-    const cacheDir = path.join(fakeHome, ".tank", "cache");
-    fs.mkdirSync(path.join(cacheDir, "nested"), { recursive: true });
-    fs.writeFileSync(path.join(cacheDir, "abc.tgz"), "tarball");
-    fs.writeFileSync(path.join(cacheDir, "nested", "def.tgz"), "tarball");
+  it('removes ~/.tank/cache recursively when running clean', async () => {
+    const { cacheCleanCommand } = await import('../commands/cache.js');
+    const cacheDir = path.join(fakeHome, '.tank', 'cache');
+    fs.mkdirSync(path.join(cacheDir, 'nested'), { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'abc.tgz'), 'tarball');
+    fs.writeFileSync(path.join(cacheDir, 'nested', 'def.tgz'), 'tarball');
 
     await cacheCleanCommand({ homedir: fakeHome });
 

--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -1,89 +1,89 @@
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock global fetch
 const mockFetch = vi.fn();
-vi.stubGlobal('fetch', mockFetch);
+vi.stubGlobal("fetch", mockFetch);
 
 // Mock ora — spinner is a side-effect UI concern
-vi.mock('ora', () => {
+vi.mock("ora", () => {
   const spinner = {
     start: vi.fn().mockReturnThis(),
     stop: vi.fn().mockReturnThis(),
     succeed: vi.fn().mockReturnThis(),
     fail: vi.fn().mockReturnThis(),
-    text: ''
+    text: "",
   };
   return { default: vi.fn(() => spinner) };
 });
 
 // Mock tar extract — we don't want to actually extract tarballs in tests
-vi.mock('tar', () => ({
-  extract: vi.fn().mockResolvedValue(undefined)
+vi.mock("tar", () => ({
+  extract: vi.fn().mockResolvedValue(undefined),
 }));
 
-describe('installCommand', () => {
+describe("installCommand", () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   const validSkillsJson = {
-    name: 'my-project',
-    version: '1.0.0',
-    description: 'A test project',
+    name: "my-project",
+    version: "1.0.0",
+    description: "A test project",
     skills: {},
     permissions: {
-      network: { outbound: ['*.example.com'] },
-      filesystem: { read: ['./src/**'], write: ['./output/**'] },
-      subprocess: false
-    }
+      network: { outbound: ["*.example.com"] },
+      filesystem: { read: ["./src/**"], write: ["./output/**"] },
+      subprocess: false,
+    },
   };
 
   const versionsResponse = {
-    name: '@test-org/my-skill',
+    name: "@test-org/my-skill",
     versions: [
       {
-        version: '1.0.0',
-        integrity: 'sha512-abc123',
+        version: "1.0.0",
+        integrity: "sha512-abc123",
         auditScore: 8.5,
-        auditStatus: 'published',
-        publishedAt: '2026-01-01T00:00:00Z'
+        auditStatus: "published",
+        publishedAt: "2026-01-01T00:00:00Z",
       },
       {
-        version: '1.1.0',
-        integrity: 'sha512-def456',
+        version: "1.1.0",
+        integrity: "sha512-def456",
         auditScore: 9.0,
-        auditStatus: 'published',
-        publishedAt: '2026-01-15T00:00:00Z'
+        auditStatus: "published",
+        publishedAt: "2026-01-15T00:00:00Z",
       },
       {
-        version: '2.0.0',
-        integrity: 'sha512-ghi789',
+        version: "2.0.0",
+        integrity: "sha512-ghi789",
         auditScore: 7.0,
-        auditStatus: 'published',
-        publishedAt: '2026-02-01T00:00:00Z'
-      }
-    ]
+        auditStatus: "published",
+        publishedAt: "2026-02-01T00:00:00Z",
+      },
+    ],
   };
 
   const versionMetadata = {
-    name: '@test-org/my-skill',
-    version: '2.0.0',
-    description: 'A test skill',
-    integrity: 'sha512-ghi789',
+    name: "@test-org/my-skill",
+    version: "2.0.0",
+    description: "A test skill",
+    integrity: "sha512-ghi789",
     permissions: {
-      network: { outbound: ['*.example.com'] },
-      filesystem: { read: ['./src/**'] },
-      subprocess: false
+      network: { outbound: ["*.example.com"] },
+      filesystem: { read: ["./src/**"] },
+      subprocess: false,
     },
     auditScore: 7.0,
-    auditStatus: 'published',
-    downloadUrl: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
-    publishedAt: '2026-02-01T00:00:00Z'
+    auditStatus: "published",
+    downloadUrl: "https://storage.example.com/download/my-skill-2.0.0.tgz",
+    publishedAt: "2026-02-01T00:00:00Z",
   };
 
   // Create a fake tarball with known sha512
@@ -91,29 +91,29 @@ describe('installCommand', () => {
   let fakeTarballIntegrity: string;
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-test-'));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-config-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-test-"));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-config-"));
 
     // Write a valid tank.json in the "project" directory
-    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
 
     // Write a config with registry URL (no auth needed for install)
     fs.writeFileSync(
-      path.join(configDir, 'config.json'),
+      path.join(configDir, "config.json"),
       JSON.stringify({
-        registry: 'https://tankpkg.dev'
-      })
+        registry: "https://tankpkg.dev",
+      }),
     );
 
     // Create a fake tarball and compute its real integrity
-    const crypto = await import('node:crypto');
-    fakeTarball = Buffer.from('fake-tarball-content-for-testing');
-    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
+    const crypto = await import("node:crypto");
+    fakeTarball = Buffer.from("fake-tarball-content-for-testing");
+    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -124,14 +124,14 @@ describe('installCommand', () => {
   });
 
   function getAllOutput(): string {
-    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
+    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
   }
 
   function setupSuccessfulInstall(overrides?: { versionMeta?: Record<string, unknown>; integrity?: string }) {
     const integrity = overrides?.integrity ?? fakeTarballIntegrity;
     const meta = overrides?.versionMeta ?? {
       ...versionMetadata,
-      integrity
+      integrity,
     };
 
     // 1. GET /api/v1/skills/{name}/versions
@@ -144,15 +144,15 @@ describe('installCommand', () => {
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
   }
 
-  it('installs a skill successfully: fetch versions → resolve → download → verify → extract → update files', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("installs a skill successfully: fetch versions → resolve → download → verify → extract → update files", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     // Verify 3 fetch calls
@@ -160,127 +160,127 @@ describe('installCommand', () => {
 
     // Verify versions fetch
     const [versionsUrl] = mockFetch.mock.calls[0];
-    expect(versionsUrl).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/versions');
+    expect(versionsUrl).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/versions");
 
     const [, versionsOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect((versionsOpts.headers as Record<string, string>).Authorization).toBeUndefined();
 
     // Verify version metadata fetch
     const [metaUrl] = mockFetch.mock.calls[1];
-    expect(metaUrl).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0');
+    expect(metaUrl).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
 
     // Verify tarball download
     const [downloadUrl] = mockFetch.mock.calls[2];
-    expect(downloadUrl).toBe('https://storage.example.com/download/my-skill-2.0.0.tgz');
+    expect(downloadUrl).toBe("https://storage.example.com/download/my-skill-2.0.0.tgz");
   });
 
-  it('auto-creates tank.json when missing', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("auto-creates tank.json when missing", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
-    fs.unlinkSync(path.join(tmpDir, 'tank.json'));
+    fs.unlinkSync(path.join(tmpDir, "tank.json"));
 
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse)))
       .mockResolvedValueOnce(new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity })))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)));
 
-    await installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir });
+    await installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir });
 
-    const created = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
-    expect(created.skills['@test-org/my-skill']).toBe('^2.0.0');
+    const created = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
+    expect(created.skills["@test-org/my-skill"]).toBe("^2.0.0");
   });
 
-  it('errors when skill is not found (404)', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("errors when skill is not found (404)", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Versions endpoint returns 404
-    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Skill not found' }), { status: 404 }));
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: "Skill not found" }), { status: 404 }));
 
-    await expect(installCommand({ name: '@test-org/nonexistent', directory: tmpDir, configDir })).rejects.toThrow(
-      /not found/i
+    await expect(installCommand({ name: "@test-org/nonexistent", directory: tmpDir, configDir })).rejects.toThrow(
+      /not found/i,
     );
   });
 
-  it('sends bearer token when config contains token', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("sends bearer token when config contains token", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     fs.writeFileSync(
-      path.join(configDir, 'config.json'),
-      JSON.stringify({ registry: 'https://tankpkg.dev', token: 'tank_ci_token' })
+      path.join(configDir, "config.json"),
+      JSON.stringify({ registry: "https://tankpkg.dev", token: "tank_ci_token" }),
     );
 
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     const [, versionsOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((versionsOpts.headers as Record<string, string>).Authorization).toBe('Bearer tank_ci_token');
+    expect((versionsOpts.headers as Record<string, string>).Authorization).toBe("Bearer tank_ci_token");
   });
 
-  it('shows scope error when versions endpoint returns 403', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("shows scope error when versions endpoint returns 403", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: 'Insufficient API key scope. Required: skills:read' }), { status: 403 })
+      new Response(JSON.stringify({ error: "Insufficient API key scope. Required: skills:read" }), { status: 403 }),
     );
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /skills:read/i
+    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
+      /skills:read/i,
     );
   });
 
-  it('errors when no version satisfies the range', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("errors when no version satisfies the range", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Return versions that don't match the range
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
 
     await expect(
       installCommand({
-        name: '@test-org/my-skill',
-        versionRange: '>=5.0.0',
+        name: "@test-org/my-skill",
+        versionRange: ">=5.0.0",
         directory: tmpDir,
-        configDir
-      })
+        configDir,
+      }),
     ).rejects.toThrow(/no version/i);
   });
 
-  it('aborts with error when integrity check fails', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("aborts with error when integrity check fails", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Setup with mismatched integrity
     setupSuccessfulInstall({
-      integrity: 'sha512-WRONG_HASH'
+      integrity: "sha512-WRONG_HASH",
     });
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /integrity/i
+    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
+      /integrity/i,
     );
   });
 
-  it('aborts when skill permissions exceed project budget', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("aborts when skill permissions exceed project budget", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Write tank.json with restrictive permissions
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
+      path.join(tmpDir, "tank.json"),
       JSON.stringify(
         {
           ...validSkillsJson,
           permissions: {
-            network: { outbound: ['*.example.com'] },
-            filesystem: { read: ['./src/**'], write: ['./output/**'] },
-            subprocess: false
-          }
+            network: { outbound: ["*.example.com"] },
+            filesystem: { read: ["./src/**"], write: ["./output/**"] },
+            subprocess: false,
+          },
         },
         null,
-        2
-      )
+        2,
+      ),
     );
 
     // Skill requests subprocess (project doesn't allow it)
@@ -288,10 +288,10 @@ describe('installCommand', () => {
       ...versionMetadata,
       integrity: fakeTarballIntegrity,
       permissions: {
-        network: { outbound: ['*.example.com'] },
-        filesystem: { read: ['./src/**'] },
-        subprocess: true // Project budget says false!
-      }
+        network: { outbound: ["*.example.com"] },
+        filesystem: { read: ["./src/**"] },
+        subprocess: true, // Project budget says false!
+      },
     };
 
     // 1. GET versions
@@ -300,28 +300,28 @@ describe('installCommand', () => {
     // 2. GET version metadata
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(metaWithSubprocess), { status: 200 }));
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /permission/i
+    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
+      /permission/i,
     );
   });
 
-  it('installs with warning when no permission budget is defined', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("installs with warning when no permission budget is defined", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Write tank.json WITHOUT permissions
     const noBudgetSkillsJson = {
-      name: 'my-project',
-      version: '1.0.0',
-      skills: {}
+      name: "my-project",
+      version: "1.0.0",
+      skills: {},
     };
-    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(noBudgetSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(noBudgetSkillsJson, null, 2));
 
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     // Should succeed but with a warning about missing budget
@@ -329,93 +329,93 @@ describe('installCommand', () => {
     expect(output).toMatch(/warning|budget|permission/i);
   });
 
-  it('updates tank.json with the new dependency', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("updates tank.json with the new dependency", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     // Read updated tank.json
-    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
+    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
 
-    expect(updated.skills['@test-org/my-skill']).toBe('^2.0.0');
+    expect(updated.skills["@test-org/my-skill"]).toBe("^2.0.0");
   });
 
-  it('updates tank.lock with correct entry', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("updates tank.lock with correct entry", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     // Read tank.lock
-    const lockPath = path.join(tmpDir, 'tank.lock');
+    const lockPath = path.join(tmpDir, "tank.lock");
     expect(fs.existsSync(lockPath)).toBe(true);
 
-    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    const lock = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
     expect(lock.lockfileVersion).toBe(2);
-    expect(lock.skills['@test-org/my-skill@2.0.0']).toBeDefined();
+    expect(lock.skills["@test-org/my-skill@2.0.0"]).toBeDefined();
 
-    const entry = lock.skills['@test-org/my-skill@2.0.0'];
+    const entry = lock.skills["@test-org/my-skill@2.0.0"];
     expect(entry.integrity).toBe(fakeTarballIntegrity);
     expect(entry.audit_score).toBe(7.0);
-    expect(entry.resolved).toBe('https://storage.example.com/download/my-skill-2.0.0.tgz');
+    expect(entry.resolved).toBe("https://storage.example.com/download/my-skill-2.0.0.tgz");
     expect(entry.permissions).toBeDefined();
   });
 
-  it('handles scoped package names correctly (URL encoding)', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("handles scoped package names correctly (URL encoding)", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     // Verify the URL was properly encoded
     const [versionsUrl] = mockFetch.mock.calls[0];
-    expect(versionsUrl).toContain('%40test-org%2Fmy-skill');
+    expect(versionsUrl).toContain("%40test-org%2Fmy-skill");
   });
 
-  it('skips install when same version is already installed', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("skips install when same version is already installed", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Pre-populate tank.json with the skill already installed
     const existingSkillsJson = {
       ...validSkillsJson,
-      skills: { '@test-org/my-skill': '^2.0.0' }
+      skills: { "@test-org/my-skill": "^2.0.0" },
     };
-    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(existingSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(existingSkillsJson, null, 2));
 
     // Pre-populate tank.lock with the skill already locked
     const existingLock = {
       lockfileVersion: 1,
       skills: {
-        '@test-org/my-skill@2.0.0': {
-          resolved: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
+        "@test-org/my-skill@2.0.0": {
+          resolved: "https://storage.example.com/download/my-skill-2.0.0.tgz",
           integrity: fakeTarballIntegrity,
           permissions: versionMetadata.permissions,
-          audit_score: 7.0
-        }
-      }
+          audit_score: 7.0,
+        },
+      },
     };
-    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), JSON.stringify(existingLock, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.lock"), JSON.stringify(existingLock, null, 2));
 
     // Versions endpoint still called to resolve
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     // Should only call versions endpoint, not download
@@ -425,33 +425,33 @@ describe('installCommand', () => {
     expect(output).toMatch(/already installed/i);
   });
 
-  it('extracts tarball to correct directory path', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("extracts tarball to correct directory path", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     // Verify the extraction directory was created
-    const expectedDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
+    const expectedDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
     expect(fs.existsSync(expectedDir)).toBe(true);
   });
 
-  it('aborts when skill requests network domains not in project budget', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("aborts when skill requests network domains not in project budget", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Skill requests domains not in project budget
     const metaWithExtraDomains = {
       ...versionMetadata,
       integrity: fakeTarballIntegrity,
       permissions: {
-        network: { outbound: ['*.evil.com'] }, // Not in project budget
-        filesystem: { read: ['./src/**'] },
-        subprocess: false
-      }
+        network: { outbound: ["*.evil.com"] }, // Not in project budget
+        filesystem: { read: ["./src/**"] },
+        subprocess: false,
+      },
     };
 
     // 1. GET versions
@@ -460,45 +460,45 @@ describe('installCommand', () => {
     // 2. GET version metadata
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(metaWithExtraDomains), { status: 200 }));
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /permission/i
+    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
+      /permission/i,
     );
   });
 
-  it('sorts lockfile keys alphabetically', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("sorts lockfile keys alphabetically", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // Pre-populate lock with an entry that comes after alphabetically
     const existingLock = {
       lockfileVersion: 1,
       skills: {
-        'z-skill@1.0.0': {
-          resolved: 'https://example.com/z.tgz',
-          integrity: 'sha512-zzz',
+        "z-skill@1.0.0": {
+          resolved: "https://example.com/z.tgz",
+          integrity: "sha512-zzz",
           permissions: {},
-          audit_score: 5.0
-        }
-      }
+          audit_score: 5.0,
+        },
+      },
     };
-    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), JSON.stringify(existingLock, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.lock"), JSON.stringify(existingLock, null, 2));
 
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
-    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8'));
+    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8"));
     const keys = Object.keys(lock.skills);
     expect(keys).toEqual([...keys].sort());
-    expect(keys[0]).toBe('@test-org/my-skill@2.0.0');
-    expect(keys[1]).toBe('z-skill@1.0.0');
+    expect(keys[0]).toBe("@test-org/my-skill@2.0.0");
+    expect(keys[1]).toBe("z-skill@1.0.0");
   });
 
-  it('uses specified version range instead of default *', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("uses specified version range instead of default *", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     // 1. GET versions
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
@@ -506,8 +506,8 @@ describe('installCommand', () => {
     // 2. GET version metadata for 1.1.0 (highest matching ^1.0.0)
     const meta110 = {
       ...versionMetadata,
-      version: '1.1.0',
-      integrity: fakeTarballIntegrity
+      version: "1.1.0",
+      integrity: fakeTarballIntegrity,
     };
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(meta110), { status: 200 }));
 
@@ -515,135 +515,135 @@ describe('installCommand', () => {
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
     await installCommand({
-      name: '@test-org/my-skill',
-      versionRange: '^1.0.0',
+      name: "@test-org/my-skill",
+      versionRange: "^1.0.0",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     // Should resolve to 1.1.0 (highest matching ^1.0.0)
     const [metaUrl] = mockFetch.mock.calls[1];
-    expect(metaUrl).toContain('1.1.0');
+    expect(metaUrl).toContain("1.1.0");
 
     // tank.json should use the provided range
-    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
-    expect(updated.skills['@test-org/my-skill']).toBe('^1.0.0');
+    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
+    expect(updated.skills["@test-org/my-skill"]).toBe("^1.0.0");
   });
 
-  it('creates agent symlinks after local install', async () => {
+  it("creates agent symlinks after local install", async () => {
     vi.resetModules();
-    const prepareAgentSkillDir = vi.fn().mockReturnValue('/mock/agent-skills/test-org--my-skill');
-    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ['claude'], skipped: [], failed: [] });
-    vi.doMock('../lib/frontmatter.js', () => ({ prepareAgentSkillDir }));
-    vi.doMock('../lib/linker.js', () => ({ linkSkillToAgents }));
+    const prepareAgentSkillDir = vi.fn().mockReturnValue("/mock/agent-skills/test-org--my-skill");
+    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ["claude"], skipped: [], failed: [] });
+    vi.doMock("../lib/frontmatter.js", () => ({ prepareAgentSkillDir }));
+    vi.doMock("../lib/linker.js", () => ({ linkSkillToAgents }));
 
-    const { installCommand } = await import('../commands/install.js');
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
-    const expectedExtractDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
+    const expectedExtractDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
     expect(prepareAgentSkillDir).toHaveBeenCalledWith({
-      skillName: '@test-org/my-skill',
+      skillName: "@test-org/my-skill",
       extractDir: expectedExtractDir,
-      agentSkillsBaseDir: path.join(tmpDir, '.tank', 'agent-skills'),
-      description: 'A test skill'
+      agentSkillsBaseDir: path.join(tmpDir, ".tank", "agent-skills"),
+      description: "A test skill",
     });
     expect(linkSkillToAgents).toHaveBeenCalledWith({
-      skillName: '@test-org/my-skill',
-      sourceDir: '/mock/agent-skills/test-org--my-skill',
-      linksDir: path.join(tmpDir, '.tank'),
-      source: 'local',
-      homedir: tmpDir
+      skillName: "@test-org/my-skill",
+      sourceDir: "/mock/agent-skills/test-org--my-skill",
+      linksDir: path.join(tmpDir, ".tank"),
+      source: "local",
+      homedir: tmpDir,
     });
   });
 
-  it('succeeds with warning when no agents are detected', async () => {
+  it("succeeds with warning when no agents are detected", async () => {
     vi.resetModules();
-    vi.doMock('../lib/linker.js', () => ({
-      linkSkillToAgents: vi.fn().mockReturnValue({ linked: [], skipped: [], failed: [] })
+    vi.doMock("../lib/linker.js", () => ({
+      linkSkillToAgents: vi.fn().mockReturnValue({ linked: [], skipped: [], failed: [] }),
     }));
-    vi.doMock('../lib/agents.js', async () => {
-      const actual = await vi.importActual<typeof import('../lib/agents.js')>('../lib/agents.js');
+    vi.doMock("../lib/agents.js", async () => {
+      const actual = await vi.importActual<typeof import("../lib/agents.js")>("../lib/agents.js");
       return {
         ...actual,
-        detectInstalledAgents: vi.fn().mockReturnValue([])
+        detectInstalledAgents: vi.fn().mockReturnValue([]),
       };
     });
-    const { installCommand } = await import('../commands/install.js');
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     const output = getAllOutput();
     expect(output).toMatch(/no agents detected/i);
   });
 
-  it('succeeds with warning when agent linking fails', async () => {
+  it("succeeds with warning when agent linking fails", async () => {
     vi.resetModules();
-    vi.doMock('../lib/linker.js', () => ({
+    vi.doMock("../lib/linker.js", () => ({
       linkSkillToAgents: vi.fn(() => {
-        throw new Error('link failed');
-      })
+        throw new Error("link failed");
+      }),
     }));
 
-    const { installCommand } = await import('../commands/install.js');
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
     const output = getAllOutput();
     expect(output).toMatch(/agent linking skipped/i);
   });
 
-  it('agent symlink target is agent-skills wrapper dir, not raw extract dir', async () => {
+  it("agent symlink target is agent-skills wrapper dir, not raw extract dir", async () => {
     vi.resetModules();
-    const prepareAgentSkillDir = vi.fn().mockReturnValue('/mock/agent-skills/test-org--my-skill');
+    const prepareAgentSkillDir = vi.fn().mockReturnValue("/mock/agent-skills/test-org--my-skill");
     const linkSkillToAgents = vi.fn().mockReturnValue({ linked: [], skipped: [], failed: [] });
-    vi.doMock('../lib/frontmatter.js', () => ({ prepareAgentSkillDir }));
-    vi.doMock('../lib/linker.js', () => ({ linkSkillToAgents }));
+    vi.doMock("../lib/frontmatter.js", () => ({ prepareAgentSkillDir }));
+    vi.doMock("../lib/linker.js", () => ({ linkSkillToAgents }));
 
-    const { installCommand } = await import('../commands/install.js');
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
-      configDir
+      configDir,
     });
 
-    const expectedExtractDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
+    const expectedExtractDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
     const linkArgs = linkSkillToAgents.mock.calls[0]?.[0];
-    expect(linkArgs?.sourceDir).toBe('/mock/agent-skills/test-org--my-skill');
+    expect(linkArgs?.sourceDir).toBe("/mock/agent-skills/test-org--my-skill");
     expect(linkArgs?.sourceDir).not.toBe(expectedExtractDir);
   });
 
-  it('blocks install when audit score is below min_score threshold', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("blocks install when audit score is below min_score threshold", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
+      path.join(tmpDir, "tank.json"),
       JSON.stringify(
         {
           ...validSkillsJson,
-          audit: { min_score: 8.0 }
+          audit: { min_score: 8.0 },
         },
         null,
-        2
-      )
+        2,
+      ),
     );
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
@@ -652,65 +652,65 @@ describe('installCommand', () => {
         JSON.stringify({
           ...versionMetadata,
           integrity: fakeTarballIntegrity,
-          auditScore: 7.0
+          auditScore: 7.0,
         }),
-        { status: 200 }
-      )
+        { status: 200 },
+      ),
     );
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /audit score 7.*below minimum threshold 8/i
+    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
+      /audit score 7.*below minimum threshold 8/i,
     );
   });
 
-  it('allows install when audit score meets min_score threshold', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("allows install when audit score meets min_score threshold", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
+      path.join(tmpDir, "tank.json"),
       JSON.stringify(
         {
           ...validSkillsJson,
-          audit: { min_score: 7.0 }
+          audit: { min_score: 7.0 },
         },
         null,
-        2
-      )
+        2,
+      ),
     );
 
     setupSuccessfulInstall({
       versionMeta: {
         ...versionMetadata,
         integrity: fakeTarballIntegrity,
-        auditScore: 7.0
-      }
+        auditScore: 7.0,
+      },
     });
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
-    const lockPath = path.join(tmpDir, 'tank.lock');
+    const lockPath = path.join(tmpDir, "tank.lock");
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 
-  it('allows install with warning when audit score is null (not yet scored)', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("allows install with warning when audit score is null (not yet scored)", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
+      path.join(tmpDir, "tank.json"),
       JSON.stringify(
         {
           ...validSkillsJson,
-          audit: { min_score: 7.0 }
+          audit: { min_score: 7.0 },
         },
         null,
-        2
-      )
+        2,
+      ),
     );
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
@@ -719,18 +719,18 @@ describe('installCommand', () => {
         JSON.stringify({
           ...versionMetadata,
           integrity: fakeTarballIntegrity,
-          auditScore: null
+          auditScore: null,
         }),
-        { status: 200 }
-      )
+        { status: 200 },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     const output = getAllOutput();
@@ -738,42 +738,42 @@ describe('installCommand', () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
-  it('skips audit score check when no audit.min_score is defined', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("skips audit score check when no audit.min_score is defined", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
+      path.join(tmpDir, "tank.json"),
       JSON.stringify(
         {
-          ...validSkillsJson
+          ...validSkillsJson,
         },
         null,
-        2
-      )
+        2,
+      ),
     );
 
     setupSuccessfulInstall({
       versionMeta: {
         ...versionMetadata,
         integrity: fakeTarballIntegrity,
-        auditScore: 2.0
-      }
+        auditScore: 2.0,
+      },
     });
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
-    const lockPath = path.join(tmpDir, 'tank.lock');
+    const lockPath = path.join(tmpDir, "tank.lock");
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 });
 
-describe('installCommand --global', () => {
+describe("installCommand --global", () => {
   let tmpDir: string;
   let configDir: string;
   let fakeHome: string;
@@ -781,56 +781,56 @@ describe('installCommand --global', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   const validSkillsJson = {
-    name: 'my-project',
-    version: '1.0.0',
-    description: 'A test project',
-    skills: {}
+    name: "my-project",
+    version: "1.0.0",
+    description: "A test project",
+    skills: {},
   };
 
   const versionsResponse = {
-    name: '@test-org/my-skill',
+    name: "@test-org/my-skill",
     versions: [
       {
-        version: '2.0.0',
-        integrity: 'sha512-ghi789',
+        version: "2.0.0",
+        integrity: "sha512-ghi789",
         auditScore: 7.0,
-        auditStatus: 'published',
-        publishedAt: '2026-02-01T00:00:00Z'
-      }
-    ]
+        auditStatus: "published",
+        publishedAt: "2026-02-01T00:00:00Z",
+      },
+    ],
   };
 
   const versionMetadata = {
-    name: '@test-org/my-skill',
-    version: '2.0.0',
-    description: 'A test skill',
-    integrity: 'sha512-ghi789',
+    name: "@test-org/my-skill",
+    version: "2.0.0",
+    description: "A test skill",
+    integrity: "sha512-ghi789",
     permissions: {},
     auditScore: 7.0,
-    auditStatus: 'published',
-    downloadUrl: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
-    publishedAt: '2026-02-01T00:00:00Z'
+    auditStatus: "published",
+    downloadUrl: "https://storage.example.com/download/my-skill-2.0.0.tgz",
+    publishedAt: "2026-02-01T00:00:00Z",
   };
 
   let fakeTarball: Buffer;
   let fakeTarballIntegrity: string;
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-global-test-'));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-global-config-'));
-    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-global-home-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-global-test-"));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-global-config-"));
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-global-home-"));
 
-    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
 
-    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
 
-    fakeTarball = Buffer.from('fake-tarball-content-for-testing');
-    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
+    fakeTarball = Buffer.from("fake-tarball-content-for-testing");
+    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -840,96 +840,96 @@ describe('installCommand --global', () => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
     vi.resetModules();
-    vi.unmock('../lib/frontmatter.js');
-    vi.unmock('../lib/linker.js');
+    vi.unmock("../lib/frontmatter.js");
+    vi.unmock("../lib/linker.js");
   });
 
   function setupSuccessfulInstall() {
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
   }
 
-  it('extracts to ~/.tank/skills/ for global install', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("extracts to ~/.tank/skills/ for global install", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome
+      homedir: fakeHome,
     });
 
-    const extractDir = path.join(fakeHome, '.tank', 'skills', '@test-org', 'my-skill');
+    const extractDir = path.join(fakeHome, ".tank", "skills", "@test-org", "my-skill");
     expect(fs.existsSync(extractDir)).toBe(true);
   });
 
-  it('does NOT create or modify project tank.json for global install', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("does NOT create or modify project tank.json for global install", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
-    const original = fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8');
+    const original = fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8");
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome
+      homedir: fakeHome,
     });
 
-    const updated = fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8');
+    const updated = fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8");
     expect(updated).toBe(original);
   });
 
-  it('writes to ~/.tank/tank.lock for global install', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("writes to ~/.tank/tank.lock for global install", async () => {
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome
+      homedir: fakeHome,
     });
 
-    const lockPath = path.join(fakeHome, '.tank', 'tank.lock');
+    const lockPath = path.join(fakeHome, ".tank", "tank.lock");
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 
   it('creates agent symlinks with source "global"', async () => {
     vi.resetModules();
-    const prepareAgentSkillDir = vi.fn().mockReturnValue('/mock/global-agent-skills/test-org--my-skill');
-    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ['claude'], skipped: [], failed: [] });
-    vi.doMock('../lib/frontmatter.js', () => ({ prepareAgentSkillDir }));
-    vi.doMock('../lib/linker.js', () => ({ linkSkillToAgents }));
+    const prepareAgentSkillDir = vi.fn().mockReturnValue("/mock/global-agent-skills/test-org--my-skill");
+    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ["claude"], skipped: [], failed: [] });
+    vi.doMock("../lib/frontmatter.js", () => ({ prepareAgentSkillDir }));
+    vi.doMock("../lib/linker.js", () => ({ linkSkillToAgents }));
 
-    const { installCommand } = await import('../commands/install.js');
+    const { installCommand } = await import("../commands/install.js");
     setupSuccessfulInstall();
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome
+      homedir: fakeHome,
     });
 
     expect(linkSkillToAgents).toHaveBeenCalledWith({
-      skillName: '@test-org/my-skill',
-      sourceDir: '/mock/global-agent-skills/test-org--my-skill',
-      linksDir: path.join(fakeHome, '.tank'),
-      source: 'global',
-      homedir: fakeHome
+      skillName: "@test-org/my-skill",
+      sourceDir: "/mock/global-agent-skills/test-org--my-skill",
+      linksDir: path.join(fakeHome, ".tank"),
+      source: "global",
+      homedir: fakeHome,
     });
   });
 });
 
-describe('installFromLockfile', () => {
+describe("installFromLockfile", () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -942,39 +942,39 @@ describe('installFromLockfile', () => {
   let fakeTarball2Integrity: string;
 
   const _validSkillsJson = {
-    name: 'my-project',
-    version: '1.0.0',
-    description: 'A test project',
+    name: "my-project",
+    version: "1.0.0",
+    description: "A test project",
     skills: {
-      '@test-org/my-skill': '^2.0.0',
-      'simple-skill': '^1.0.0'
+      "@test-org/my-skill": "^2.0.0",
+      "simple-skill": "^1.0.0",
     },
     permissions: {
-      network: { outbound: ['*.example.com'] },
-      filesystem: { read: ['./src/**'], write: ['./output/**'] },
-      subprocess: false
-    }
+      network: { outbound: ["*.example.com"] },
+      filesystem: { read: ["./src/**"], write: ["./output/**"] },
+      subprocess: false,
+    },
   };
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-lockfile-test-'));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-lockfile-config-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-lockfile-test-"));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-lockfile-config-"));
 
     // Write config
-    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
 
     // Create fake tarballs with real integrity
-    fakeTarball1 = Buffer.from('fake-tarball-content-skill-1');
-    const hash1 = crypto.createHash('sha512').update(fakeTarball1).digest('base64');
+    fakeTarball1 = Buffer.from("fake-tarball-content-skill-1");
+    const hash1 = crypto.createHash("sha512").update(fakeTarball1).digest("base64");
     fakeTarball1Integrity = `sha512-${hash1}`;
 
-    fakeTarball2 = Buffer.from('fake-tarball-content-skill-2');
-    const hash2 = crypto.createHash('sha512').update(fakeTarball2).digest('base64');
+    fakeTarball2 = Buffer.from("fake-tarball-content-skill-2");
+    const hash2 = crypto.createHash("sha512").update(fakeTarball2).digest("base64");
     fakeTarball2Integrity = `sha512-${hash2}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -985,85 +985,192 @@ describe('installFromLockfile', () => {
   });
 
   function _getAllOutput(): string {
-    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
+    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
   }
 
   function writeLockfile(
     skills: Record<
       string,
       { resolved: string; integrity: string; permissions: Record<string, unknown>; audit_score: number | null }
-    >
+    >,
   ) {
-    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), JSON.stringify({ lockfileVersion: 1, skills }, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.lock"), JSON.stringify({ lockfileVersion: 1, skills }, null, 2));
   }
 
-  it('installs all skills from lockfile with correct integrity', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("installs all skills from lockfile with correct integrity", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     writeLockfile({
-      '@test-org/my-skill@2.0.0': {
-        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0
-      }
+        audit_score: 8.0,
+      },
     });
 
     // Mock API metadata response (returns downloadUrl)
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
+          name: "@test-org/my-skill",
+          version: "2.0.0",
           integrity: fakeTarball1Integrity,
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     // Mock tarball download
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
-    await installFromLockfile({ directory: tmpDir, configDir });
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
     // Verify API was called for metadata
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0][0]).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0');
-    expect(mockFetch.mock.calls[1][0]).toBe('https://storage.example.com/my-skill-2.0.0.tgz');
+    expect(mockFetch.mock.calls[0][0]).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://storage.example.com/my-skill-2.0.0.tgz");
 
     // Verify extraction directory was created
-    const extractDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
+    const extractDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
     expect(fs.existsSync(extractDir)).toBe(true);
   });
 
-  it('sends bearer token when config contains token', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("uses cached tarball on cache hit and skips download request", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
+
+    writeLockfile({
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+        integrity: fakeTarball1Integrity,
+        permissions: {},
+        audit_score: 8.0,
+      },
+    });
+
+    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice("sha512-".length), "base64").toString("hex");
+    const cacheDir = path.join(tmpDir, ".tank", "cache");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, `${cacheKeyHex}.tgz`), fakeTarball1);
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: "@test-org/my-skill",
+          version: "2.0.0",
+          integrity: fakeTarball1Integrity,
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
+  });
+
+  it("stores tarball in global cache on cache miss", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
+
+    writeLockfile({
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+        integrity: fakeTarball1Integrity,
+        permissions: {},
+        audit_score: 8.0,
+      },
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: "@test-org/my-skill",
+          version: "2.0.0",
+          integrity: fakeTarball1Integrity,
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
+
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
+
+    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice("sha512-".length), "base64").toString("hex");
+    const cachePath = path.join(tmpDir, ".tank", "cache", `${cacheKeyHex}.tgz`);
+    expect(fs.existsSync(cachePath)).toBe(true);
+  });
+
+  it("invalidates corrupted cached tarball and re-downloads once", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
+    const { extract } = await import("tar");
+
+    writeLockfile({
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+        integrity: fakeTarball1Integrity,
+        permissions: {},
+        audit_score: 8.0,
+      },
+    });
+
+    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice("sha512-".length), "base64").toString("hex");
+    const cacheDir = path.join(tmpDir, ".tank", "cache");
+    const cachePath = path.join(cacheDir, `${cacheKeyHex}.tgz`);
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(cachePath, fakeTarball1);
+
+    vi.mocked(extract).mockRejectedValueOnce(new Error("cached tarball corrupt")).mockResolvedValueOnce(undefined);
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          name: "@test-org/my-skill",
+          version: "2.0.0",
+          integrity: fakeTarball1Integrity,
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
+
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(fs.existsSync(cachePath)).toBe(true);
+  });
+
+  it("sends bearer token when config contains token", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     fs.writeFileSync(
-      path.join(configDir, 'config.json'),
-      JSON.stringify({ registry: 'https://tankpkg.dev', token: 'tank_ci_token' })
+      path.join(configDir, "config.json"),
+      JSON.stringify({ registry: "https://tankpkg.dev", token: "tank_ci_token" }),
     );
 
     writeLockfile({
-      '@test-org/my-skill@2.0.0': {
-        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0
-      }
+        audit_score: 8.0,
+      },
     });
 
     // Mock API metadata response
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
+          name: "@test-org/my-skill",
+          version: "2.0.0",
           integrity: fakeTarball1Integrity,
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     // Mock tarball download
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
@@ -1071,267 +1178,267 @@ describe('installFromLockfile', () => {
     await installFromLockfile({ directory: tmpDir, configDir });
 
     const [, metaOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((metaOpts.headers as Record<string, string>).Authorization).toBe('Bearer tank_ci_token');
+    expect((metaOpts.headers as Record<string, string>).Authorization).toBe("Bearer tank_ci_token");
   });
 
-  it('aborts entire install when integrity mismatch on any skill', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("aborts entire install when integrity mismatch on any skill", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     writeLockfile({
-      '@test-org/my-skill@2.0.0': {
-        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
-        integrity: 'sha512-WRONG_HASH_THAT_WILL_NOT_MATCH',
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+        integrity: "sha512-WRONG_HASH_THAT_WILL_NOT_MATCH",
         permissions: {},
-        audit_score: 8.0
-      }
+        audit_score: 8.0,
+      },
     });
 
     // Mock API metadata response
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
-          integrity: 'sha512-WRONG_HASH_THAT_WILL_NOT_MATCH',
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
+          name: "@test-org/my-skill",
+          version: "2.0.0",
+          integrity: "sha512-WRONG_HASH_THAT_WILL_NOT_MATCH",
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     // Mock tarball download — content won't match the integrity
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
-    await expect(installFromLockfile({ directory: tmpDir, configDir })).rejects.toThrow(/integrity/i);
+    await expect(installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir })).rejects.toThrow(/integrity/i);
 
     // .tank/skills directory should be cleaned up on abort
-    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills"))).toBe(false);
   });
 
-  it('prints summary with count after successful install', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
-    const ora = (await import('ora')).default;
+  it("prints summary with count after successful install", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
+    const ora = (await import("ora")).default;
 
     writeLockfile({
-      '@test-org/my-skill@2.0.0': {
-        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0
-      }
+        audit_score: 8.0,
+      },
     });
 
     // Mock API metadata response
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
+          name: "@test-org/my-skill",
+          version: "2.0.0",
           integrity: fakeTarball1Integrity,
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
-    await installFromLockfile({ directory: tmpDir, configDir });
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
     const spinner = ora();
     const succeedCalls = vi.mocked(spinner.succeed).mock.calls;
-    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? '';
+    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? "";
     expect(lastSucceed).toMatch(/installed 1 skill/i);
   });
 
-  it('installs multiple skills from lockfile', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("installs multiple skills from lockfile", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     writeLockfile({
-      '@test-org/my-skill@2.0.0': {
-        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0
+        audit_score: 8.0,
       },
-      'simple-skill@1.0.0': {
-        resolved: 'https://storage.example.com/simple-skill-1.0.0.tgz',
+      "simple-skill@1.0.0": {
+        resolved: "https://storage.example.com/simple-skill-1.0.0.tgz",
         integrity: fakeTarball2Integrity,
         permissions: {},
-        audit_score: 9.0
-      }
+        audit_score: 9.0,
+      },
     });
 
     // Mock API + tarball for first skill
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
+          name: "@test-org/my-skill",
+          version: "2.0.0",
           integrity: fakeTarball1Integrity,
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
     // Mock API + tarball for second skill
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: 'simple-skill',
-          version: '1.0.0',
+          name: "simple-skill",
+          version: "1.0.0",
           integrity: fakeTarball2Integrity,
-          downloadUrl: 'https://storage.example.com/simple-skill-1.0.0.tgz'
+          downloadUrl: "https://storage.example.com/simple-skill-1.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball2), { status: 200 }));
 
-    await installFromLockfile({ directory: tmpDir, configDir });
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
     expect(mockFetch).toHaveBeenCalledTimes(4);
 
     // Both extraction directories should exist
-    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill'))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills', 'simple-skill'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills", "simple-skill"))).toBe(true);
 
-    const ora = (await import('ora')).default;
+    const ora = (await import("ora")).default;
     const spinner = ora();
     const succeedCalls = vi.mocked(spinner.succeed).mock.calls;
-    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? '';
+    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? "";
     expect(lastSucceed).toMatch(/installed 2 skills/i);
   });
 
-  it('handles scoped package names with correct extraction paths', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("handles scoped package names with correct extraction paths", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     writeLockfile({
-      '@my-org/deep-skill@3.0.0': {
-        resolved: 'https://storage.example.com/deep-skill-3.0.0.tgz',
+      "@my-org/deep-skill@3.0.0": {
+        resolved: "https://storage.example.com/deep-skill-3.0.0.tgz",
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 7.5
-      }
+        audit_score: 7.5,
+      },
     });
 
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@my-org/deep-skill',
-          version: '3.0.0',
+          name: "@my-org/deep-skill",
+          version: "3.0.0",
           integrity: fakeTarball1Integrity,
-          downloadUrl: 'https://storage.example.com/deep-skill-3.0.0.tgz'
+          downloadUrl: "https://storage.example.com/deep-skill-3.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
-    await installFromLockfile({ directory: tmpDir, configDir });
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
     // Scoped package: .tank/skills/@my-org/deep-skill
-    const extractDir = path.join(tmpDir, '.tank', 'skills', '@my-org', 'deep-skill');
+    const extractDir = path.join(tmpDir, ".tank", "skills", "@my-org", "deep-skill");
     expect(fs.existsSync(extractDir)).toBe(true);
   });
 
-  it('re-extracts when directory already exists (fresh install)', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("re-extracts when directory already exists (fresh install)", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     // Pre-create the extraction directory with a marker file
-    const existingDir = path.join(tmpDir, '.tank', 'skills', 'simple-skill');
+    const existingDir = path.join(tmpDir, ".tank", "skills", "simple-skill");
     fs.mkdirSync(existingDir, { recursive: true });
-    fs.writeFileSync(path.join(existingDir, 'old-file.txt'), 'old content');
+    fs.writeFileSync(path.join(existingDir, "old-file.txt"), "old content");
 
     writeLockfile({
-      'simple-skill@1.0.0': {
-        resolved: 'https://storage.example.com/simple-skill-1.0.0.tgz',
+      "simple-skill@1.0.0": {
+        resolved: "https://storage.example.com/simple-skill-1.0.0.tgz",
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 9.0
-      }
+        audit_score: 9.0,
+      },
     });
 
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: 'simple-skill',
-          version: '1.0.0',
+          name: "simple-skill",
+          version: "1.0.0",
           integrity: fakeTarball1Integrity,
-          downloadUrl: 'https://storage.example.com/simple-skill-1.0.0.tgz'
+          downloadUrl: "https://storage.example.com/simple-skill-1.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
-    await installFromLockfile({ directory: tmpDir, configDir });
+    await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
     // Directory should still exist (re-created)
     expect(fs.existsSync(existingDir)).toBe(true);
     // Old file should be gone (directory was cleaned and re-extracted)
-    expect(fs.existsSync(path.join(existingDir, 'old-file.txt'))).toBe(false);
+    expect(fs.existsSync(path.join(existingDir, "old-file.txt"))).toBe(false);
   });
 
-  it('cleans up .tank/skills on integrity failure mid-install', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("cleans up .tank/skills on integrity failure mid-install", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     writeLockfile({
-      '@test-org/my-skill@2.0.0': {
-        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+      "@test-org/my-skill@2.0.0": {
+        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0
+        audit_score: 8.0,
       },
-      'bad-skill@1.0.0': {
-        resolved: 'https://storage.example.com/bad-skill-1.0.0.tgz',
-        integrity: 'sha512-DEFINITELY_WRONG',
+      "bad-skill@1.0.0": {
+        resolved: "https://storage.example.com/bad-skill-1.0.0.tgz",
+        integrity: "sha512-DEFINITELY_WRONG",
         permissions: {},
-        audit_score: 5.0
-      }
+        audit_score: 5.0,
+      },
     });
 
     // First skill: API + tarball
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
+          name: "@test-org/my-skill",
+          version: "2.0.0",
           integrity: fakeTarball1Integrity,
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
     // Second skill: API + tarball (integrity won't match)
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: 'bad-skill',
-          version: '1.0.0',
-          integrity: 'sha512-DEFINITELY_WRONG',
-          downloadUrl: 'https://storage.example.com/bad-skill-1.0.0.tgz'
+          name: "bad-skill",
+          version: "1.0.0",
+          integrity: "sha512-DEFINITELY_WRONG",
+          downloadUrl: "https://storage.example.com/bad-skill-1.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball2), { status: 200 }));
 
-    await expect(installFromLockfile({ directory: tmpDir, configDir })).rejects.toThrow(/integrity/i);
+    await expect(installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir })).rejects.toThrow(/integrity/i);
 
     // Even though first skill was extracted, the entire .tank/skills should be cleaned up
-    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills"))).toBe(false);
   });
 
-  it('errors when tank.lock file is missing', async () => {
-    const { installFromLockfile } = await import('../commands/install.js');
+  it("errors when tank.lock file is missing", async () => {
+    const { installFromLockfile } = await import("../commands/install.js");
 
     // No lockfile exists
-    await expect(installFromLockfile({ directory: tmpDir, configDir })).rejects.toThrow(/tank\.lock/i);
+    await expect(installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir })).rejects.toThrow(/tank\.lock/i);
   });
 });
 
-describe('installAll (no-args dispatch)', () => {
+describe("installAll (no-args dispatch)", () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -1341,45 +1448,45 @@ describe('installAll (no-args dispatch)', () => {
   let fakeTarballIntegrity: string;
 
   const validSkillsJson = {
-    name: 'my-project',
-    version: '1.0.0',
-    description: 'A test project',
+    name: "my-project",
+    version: "1.0.0",
+    description: "A test project",
     skills: {
-      '@test-org/my-skill': '^2.0.0'
+      "@test-org/my-skill": "^2.0.0",
     },
     permissions: {
-      network: { outbound: ['*.example.com'] },
-      filesystem: { read: ['./src/**'], write: ['./output/**'] },
-      subprocess: false
-    }
+      network: { outbound: ["*.example.com"] },
+      filesystem: { read: ["./src/**"], write: ["./output/**"] },
+      subprocess: false,
+    },
   };
 
   const versionsResponse = {
-    name: '@test-org/my-skill',
+    name: "@test-org/my-skill",
     versions: [
       {
-        version: '2.0.0',
-        integrity: 'sha512-ghi789',
+        version: "2.0.0",
+        integrity: "sha512-ghi789",
         auditScore: 7.0,
-        auditStatus: 'published',
-        publishedAt: '2026-02-01T00:00:00Z'
-      }
-    ]
+        auditStatus: "published",
+        publishedAt: "2026-02-01T00:00:00Z",
+      },
+    ],
   };
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-installall-test-'));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-installall-config-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-installall-test-"));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-installall-config-"));
 
-    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
 
-    fakeTarball = Buffer.from('fake-tarball-content-for-testing');
-    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
+    fakeTarball = Buffer.from("fake-tarball-content-for-testing");
+    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -1390,70 +1497,70 @@ describe('installAll (no-args dispatch)', () => {
   });
 
   function getAllOutput(): string {
-    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
+    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
   }
 
-  it('returns gracefully when neither tank.json nor tank.lock exists', async () => {
-    const { installAll } = await import('../commands/install.js');
+  it("returns gracefully when neither tank.json nor tank.lock exists", async () => {
+    const { installAll } = await import("../commands/install.js");
 
-    await installAll({ directory: tmpDir, configDir });
+    await installAll({ directory: tmpDir, configDir, homedir: tmpDir });
 
-    expect(getAllOutput()).toContain('nothing to install');
+    expect(getAllOutput()).toContain("nothing to install");
   });
 
-  it('uses lockfile when tank.lock exists (deterministic mode)', async () => {
-    const { installAll } = await import('../commands/install.js');
+  it("uses lockfile when tank.lock exists (deterministic mode)", async () => {
+    const { installAll } = await import("../commands/install.js");
 
     // Write tank.json
-    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
 
     // Write tank.lock
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.lock'),
+      path.join(tmpDir, "tank.lock"),
       JSON.stringify(
         {
           lockfileVersion: 1,
           skills: {
-            '@test-org/my-skill@2.0.0': {
-              resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+            "@test-org/my-skill@2.0.0": {
+              resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
               integrity: fakeTarballIntegrity,
               permissions: {},
-              audit_score: 7.0
-            }
-          }
+              audit_score: 7.0,
+            },
+          },
         },
         null,
-        2
-      )
+        2,
+      ),
     );
 
     // Mock API metadata + tarball download
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
+          name: "@test-org/my-skill",
+          version: "2.0.0",
           integrity: fakeTarballIntegrity,
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
-    await installAll({ directory: tmpDir, configDir });
+    await installAll({ directory: tmpDir, configDir, homedir: tmpDir });
 
     // Should have called API for metadata, then downloaded tarball
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0][0]).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0');
-    expect(mockFetch.mock.calls[1][0]).toBe('https://storage.example.com/my-skill-2.0.0.tgz');
+    expect(mockFetch.mock.calls[0][0]).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://storage.example.com/my-skill-2.0.0.tgz");
   });
 
-  it('resolves from tank.json when no lockfile exists (first install)', async () => {
-    const { installAll } = await import('../commands/install.js');
+  it("resolves from tank.json when no lockfile exists (first install)", async () => {
+    const { installAll } = await import("../commands/install.js");
 
     // Write tank.json with a skill dependency
-    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
 
     // No tank.lock — should resolve via registry
     // Mock the 3-step install flow for @test-org/my-skill
@@ -1461,82 +1568,82 @@ describe('installAll (no-args dispatch)', () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '2.0.0',
+          name: "@test-org/my-skill",
+          version: "2.0.0",
           integrity: fakeTarballIntegrity,
-          permissions: { network: { outbound: ['*.example.com'] } },
+          permissions: { network: { outbound: ["*.example.com"] } },
           auditScore: 7.0,
-          auditStatus: 'published',
-          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz',
-          publishedAt: '2026-02-01T00:00:00Z'
+          auditStatus: "published",
+          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          publishedAt: "2026-02-01T00:00:00Z",
         }),
-        { status: 200 }
-      )
+        { status: 200 },
+      ),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
-    await installAll({ directory: tmpDir, configDir });
+    await installAll({ directory: tmpDir, configDir, homedir: tmpDir });
 
     // Should have made 3 fetch calls (versions, metadata, download) — the full install flow
     expect(mockFetch).toHaveBeenCalledTimes(3);
 
     // Lockfile should now exist (created by installCommand)
-    expect(fs.existsSync(path.join(tmpDir, 'tank.lock'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "tank.lock"))).toBe(true);
   });
 });
 
-describe('installCommand — additional error paths', () => {
+describe("installCommand — additional error paths", () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   const versionsResponse = {
-    name: '@test-org/my-skill',
+    name: "@test-org/my-skill",
     versions: [
       {
-        version: '2.0.0',
-        integrity: 'sha512-ghi789',
+        version: "2.0.0",
+        integrity: "sha512-ghi789",
         auditScore: 7.0,
-        auditStatus: 'published',
-        publishedAt: '2026-02-01T00:00:00Z'
-      }
-    ]
+        auditStatus: "published",
+        publishedAt: "2026-02-01T00:00:00Z",
+      },
+    ],
   };
 
   const versionMetadata = {
-    name: '@test-org/my-skill',
-    version: '2.0.0',
-    description: 'A test skill',
-    integrity: 'sha512-placeholder',
+    name: "@test-org/my-skill",
+    version: "2.0.0",
+    description: "A test skill",
+    integrity: "sha512-placeholder",
     permissions: {},
     auditScore: 7.0,
-    auditStatus: 'published',
-    downloadUrl: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
-    publishedAt: '2026-02-01T00:00:00Z'
+    auditStatus: "published",
+    downloadUrl: "https://storage.example.com/download/my-skill-2.0.0.tgz",
+    publishedAt: "2026-02-01T00:00:00Z",
   };
 
   let fakeTarball: Buffer;
   let fakeTarballIntegrity: string;
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-extra-test-'));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-extra-config-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-extra-test-"));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-extra-config-"));
 
-    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
 
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
-      JSON.stringify({ name: 'my-project', version: '1.0.0', skills: {} }, null, 2)
+      path.join(tmpDir, "tank.json"),
+      JSON.stringify({ name: "my-project", version: "1.0.0", skills: {} }, null, 2),
     );
 
-    fakeTarball = Buffer.from('fake-tarball-content-for-extra-tests');
-    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
+    fakeTarball = Buffer.from("fake-tarball-content-for-extra-tests");
+    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -1546,89 +1653,89 @@ describe('installCommand — additional error paths', () => {
     errorSpy.mockRestore();
   });
 
-  it('throws network error when fetch rejects on versions endpoint', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("throws network error when fetch rejects on versions endpoint", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
-    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED: Connection refused'));
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED: Connection refused"));
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /network/i
+    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
+      /network/i,
     );
   });
 
-  it('throws when tarball download returns non-ok status', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("throws when tarball download returns non-ok status", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
     );
-    mockFetch.mockResolvedValueOnce(new Response('Not Found', { status: 404, statusText: 'Not Found' }));
+    mockFetch.mockResolvedValueOnce(new Response("Not Found", { status: 404, statusText: "Not Found" }));
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /404|download|failed/i
-    );
+    await expect(
+      installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir, homedir: tmpDir }),
+    ).rejects.toThrow(/404|download|failed/i);
   });
 
-  it('throws network error when fetch rejects on tarball download', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("throws network error when fetch rejects on tarball download", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
     );
-    mockFetch.mockRejectedValueOnce(new Error('Connection reset'));
+    mockFetch.mockRejectedValueOnce(new Error("Connection reset"));
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
-      /network/i
-    );
+    await expect(
+      installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir, homedir: tmpDir }),
+    ).rejects.toThrow(/network/i);
   });
 
-  it('recovers gracefully when tank.lock contains invalid JSON', async () => {
-    const { installCommand } = await import('../commands/install.js');
+  it("recovers gracefully when tank.lock contains invalid JSON", async () => {
+    const { installCommand } = await import("../commands/install.js");
 
-    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), '{ this is not valid json !!!');
+    fs.writeFileSync(path.join(tmpDir, "tank.lock"), "{ this is not valid json !!!");
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
-    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).resolves.toBeUndefined();
+    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).resolves.toBeUndefined();
 
-    const lockRaw = fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8');
+    const lockRaw = fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8");
     const lock = JSON.parse(lockRaw);
     expect(lock.lockfileVersion).toBe(2);
-    expect(lock.skills['@test-org/my-skill@2.0.0']).toBeDefined();
+    expect(lock.skills["@test-org/my-skill@2.0.0"]).toBeDefined();
   });
 
-  it('throws when tank.json contains invalid JSON (installAll)', async () => {
-    const { installAll } = await import('../commands/install.js');
+  it("throws when tank.json contains invalid JSON (installAll)", async () => {
+    const { installAll } = await import("../commands/install.js");
 
-    fs.writeFileSync(path.join(tmpDir, 'tank.json'), '{ invalid json here !!!');
+    fs.writeFileSync(path.join(tmpDir, "tank.json"), "{ invalid json here !!!");
 
     await expect(installAll({ directory: tmpDir, configDir })).rejects.toThrow(/tank\.json|parse/i);
   });
 
-  it('prints nothing-to-install message when tank.json has empty skills map', async () => {
-    const { installAll } = await import('../commands/install.js');
+  it("prints nothing-to-install message when tank.json has empty skills map", async () => {
+    const { installAll } = await import("../commands/install.js");
 
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
-      JSON.stringify({ name: 'my-project', version: '1.0.0', skills: {} }, null, 2)
+      path.join(tmpDir, "tank.json"),
+      JSON.stringify({ name: "my-project", version: "1.0.0", skills: {} }, null, 2),
     );
 
     await installAll({ directory: tmpDir, configDir });
 
     expect(mockFetch).not.toHaveBeenCalled();
 
-    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
+    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
     expect(output).toMatch(/no skills|nothing to install/i);
   });
 });
 
-describe('installCommand — transitive dependency resolution', () => {
+describe("installCommand — transitive dependency resolution", () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -1636,58 +1743,64 @@ describe('installCommand — transitive dependency resolution', () => {
 
   let fakeTarball: Buffer;
   let fakeTarballIntegrity: string;
+  let fakeDepTarball: Buffer;
+  let fakeDepTarballIntegrity: string;
 
   const primaryVersionsResponse = {
-    name: '@test-org/my-skill',
+    name: "@test-org/my-skill",
     versions: [
       {
-        version: '1.0.0',
-        integrity: 'sha512-abc',
+        version: "1.0.0",
+        integrity: "sha512-abc",
         auditScore: 8.0,
-        auditStatus: 'published',
-        publishedAt: '2026-01-01T00:00:00Z'
-      }
-    ]
+        auditStatus: "published",
+        publishedAt: "2026-01-01T00:00:00Z",
+      },
+    ],
   };
 
   const depVersionsResponse = {
-    name: '@dep/helper',
+    name: "@dep/helper",
     versions: [
       {
-        version: '1.0.0',
-        integrity: 'sha512-dep1',
+        version: "1.0.0",
+        integrity: "sha512-dep1",
         auditScore: 9.0,
-        auditStatus: 'published',
-        publishedAt: '2026-01-01T00:00:00Z'
+        auditStatus: "published",
+        publishedAt: "2026-01-01T00:00:00Z",
       },
       {
-        version: '1.1.0',
-        integrity: 'sha512-dep2',
+        version: "1.1.0",
+        integrity: "sha512-dep2",
         auditScore: 9.0,
-        auditStatus: 'published',
-        publishedAt: '2026-01-15T00:00:00Z'
-      }
-    ]
+        auditStatus: "published",
+        publishedAt: "2026-01-15T00:00:00Z",
+      },
+    ],
   };
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-transitive-test-'));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-transitive-config-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-transitive-test-"));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-transitive-config-"));
 
-    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
+    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
 
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.json'),
-      JSON.stringify({ name: 'my-project', version: '1.0.0', skills: {} }, null, 2)
+      path.join(tmpDir, "tank.json"),
+      JSON.stringify({ name: "my-project", version: "1.0.0", skills: {} }, null, 2),
     );
 
-    fakeTarball = Buffer.from('fake-tarball-transitive-test');
-    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
+    fakeTarball = Buffer.from("fake-tarball-transitive-test");
+    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
     fakeTarballIntegrity = `sha512-${hash}`;
 
+    fakeDepTarball = Buffer.from("fake-tarball-transitive-dep-test");
+    const depHash = crypto.createHash("sha512").update(fakeDepTarball).digest("base64");
+    fakeDepTarballIntegrity = `sha512-${depHash}`;
+
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -1698,34 +1811,36 @@ describe('installCommand — transitive dependency resolution', () => {
   });
 
   function makeMeta(name: string, version: string) {
+    const integrity = name.startsWith("@dep/") ? fakeDepTarballIntegrity : fakeTarballIntegrity;
+
     return {
       name,
       version,
       description: `Test skill ${name}`,
-      integrity: fakeTarballIntegrity,
+      integrity,
       permissions: {},
       auditScore: 8.0,
-      auditStatus: 'published',
+      auditStatus: "published",
       downloadUrl: `https://storage.example.com/${name}-${version}.tgz`,
-      publishedAt: '2026-01-01T00:00:00Z'
+      publishedAt: "2026-01-01T00:00:00Z",
     };
   }
 
-  it('installs transitive dependencies declared in extracted tank.json', async () => {
-    const { installCommand } = await import('../commands/install.js');
-    const { extract } = await import('tar');
+  it("installs transitive dependencies declared in extracted tank.json", async () => {
+    const { installCommand } = await import("../commands/install.js");
+    const { extract } = await import("tar");
 
     // Primary skill's extract writes a tank.json with a dependency
     vi.mocked(extract)
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, 'tank.json'),
+          path.join(cwd, "tank.json"),
           JSON.stringify({
-            name: '@test-org/my-skill',
-            version: '1.0.0',
-            skills: { '@dep/helper': '^1.0.0' }
-          })
+            name: "@test-org/my-skill",
+            version: "1.0.0",
+            skills: { "@dep/helper": "^1.0.0" },
+          }),
         );
       })
       .mockImplementationOnce(async () => {
@@ -1736,133 +1851,133 @@ describe('installCommand — transitive dependency resolution', () => {
     //                  dep versions, dep meta, dep tarball
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(depVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@dep/helper', '1.1.0'))))
-      .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)));
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@dep/helper", "1.1.0"))))
+      .mockResolvedValueOnce(new Response(new Uint8Array(fakeDepTarball)));
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(6);
 
-    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8'));
-    expect(lock.skills['@test-org/my-skill@1.0.0']).toBeDefined();
-    expect(lock.skills['@dep/helper@1.1.0']).toBeDefined();
+    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8"));
+    expect(lock.skills["@test-org/my-skill@1.0.0"]).toBeDefined();
+    expect(lock.skills["@dep/helper@1.1.0"]).toBeDefined();
   });
 
-  it('does not add transitive deps to project tank.json', async () => {
-    const { installCommand } = await import('../commands/install.js');
-    const { extract } = await import('tar');
+  it("does not add transitive deps to project tank.json", async () => {
+    const { installCommand } = await import("../commands/install.js");
+    const { extract } = await import("tar");
 
     vi.mocked(extract)
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, 'tank.json'),
+          path.join(cwd, "tank.json"),
           JSON.stringify({
-            name: '@test-org/my-skill',
-            version: '1.0.0',
-            skills: { '@dep/helper': '^1.0.0' }
-          })
+            name: "@test-org/my-skill",
+            version: "1.0.0",
+            skills: { "@dep/helper": "^1.0.0" },
+          }),
         );
       })
       .mockImplementationOnce(async () => {});
 
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(depVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@dep/helper', '1.1.0'))))
-      .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)));
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@dep/helper", "1.1.0"))))
+      .mockResolvedValueOnce(new Response(new Uint8Array(fakeDepTarball)));
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
-    const skillsJson = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
-    expect(skillsJson.skills['@test-org/my-skill']).toBe('^1.0.0');
-    expect(skillsJson.skills['@dep/helper']).toBeUndefined();
+    const skillsJson = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
+    expect(skillsJson.skills["@test-org/my-skill"]).toBe("^1.0.0");
+    expect(skillsJson.skills["@dep/helper"]).toBeUndefined();
   });
 
-  it('skips already-installed transitive deps', async () => {
-    const { installCommand } = await import('../commands/install.js');
-    const { extract } = await import('tar');
+  it("skips already-installed transitive deps", async () => {
+    const { installCommand } = await import("../commands/install.js");
+    const { extract } = await import("tar");
 
     // Pre-populate lockfile with the dependency already installed
     fs.writeFileSync(
-      path.join(tmpDir, 'tank.lock'),
+      path.join(tmpDir, "tank.lock"),
       JSON.stringify(
         {
           lockfileVersion: 1,
           skills: {
-            '@dep/helper@1.1.0': {
-              resolved: 'https://storage.example.com/dep-helper-1.1.0.tgz',
+            "@dep/helper@1.1.0": {
+              resolved: "https://storage.example.com/dep-helper-1.1.0.tgz",
               integrity: fakeTarballIntegrity,
               permissions: {},
-              audit_score: 9.0
-            }
-          }
+              audit_score: 9.0,
+            },
+          },
         },
         null,
-        2
-      )
+        2,
+      ),
     );
 
     vi.mocked(extract).mockImplementationOnce(async (opts: unknown) => {
       const { cwd } = opts as { cwd: string };
       fs.writeFileSync(
-        path.join(cwd, 'tank.json'),
+        path.join(cwd, "tank.json"),
         JSON.stringify({
-          name: '@test-org/my-skill',
-          version: '1.0.0',
-          skills: { '@dep/helper': '^1.0.0' }
-        })
+          name: "@test-org/my-skill",
+          version: "1.0.0",
+          skills: { "@dep/helper": "^1.0.0" },
+        }),
       );
     });
 
     // Primary: 3 fetches. Dep: only versions fetch (then skipped as already installed)
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(depVersionsResponse)));
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     // 3 for primary + 1 versions fetch for dep (skipped after resolution)
     expect(mockFetch).toHaveBeenCalledTimes(4);
   });
 
-  it('handles circular dependencies without infinite recursion', async () => {
-    const { installCommand } = await import('../commands/install.js');
-    const { extract } = await import('tar');
+  it("handles circular dependencies without infinite recursion", async () => {
+    const { installCommand } = await import("../commands/install.js");
+    const { extract } = await import("tar");
 
     const circularDepVersions = {
-      name: '@dep/circular',
+      name: "@dep/circular",
       versions: [
         {
-          version: '1.0.0',
-          integrity: 'sha512-circ',
+          version: "1.0.0",
+          integrity: "sha512-circ",
           auditScore: 8.0,
-          auditStatus: 'published',
-          publishedAt: '2026-01-01T00:00:00Z'
-        }
-      ]
+          auditStatus: "published",
+          publishedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
     };
 
     // Primary depends on @dep/circular, @dep/circular depends back on primary
@@ -1870,23 +1985,23 @@ describe('installCommand — transitive dependency resolution', () => {
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, 'tank.json'),
+          path.join(cwd, "tank.json"),
           JSON.stringify({
-            name: '@test-org/my-skill',
-            version: '1.0.0',
-            skills: { '@dep/circular': '^1.0.0' }
-          })
+            name: "@test-org/my-skill",
+            version: "1.0.0",
+            skills: { "@dep/circular": "^1.0.0" },
+          }),
         );
       })
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, 'tank.json'),
+          path.join(cwd, "tank.json"),
           JSON.stringify({
-            name: '@dep/circular',
-            version: '1.0.0',
-            skills: { '@test-org/my-skill': '^1.0.0' }
-          })
+            name: "@dep/circular",
+            version: "1.0.0",
+            skills: { "@test-org/my-skill": "^1.0.0" },
+          }),
         );
       });
 
@@ -1895,48 +2010,48 @@ describe('installCommand — transitive dependency resolution', () => {
     // @test-org/my-skill (cycle): versions fetch → already in lockfile → skip
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(circularDepVersions)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@dep/circular', '1.0.0'))))
-      .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@dep/circular", "1.0.0"))))
+      .mockResolvedValueOnce(new Response(new Uint8Array(fakeDepTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)));
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     // 3 primary + 3 dep + 1 cycle detection = 7
     expect(mockFetch).toHaveBeenCalledTimes(7);
 
-    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8'));
-    expect(lock.skills['@test-org/my-skill@1.0.0']).toBeDefined();
-    expect(lock.skills['@dep/circular@1.0.0']).toBeDefined();
+    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8"));
+    expect(lock.skills["@test-org/my-skill@1.0.0"]).toBeDefined();
+    expect(lock.skills["@dep/circular@1.0.0"]).toBeDefined();
   });
 
-  it('works normally when skill has no dependencies', async () => {
-    const { installCommand } = await import('../commands/install.js');
-    const { extract } = await import('tar');
+  it("works normally when skill has no dependencies", async () => {
+    const { installCommand } = await import("../commands/install.js");
+    const { extract } = await import("tar");
 
     // Extract writes a tank.json with no skills field
     vi.mocked(extract).mockImplementationOnce(async (opts: unknown) => {
       const { cwd } = opts as { cwd: string };
-      fs.writeFileSync(path.join(cwd, 'tank.json'), JSON.stringify({ name: '@test-org/my-skill', version: '1.0.0' }));
+      fs.writeFileSync(path.join(cwd, "tank.json"), JSON.stringify({ name: "@test-org/my-skill", version: "1.0.0" }));
     });
 
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)));
 
     await installCommand({
-      name: '@test-org/my-skill',
+      name: "@test-org/my-skill",
       directory: tmpDir,
       configDir,
-      homedir: tmpDir
+      homedir: tmpDir,
     });
 
     // Only 3 fetches for the primary skill

--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -1,89 +1,89 @@
-import crypto from "node:crypto";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock global fetch
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+vi.stubGlobal('fetch', mockFetch);
 
 // Mock ora — spinner is a side-effect UI concern
-vi.mock("ora", () => {
+vi.mock('ora', () => {
   const spinner = {
     start: vi.fn().mockReturnThis(),
     stop: vi.fn().mockReturnThis(),
     succeed: vi.fn().mockReturnThis(),
     fail: vi.fn().mockReturnThis(),
-    text: "",
+    text: ''
   };
   return { default: vi.fn(() => spinner) };
 });
 
 // Mock tar extract — we don't want to actually extract tarballs in tests
-vi.mock("tar", () => ({
-  extract: vi.fn().mockResolvedValue(undefined),
+vi.mock('tar', () => ({
+  extract: vi.fn().mockResolvedValue(undefined)
 }));
 
-describe("installCommand", () => {
+describe('installCommand', () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   const validSkillsJson = {
-    name: "my-project",
-    version: "1.0.0",
-    description: "A test project",
+    name: 'my-project',
+    version: '1.0.0',
+    description: 'A test project',
     skills: {},
     permissions: {
-      network: { outbound: ["*.example.com"] },
-      filesystem: { read: ["./src/**"], write: ["./output/**"] },
-      subprocess: false,
-    },
+      network: { outbound: ['*.example.com'] },
+      filesystem: { read: ['./src/**'], write: ['./output/**'] },
+      subprocess: false
+    }
   };
 
   const versionsResponse = {
-    name: "@test-org/my-skill",
+    name: '@test-org/my-skill',
     versions: [
       {
-        version: "1.0.0",
-        integrity: "sha512-abc123",
+        version: '1.0.0',
+        integrity: 'sha512-abc123',
         auditScore: 8.5,
-        auditStatus: "published",
-        publishedAt: "2026-01-01T00:00:00Z",
+        auditStatus: 'published',
+        publishedAt: '2026-01-01T00:00:00Z'
       },
       {
-        version: "1.1.0",
-        integrity: "sha512-def456",
+        version: '1.1.0',
+        integrity: 'sha512-def456',
         auditScore: 9.0,
-        auditStatus: "published",
-        publishedAt: "2026-01-15T00:00:00Z",
+        auditStatus: 'published',
+        publishedAt: '2026-01-15T00:00:00Z'
       },
       {
-        version: "2.0.0",
-        integrity: "sha512-ghi789",
+        version: '2.0.0',
+        integrity: 'sha512-ghi789',
         auditScore: 7.0,
-        auditStatus: "published",
-        publishedAt: "2026-02-01T00:00:00Z",
-      },
-    ],
+        auditStatus: 'published',
+        publishedAt: '2026-02-01T00:00:00Z'
+      }
+    ]
   };
 
   const versionMetadata = {
-    name: "@test-org/my-skill",
-    version: "2.0.0",
-    description: "A test skill",
-    integrity: "sha512-ghi789",
+    name: '@test-org/my-skill',
+    version: '2.0.0',
+    description: 'A test skill',
+    integrity: 'sha512-ghi789',
     permissions: {
-      network: { outbound: ["*.example.com"] },
-      filesystem: { read: ["./src/**"] },
-      subprocess: false,
+      network: { outbound: ['*.example.com'] },
+      filesystem: { read: ['./src/**'] },
+      subprocess: false
     },
     auditScore: 7.0,
-    auditStatus: "published",
-    downloadUrl: "https://storage.example.com/download/my-skill-2.0.0.tgz",
-    publishedAt: "2026-02-01T00:00:00Z",
+    auditStatus: 'published',
+    downloadUrl: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
+    publishedAt: '2026-02-01T00:00:00Z'
   };
 
   // Create a fake tarball with known sha512
@@ -91,29 +91,29 @@ describe("installCommand", () => {
   let fakeTarballIntegrity: string;
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-test-"));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-config-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-test-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-config-'));
 
     // Write a valid tank.json in the "project" directory
-    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
 
     // Write a config with registry URL (no auth needed for install)
     fs.writeFileSync(
-      path.join(configDir, "config.json"),
+      path.join(configDir, 'config.json'),
       JSON.stringify({
-        registry: "https://tankpkg.dev",
-      }),
+        registry: 'https://tankpkg.dev'
+      })
     );
 
     // Create a fake tarball and compute its real integrity
-    const crypto = await import("node:crypto");
-    fakeTarball = Buffer.from("fake-tarball-content-for-testing");
-    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
+    const crypto = await import('node:crypto');
+    fakeTarball = Buffer.from('fake-tarball-content-for-testing');
+    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -124,14 +124,14 @@ describe("installCommand", () => {
   });
 
   function getAllOutput(): string {
-    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
+    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
   }
 
   function setupSuccessfulInstall(overrides?: { versionMeta?: Record<string, unknown>; integrity?: string }) {
     const integrity = overrides?.integrity ?? fakeTarballIntegrity;
     const meta = overrides?.versionMeta ?? {
       ...versionMetadata,
-      integrity,
+      integrity
     };
 
     // 1. GET /api/v1/skills/{name}/versions
@@ -144,15 +144,15 @@ describe("installCommand", () => {
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
   }
 
-  it("installs a skill successfully: fetch versions → resolve → download → verify → extract → update files", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('installs a skill successfully: fetch versions → resolve → download → verify → extract → update files', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     // Verify 3 fetch calls
@@ -160,127 +160,127 @@ describe("installCommand", () => {
 
     // Verify versions fetch
     const [versionsUrl] = mockFetch.mock.calls[0];
-    expect(versionsUrl).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/versions");
+    expect(versionsUrl).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/versions');
 
     const [, versionsOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect((versionsOpts.headers as Record<string, string>).Authorization).toBeUndefined();
 
     // Verify version metadata fetch
     const [metaUrl] = mockFetch.mock.calls[1];
-    expect(metaUrl).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
+    expect(metaUrl).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0');
 
     // Verify tarball download
     const [downloadUrl] = mockFetch.mock.calls[2];
-    expect(downloadUrl).toBe("https://storage.example.com/download/my-skill-2.0.0.tgz");
+    expect(downloadUrl).toBe('https://storage.example.com/download/my-skill-2.0.0.tgz');
   });
 
-  it("auto-creates tank.json when missing", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('auto-creates tank.json when missing', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
-    fs.unlinkSync(path.join(tmpDir, "tank.json"));
+    fs.unlinkSync(path.join(tmpDir, 'tank.json'));
 
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse)))
       .mockResolvedValueOnce(new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity })))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)));
 
-    await installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir });
+    await installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir });
 
-    const created = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
-    expect(created.skills["@test-org/my-skill"]).toBe("^2.0.0");
+    const created = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
+    expect(created.skills['@test-org/my-skill']).toBe('^2.0.0');
   });
 
-  it("errors when skill is not found (404)", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('errors when skill is not found (404)', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Versions endpoint returns 404
-    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: "Skill not found" }), { status: 404 }));
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'Skill not found' }), { status: 404 }));
 
-    await expect(installCommand({ name: "@test-org/nonexistent", directory: tmpDir, configDir })).rejects.toThrow(
-      /not found/i,
+    await expect(installCommand({ name: '@test-org/nonexistent', directory: tmpDir, configDir })).rejects.toThrow(
+      /not found/i
     );
   });
 
-  it("sends bearer token when config contains token", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('sends bearer token when config contains token', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     fs.writeFileSync(
-      path.join(configDir, "config.json"),
-      JSON.stringify({ registry: "https://tankpkg.dev", token: "tank_ci_token" }),
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ registry: 'https://tankpkg.dev', token: 'tank_ci_token' })
     );
 
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     const [, versionsOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((versionsOpts.headers as Record<string, string>).Authorization).toBe("Bearer tank_ci_token");
+    expect((versionsOpts.headers as Record<string, string>).Authorization).toBe('Bearer tank_ci_token');
   });
 
-  it("shows scope error when versions endpoint returns 403", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('shows scope error when versions endpoint returns 403', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: "Insufficient API key scope. Required: skills:read" }), { status: 403 }),
+      new Response(JSON.stringify({ error: 'Insufficient API key scope. Required: skills:read' }), { status: 403 })
     );
 
-    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
-      /skills:read/i,
+    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
+      /skills:read/i
     );
   });
 
-  it("errors when no version satisfies the range", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('errors when no version satisfies the range', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Return versions that don't match the range
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
 
     await expect(
       installCommand({
-        name: "@test-org/my-skill",
-        versionRange: ">=5.0.0",
+        name: '@test-org/my-skill',
+        versionRange: '>=5.0.0',
         directory: tmpDir,
-        configDir,
-      }),
+        configDir
+      })
     ).rejects.toThrow(/no version/i);
   });
 
-  it("aborts with error when integrity check fails", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('aborts with error when integrity check fails', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Setup with mismatched integrity
     setupSuccessfulInstall({
-      integrity: "sha512-WRONG_HASH",
+      integrity: 'sha512-WRONG_HASH'
     });
 
-    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
-      /integrity/i,
+    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
+      /integrity/i
     );
   });
 
-  it("aborts when skill permissions exceed project budget", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('aborts when skill permissions exceed project budget', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Write tank.json with restrictive permissions
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
+      path.join(tmpDir, 'tank.json'),
       JSON.stringify(
         {
           ...validSkillsJson,
           permissions: {
-            network: { outbound: ["*.example.com"] },
-            filesystem: { read: ["./src/**"], write: ["./output/**"] },
-            subprocess: false,
-          },
+            network: { outbound: ['*.example.com'] },
+            filesystem: { read: ['./src/**'], write: ['./output/**'] },
+            subprocess: false
+          }
         },
         null,
-        2,
-      ),
+        2
+      )
     );
 
     // Skill requests subprocess (project doesn't allow it)
@@ -288,10 +288,10 @@ describe("installCommand", () => {
       ...versionMetadata,
       integrity: fakeTarballIntegrity,
       permissions: {
-        network: { outbound: ["*.example.com"] },
-        filesystem: { read: ["./src/**"] },
-        subprocess: true, // Project budget says false!
-      },
+        network: { outbound: ['*.example.com'] },
+        filesystem: { read: ['./src/**'] },
+        subprocess: true // Project budget says false!
+      }
     };
 
     // 1. GET versions
@@ -300,28 +300,28 @@ describe("installCommand", () => {
     // 2. GET version metadata
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(metaWithSubprocess), { status: 200 }));
 
-    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
-      /permission/i,
+    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
+      /permission/i
     );
   });
 
-  it("installs with warning when no permission budget is defined", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('installs with warning when no permission budget is defined', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Write tank.json WITHOUT permissions
     const noBudgetSkillsJson = {
-      name: "my-project",
-      version: "1.0.0",
-      skills: {},
+      name: 'my-project',
+      version: '1.0.0',
+      skills: {}
     };
-    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(noBudgetSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(noBudgetSkillsJson, null, 2));
 
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     // Should succeed but with a warning about missing budget
@@ -329,93 +329,93 @@ describe("installCommand", () => {
     expect(output).toMatch(/warning|budget|permission/i);
   });
 
-  it("updates tank.json with the new dependency", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('updates tank.json with the new dependency', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     // Read updated tank.json
-    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
+    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
 
-    expect(updated.skills["@test-org/my-skill"]).toBe("^2.0.0");
+    expect(updated.skills['@test-org/my-skill']).toBe('^2.0.0');
   });
 
-  it("updates tank.lock with correct entry", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('updates tank.lock with correct entry', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     // Read tank.lock
-    const lockPath = path.join(tmpDir, "tank.lock");
+    const lockPath = path.join(tmpDir, 'tank.lock');
     expect(fs.existsSync(lockPath)).toBe(true);
 
-    const lock = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
     expect(lock.lockfileVersion).toBe(2);
-    expect(lock.skills["@test-org/my-skill@2.0.0"]).toBeDefined();
+    expect(lock.skills['@test-org/my-skill@2.0.0']).toBeDefined();
 
-    const entry = lock.skills["@test-org/my-skill@2.0.0"];
+    const entry = lock.skills['@test-org/my-skill@2.0.0'];
     expect(entry.integrity).toBe(fakeTarballIntegrity);
     expect(entry.audit_score).toBe(7.0);
-    expect(entry.resolved).toBe("https://storage.example.com/download/my-skill-2.0.0.tgz");
+    expect(entry.resolved).toBe('https://storage.example.com/download/my-skill-2.0.0.tgz');
     expect(entry.permissions).toBeDefined();
   });
 
-  it("handles scoped package names correctly (URL encoding)", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('handles scoped package names correctly (URL encoding)', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     // Verify the URL was properly encoded
     const [versionsUrl] = mockFetch.mock.calls[0];
-    expect(versionsUrl).toContain("%40test-org%2Fmy-skill");
+    expect(versionsUrl).toContain('%40test-org%2Fmy-skill');
   });
 
-  it("skips install when same version is already installed", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('skips install when same version is already installed', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Pre-populate tank.json with the skill already installed
     const existingSkillsJson = {
       ...validSkillsJson,
-      skills: { "@test-org/my-skill": "^2.0.0" },
+      skills: { '@test-org/my-skill': '^2.0.0' }
     };
-    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(existingSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(existingSkillsJson, null, 2));
 
     // Pre-populate tank.lock with the skill already locked
     const existingLock = {
       lockfileVersion: 1,
       skills: {
-        "@test-org/my-skill@2.0.0": {
-          resolved: "https://storage.example.com/download/my-skill-2.0.0.tgz",
+        '@test-org/my-skill@2.0.0': {
+          resolved: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
           integrity: fakeTarballIntegrity,
           permissions: versionMetadata.permissions,
-          audit_score: 7.0,
-        },
-      },
+          audit_score: 7.0
+        }
+      }
     };
-    fs.writeFileSync(path.join(tmpDir, "tank.lock"), JSON.stringify(existingLock, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), JSON.stringify(existingLock, null, 2));
 
     // Versions endpoint still called to resolve
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     // Should only call versions endpoint, not download
@@ -425,33 +425,33 @@ describe("installCommand", () => {
     expect(output).toMatch(/already installed/i);
   });
 
-  it("extracts tarball to correct directory path", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('extracts tarball to correct directory path', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     // Verify the extraction directory was created
-    const expectedDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
+    const expectedDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
     expect(fs.existsSync(expectedDir)).toBe(true);
   });
 
-  it("aborts when skill requests network domains not in project budget", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('aborts when skill requests network domains not in project budget', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Skill requests domains not in project budget
     const metaWithExtraDomains = {
       ...versionMetadata,
       integrity: fakeTarballIntegrity,
       permissions: {
-        network: { outbound: ["*.evil.com"] }, // Not in project budget
-        filesystem: { read: ["./src/**"] },
-        subprocess: false,
-      },
+        network: { outbound: ['*.evil.com'] }, // Not in project budget
+        filesystem: { read: ['./src/**'] },
+        subprocess: false
+      }
     };
 
     // 1. GET versions
@@ -460,45 +460,45 @@ describe("installCommand", () => {
     // 2. GET version metadata
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(metaWithExtraDomains), { status: 200 }));
 
-    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
-      /permission/i,
+    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
+      /permission/i
     );
   });
 
-  it("sorts lockfile keys alphabetically", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('sorts lockfile keys alphabetically', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // Pre-populate lock with an entry that comes after alphabetically
     const existingLock = {
       lockfileVersion: 1,
       skills: {
-        "z-skill@1.0.0": {
-          resolved: "https://example.com/z.tgz",
-          integrity: "sha512-zzz",
+        'z-skill@1.0.0': {
+          resolved: 'https://example.com/z.tgz',
+          integrity: 'sha512-zzz',
           permissions: {},
-          audit_score: 5.0,
-        },
-      },
+          audit_score: 5.0
+        }
+      }
     };
-    fs.writeFileSync(path.join(tmpDir, "tank.lock"), JSON.stringify(existingLock, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), JSON.stringify(existingLock, null, 2));
 
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
-    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8"));
+    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8'));
     const keys = Object.keys(lock.skills);
     expect(keys).toEqual([...keys].sort());
-    expect(keys[0]).toBe("@test-org/my-skill@2.0.0");
-    expect(keys[1]).toBe("z-skill@1.0.0");
+    expect(keys[0]).toBe('@test-org/my-skill@2.0.0');
+    expect(keys[1]).toBe('z-skill@1.0.0');
   });
 
-  it("uses specified version range instead of default *", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('uses specified version range instead of default *', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     // 1. GET versions
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
@@ -506,8 +506,8 @@ describe("installCommand", () => {
     // 2. GET version metadata for 1.1.0 (highest matching ^1.0.0)
     const meta110 = {
       ...versionMetadata,
-      version: "1.1.0",
-      integrity: fakeTarballIntegrity,
+      version: '1.1.0',
+      integrity: fakeTarballIntegrity
     };
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(meta110), { status: 200 }));
 
@@ -515,135 +515,135 @@ describe("installCommand", () => {
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
     await installCommand({
-      name: "@test-org/my-skill",
-      versionRange: "^1.0.0",
+      name: '@test-org/my-skill',
+      versionRange: '^1.0.0',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     // Should resolve to 1.1.0 (highest matching ^1.0.0)
     const [metaUrl] = mockFetch.mock.calls[1];
-    expect(metaUrl).toContain("1.1.0");
+    expect(metaUrl).toContain('1.1.0');
 
     // tank.json should use the provided range
-    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
-    expect(updated.skills["@test-org/my-skill"]).toBe("^1.0.0");
+    const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
+    expect(updated.skills['@test-org/my-skill']).toBe('^1.0.0');
   });
 
-  it("creates agent symlinks after local install", async () => {
+  it('creates agent symlinks after local install', async () => {
     vi.resetModules();
-    const prepareAgentSkillDir = vi.fn().mockReturnValue("/mock/agent-skills/test-org--my-skill");
-    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ["claude"], skipped: [], failed: [] });
-    vi.doMock("../lib/frontmatter.js", () => ({ prepareAgentSkillDir }));
-    vi.doMock("../lib/linker.js", () => ({ linkSkillToAgents }));
+    const prepareAgentSkillDir = vi.fn().mockReturnValue('/mock/agent-skills/test-org--my-skill');
+    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ['claude'], skipped: [], failed: [] });
+    vi.doMock('../lib/frontmatter.js', () => ({ prepareAgentSkillDir }));
+    vi.doMock('../lib/linker.js', () => ({ linkSkillToAgents }));
 
-    const { installCommand } = await import("../commands/install.js");
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
-    const expectedExtractDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
+    const expectedExtractDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
     expect(prepareAgentSkillDir).toHaveBeenCalledWith({
-      skillName: "@test-org/my-skill",
+      skillName: '@test-org/my-skill',
       extractDir: expectedExtractDir,
-      agentSkillsBaseDir: path.join(tmpDir, ".tank", "agent-skills"),
-      description: "A test skill",
+      agentSkillsBaseDir: path.join(tmpDir, '.tank', 'agent-skills'),
+      description: 'A test skill'
     });
     expect(linkSkillToAgents).toHaveBeenCalledWith({
-      skillName: "@test-org/my-skill",
-      sourceDir: "/mock/agent-skills/test-org--my-skill",
-      linksDir: path.join(tmpDir, ".tank"),
-      source: "local",
-      homedir: tmpDir,
+      skillName: '@test-org/my-skill',
+      sourceDir: '/mock/agent-skills/test-org--my-skill',
+      linksDir: path.join(tmpDir, '.tank'),
+      source: 'local',
+      homedir: tmpDir
     });
   });
 
-  it("succeeds with warning when no agents are detected", async () => {
+  it('succeeds with warning when no agents are detected', async () => {
     vi.resetModules();
-    vi.doMock("../lib/linker.js", () => ({
-      linkSkillToAgents: vi.fn().mockReturnValue({ linked: [], skipped: [], failed: [] }),
+    vi.doMock('../lib/linker.js', () => ({
+      linkSkillToAgents: vi.fn().mockReturnValue({ linked: [], skipped: [], failed: [] })
     }));
-    vi.doMock("../lib/agents.js", async () => {
-      const actual = await vi.importActual<typeof import("../lib/agents.js")>("../lib/agents.js");
+    vi.doMock('../lib/agents.js', async () => {
+      const actual = await vi.importActual<typeof import('../lib/agents.js')>('../lib/agents.js');
       return {
         ...actual,
-        detectInstalledAgents: vi.fn().mockReturnValue([]),
+        detectInstalledAgents: vi.fn().mockReturnValue([])
       };
     });
-    const { installCommand } = await import("../commands/install.js");
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     const output = getAllOutput();
     expect(output).toMatch(/no agents detected/i);
   });
 
-  it("succeeds with warning when agent linking fails", async () => {
+  it('succeeds with warning when agent linking fails', async () => {
     vi.resetModules();
-    vi.doMock("../lib/linker.js", () => ({
+    vi.doMock('../lib/linker.js', () => ({
       linkSkillToAgents: vi.fn(() => {
-        throw new Error("link failed");
-      }),
+        throw new Error('link failed');
+      })
     }));
 
-    const { installCommand } = await import("../commands/install.js");
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
     const output = getAllOutput();
     expect(output).toMatch(/agent linking skipped/i);
   });
 
-  it("agent symlink target is agent-skills wrapper dir, not raw extract dir", async () => {
+  it('agent symlink target is agent-skills wrapper dir, not raw extract dir', async () => {
     vi.resetModules();
-    const prepareAgentSkillDir = vi.fn().mockReturnValue("/mock/agent-skills/test-org--my-skill");
+    const prepareAgentSkillDir = vi.fn().mockReturnValue('/mock/agent-skills/test-org--my-skill');
     const linkSkillToAgents = vi.fn().mockReturnValue({ linked: [], skipped: [], failed: [] });
-    vi.doMock("../lib/frontmatter.js", () => ({ prepareAgentSkillDir }));
-    vi.doMock("../lib/linker.js", () => ({ linkSkillToAgents }));
+    vi.doMock('../lib/frontmatter.js', () => ({ prepareAgentSkillDir }));
+    vi.doMock('../lib/linker.js', () => ({ linkSkillToAgents }));
 
-    const { installCommand } = await import("../commands/install.js");
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
-      configDir,
+      configDir
     });
 
-    const expectedExtractDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
+    const expectedExtractDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
     const linkArgs = linkSkillToAgents.mock.calls[0]?.[0];
-    expect(linkArgs?.sourceDir).toBe("/mock/agent-skills/test-org--my-skill");
+    expect(linkArgs?.sourceDir).toBe('/mock/agent-skills/test-org--my-skill');
     expect(linkArgs?.sourceDir).not.toBe(expectedExtractDir);
   });
 
-  it("blocks install when audit score is below min_score threshold", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('blocks install when audit score is below min_score threshold', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
+      path.join(tmpDir, 'tank.json'),
       JSON.stringify(
         {
           ...validSkillsJson,
-          audit: { min_score: 8.0 },
+          audit: { min_score: 8.0 }
         },
         null,
-        2,
-      ),
+        2
+      )
     );
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
@@ -652,65 +652,65 @@ describe("installCommand", () => {
         JSON.stringify({
           ...versionMetadata,
           integrity: fakeTarballIntegrity,
-          auditScore: 7.0,
+          auditScore: 7.0
         }),
-        { status: 200 },
-      ),
+        { status: 200 }
+      )
     );
 
-    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
-      /audit score 7.*below minimum threshold 8/i,
+    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
+      /audit score 7.*below minimum threshold 8/i
     );
   });
 
-  it("allows install when audit score meets min_score threshold", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('allows install when audit score meets min_score threshold', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
+      path.join(tmpDir, 'tank.json'),
       JSON.stringify(
         {
           ...validSkillsJson,
-          audit: { min_score: 7.0 },
+          audit: { min_score: 7.0 }
         },
         null,
-        2,
-      ),
+        2
+      )
     );
 
     setupSuccessfulInstall({
       versionMeta: {
         ...versionMetadata,
         integrity: fakeTarballIntegrity,
-        auditScore: 7.0,
-      },
+        auditScore: 7.0
+      }
     });
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
-    const lockPath = path.join(tmpDir, "tank.lock");
+    const lockPath = path.join(tmpDir, 'tank.lock');
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 
-  it("allows install with warning when audit score is null (not yet scored)", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('allows install with warning when audit score is null (not yet scored)', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
+      path.join(tmpDir, 'tank.json'),
       JSON.stringify(
         {
           ...validSkillsJson,
-          audit: { min_score: 7.0 },
+          audit: { min_score: 7.0 }
         },
         null,
-        2,
-      ),
+        2
+      )
     );
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
@@ -719,18 +719,18 @@ describe("installCommand", () => {
         JSON.stringify({
           ...versionMetadata,
           integrity: fakeTarballIntegrity,
-          auditScore: null,
+          auditScore: null
         }),
-        { status: 200 },
-      ),
+        { status: 200 }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     const output = getAllOutput();
@@ -738,42 +738,42 @@ describe("installCommand", () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
-  it("skips audit score check when no audit.min_score is defined", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('skips audit score check when no audit.min_score is defined', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
+      path.join(tmpDir, 'tank.json'),
       JSON.stringify(
         {
-          ...validSkillsJson,
+          ...validSkillsJson
         },
         null,
-        2,
-      ),
+        2
+      )
     );
 
     setupSuccessfulInstall({
       versionMeta: {
         ...versionMetadata,
         integrity: fakeTarballIntegrity,
-        auditScore: 2.0,
-      },
+        auditScore: 2.0
+      }
     });
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
-    const lockPath = path.join(tmpDir, "tank.lock");
+    const lockPath = path.join(tmpDir, 'tank.lock');
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 });
 
-describe("installCommand --global", () => {
+describe('installCommand --global', () => {
   let tmpDir: string;
   let configDir: string;
   let fakeHome: string;
@@ -781,56 +781,56 @@ describe("installCommand --global", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   const validSkillsJson = {
-    name: "my-project",
-    version: "1.0.0",
-    description: "A test project",
-    skills: {},
+    name: 'my-project',
+    version: '1.0.0',
+    description: 'A test project',
+    skills: {}
   };
 
   const versionsResponse = {
-    name: "@test-org/my-skill",
+    name: '@test-org/my-skill',
     versions: [
       {
-        version: "2.0.0",
-        integrity: "sha512-ghi789",
+        version: '2.0.0',
+        integrity: 'sha512-ghi789',
         auditScore: 7.0,
-        auditStatus: "published",
-        publishedAt: "2026-02-01T00:00:00Z",
-      },
-    ],
+        auditStatus: 'published',
+        publishedAt: '2026-02-01T00:00:00Z'
+      }
+    ]
   };
 
   const versionMetadata = {
-    name: "@test-org/my-skill",
-    version: "2.0.0",
-    description: "A test skill",
-    integrity: "sha512-ghi789",
+    name: '@test-org/my-skill',
+    version: '2.0.0',
+    description: 'A test skill',
+    integrity: 'sha512-ghi789',
     permissions: {},
     auditScore: 7.0,
-    auditStatus: "published",
-    downloadUrl: "https://storage.example.com/download/my-skill-2.0.0.tgz",
-    publishedAt: "2026-02-01T00:00:00Z",
+    auditStatus: 'published',
+    downloadUrl: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
+    publishedAt: '2026-02-01T00:00:00Z'
   };
 
   let fakeTarball: Buffer;
   let fakeTarballIntegrity: string;
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-global-test-"));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-global-config-"));
-    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-global-home-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-global-test-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-global-config-'));
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-global-home-'));
 
-    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
 
-    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
 
-    fakeTarball = Buffer.from("fake-tarball-content-for-testing");
-    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
+    fakeTarball = Buffer.from('fake-tarball-content-for-testing');
+    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -840,96 +840,96 @@ describe("installCommand --global", () => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
     vi.resetModules();
-    vi.unmock("../lib/frontmatter.js");
-    vi.unmock("../lib/linker.js");
+    vi.unmock('../lib/frontmatter.js');
+    vi.unmock('../lib/linker.js');
   });
 
   function setupSuccessfulInstall() {
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
   }
 
-  it("extracts to ~/.tank/skills/ for global install", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('extracts to ~/.tank/skills/ for global install', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome,
+      homedir: fakeHome
     });
 
-    const extractDir = path.join(fakeHome, ".tank", "skills", "@test-org", "my-skill");
+    const extractDir = path.join(fakeHome, '.tank', 'skills', '@test-org', 'my-skill');
     expect(fs.existsSync(extractDir)).toBe(true);
   });
 
-  it("does NOT create or modify project tank.json for global install", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('does NOT create or modify project tank.json for global install', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
-    const original = fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8");
+    const original = fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8');
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome,
+      homedir: fakeHome
     });
 
-    const updated = fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8");
+    const updated = fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8');
     expect(updated).toBe(original);
   });
 
-  it("writes to ~/.tank/tank.lock for global install", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('writes to ~/.tank/tank.lock for global install', async () => {
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome,
+      homedir: fakeHome
     });
 
-    const lockPath = path.join(fakeHome, ".tank", "tank.lock");
+    const lockPath = path.join(fakeHome, '.tank', 'tank.lock');
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 
   it('creates agent symlinks with source "global"', async () => {
     vi.resetModules();
-    const prepareAgentSkillDir = vi.fn().mockReturnValue("/mock/global-agent-skills/test-org--my-skill");
-    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ["claude"], skipped: [], failed: [] });
-    vi.doMock("../lib/frontmatter.js", () => ({ prepareAgentSkillDir }));
-    vi.doMock("../lib/linker.js", () => ({ linkSkillToAgents }));
+    const prepareAgentSkillDir = vi.fn().mockReturnValue('/mock/global-agent-skills/test-org--my-skill');
+    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ['claude'], skipped: [], failed: [] });
+    vi.doMock('../lib/frontmatter.js', () => ({ prepareAgentSkillDir }));
+    vi.doMock('../lib/linker.js', () => ({ linkSkillToAgents }));
 
-    const { installCommand } = await import("../commands/install.js");
+    const { installCommand } = await import('../commands/install.js');
     setupSuccessfulInstall();
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
       global: true,
-      homedir: fakeHome,
+      homedir: fakeHome
     });
 
     expect(linkSkillToAgents).toHaveBeenCalledWith({
-      skillName: "@test-org/my-skill",
-      sourceDir: "/mock/global-agent-skills/test-org--my-skill",
-      linksDir: path.join(fakeHome, ".tank"),
-      source: "global",
-      homedir: fakeHome,
+      skillName: '@test-org/my-skill',
+      sourceDir: '/mock/global-agent-skills/test-org--my-skill',
+      linksDir: path.join(fakeHome, '.tank'),
+      source: 'global',
+      homedir: fakeHome
     });
   });
 });
 
-describe("installFromLockfile", () => {
+describe('installFromLockfile', () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -942,39 +942,39 @@ describe("installFromLockfile", () => {
   let fakeTarball2Integrity: string;
 
   const _validSkillsJson = {
-    name: "my-project",
-    version: "1.0.0",
-    description: "A test project",
+    name: 'my-project',
+    version: '1.0.0',
+    description: 'A test project',
     skills: {
-      "@test-org/my-skill": "^2.0.0",
-      "simple-skill": "^1.0.0",
+      '@test-org/my-skill': '^2.0.0',
+      'simple-skill': '^1.0.0'
     },
     permissions: {
-      network: { outbound: ["*.example.com"] },
-      filesystem: { read: ["./src/**"], write: ["./output/**"] },
-      subprocess: false,
-    },
+      network: { outbound: ['*.example.com'] },
+      filesystem: { read: ['./src/**'], write: ['./output/**'] },
+      subprocess: false
+    }
   };
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-lockfile-test-"));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-lockfile-config-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-lockfile-test-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-lockfile-config-'));
 
     // Write config
-    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
 
     // Create fake tarballs with real integrity
-    fakeTarball1 = Buffer.from("fake-tarball-content-skill-1");
-    const hash1 = crypto.createHash("sha512").update(fakeTarball1).digest("base64");
+    fakeTarball1 = Buffer.from('fake-tarball-content-skill-1');
+    const hash1 = crypto.createHash('sha512').update(fakeTarball1).digest('base64');
     fakeTarball1Integrity = `sha512-${hash1}`;
 
-    fakeTarball2 = Buffer.from("fake-tarball-content-skill-2");
-    const hash2 = crypto.createHash("sha512").update(fakeTarball2).digest("base64");
+    fakeTarball2 = Buffer.from('fake-tarball-content-skill-2');
+    const hash2 = crypto.createHash('sha512').update(fakeTarball2).digest('base64');
     fakeTarball2Integrity = `sha512-${hash2}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -985,41 +985,41 @@ describe("installFromLockfile", () => {
   });
 
   function _getAllOutput(): string {
-    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
+    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
   }
 
   function writeLockfile(
     skills: Record<
       string,
       { resolved: string; integrity: string; permissions: Record<string, unknown>; audit_score: number | null }
-    >,
+    >
   ) {
-    fs.writeFileSync(path.join(tmpDir, "tank.lock"), JSON.stringify({ lockfileVersion: 1, skills }, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), JSON.stringify({ lockfileVersion: 1, skills }, null, 2));
   }
 
-  it("installs all skills from lockfile with correct integrity", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('installs all skills from lockfile with correct integrity', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
-      },
+        audit_score: 8.0
+      }
     });
 
     // Mock API metadata response (returns downloadUrl)
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     // Mock tarball download
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
@@ -1028,112 +1028,112 @@ describe("installFromLockfile", () => {
 
     // Verify API was called for metadata
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0][0]).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
-    expect(mockFetch.mock.calls[1][0]).toBe("https://storage.example.com/my-skill-2.0.0.tgz");
+    expect(mockFetch.mock.calls[0][0]).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0');
+    expect(mockFetch.mock.calls[1][0]).toBe('https://storage.example.com/my-skill-2.0.0.tgz');
 
     // Verify extraction directory was created
-    const extractDir = path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill");
+    const extractDir = path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill');
     expect(fs.existsSync(extractDir)).toBe(true);
   });
 
-  it("uses cached tarball on cache hit and skips download request", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('uses cached tarball on cache hit and skips download request', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
-      },
+        audit_score: 8.0
+      }
     });
 
-    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice("sha512-".length), "base64").toString("hex");
-    const cacheDir = path.join(tmpDir, ".tank", "cache");
+    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice('sha512-'.length), 'base64').toString('hex');
+    const cacheDir = path.join(tmpDir, '.tank', 'cache');
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(path.join(cacheDir, `${cacheKeyHex}.tgz`), fakeTarball1);
 
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
 
     await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
+    expect(mockFetch.mock.calls[0]?.[0]).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0');
   });
 
-  it("stores tarball in global cache on cache miss", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('stores tarball in global cache on cache miss', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
-      },
+        audit_score: 8.0
+      }
     });
 
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
     await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
-    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice("sha512-".length), "base64").toString("hex");
-    const cachePath = path.join(tmpDir, ".tank", "cache", `${cacheKeyHex}.tgz`);
+    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice('sha512-'.length), 'base64').toString('hex');
+    const cachePath = path.join(tmpDir, '.tank', 'cache', `${cacheKeyHex}.tgz`);
     expect(fs.existsSync(cachePath)).toBe(true);
   });
 
-  it("invalidates corrupted cached tarball and re-downloads once", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
-    const { extract } = await import("tar");
+  it('invalidates corrupted cached tarball and re-downloads once', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
+    const { extract } = await import('tar');
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
-      },
+        audit_score: 8.0
+      }
     });
 
-    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice("sha512-".length), "base64").toString("hex");
-    const cacheDir = path.join(tmpDir, ".tank", "cache");
+    const cacheKeyHex = Buffer.from(fakeTarball1Integrity.slice('sha512-'.length), 'base64').toString('hex');
+    const cacheDir = path.join(tmpDir, '.tank', 'cache');
     const cachePath = path.join(cacheDir, `${cacheKeyHex}.tgz`);
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(cachePath, fakeTarball1);
 
-    vi.mocked(extract).mockRejectedValueOnce(new Error("cached tarball corrupt")).mockResolvedValueOnce(undefined);
+    vi.mocked(extract).mockRejectedValueOnce(new Error('cached tarball corrupt')).mockResolvedValueOnce(undefined);
 
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
@@ -1143,34 +1143,34 @@ describe("installFromLockfile", () => {
     expect(fs.existsSync(cachePath)).toBe(true);
   });
 
-  it("sends bearer token when config contains token", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('sends bearer token when config contains token', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     fs.writeFileSync(
-      path.join(configDir, "config.json"),
-      JSON.stringify({ registry: "https://tankpkg.dev", token: "tank_ci_token" }),
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ registry: 'https://tankpkg.dev', token: 'tank_ci_token' })
     );
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
-      },
+        audit_score: 8.0
+      }
     });
 
     // Mock API metadata response
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     // Mock tarball download
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
@@ -1178,32 +1178,32 @@ describe("installFromLockfile", () => {
     await installFromLockfile({ directory: tmpDir, configDir });
 
     const [, metaOpts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect((metaOpts.headers as Record<string, string>).Authorization).toBe("Bearer tank_ci_token");
+    expect((metaOpts.headers as Record<string, string>).Authorization).toBe('Bearer tank_ci_token');
   });
 
-  it("aborts entire install when integrity mismatch on any skill", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('aborts entire install when integrity mismatch on any skill', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
-        integrity: "sha512-WRONG_HASH_THAT_WILL_NOT_MATCH",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
+        integrity: 'sha512-WRONG_HASH_THAT_WILL_NOT_MATCH',
         permissions: {},
-        audit_score: 8.0,
-      },
+        audit_score: 8.0
+      }
     });
 
     // Mock API metadata response
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
-          integrity: "sha512-WRONG_HASH_THAT_WILL_NOT_MATCH",
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
+          integrity: 'sha512-WRONG_HASH_THAT_WILL_NOT_MATCH',
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     // Mock tarball download — content won't match the integrity
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
@@ -1211,33 +1211,33 @@ describe("installFromLockfile", () => {
     await expect(installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir })).rejects.toThrow(/integrity/i);
 
     // .tank/skills directory should be cleaned up on abort
-    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills'))).toBe(false);
   });
 
-  it("prints summary with count after successful install", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
-    const ora = (await import("ora")).default;
+  it('prints summary with count after successful install', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
+    const ora = (await import('ora')).default;
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
-      },
+        audit_score: 8.0
+      }
     });
 
     // Mock API metadata response
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
@@ -1245,52 +1245,52 @@ describe("installFromLockfile", () => {
 
     const spinner = ora();
     const succeedCalls = vi.mocked(spinner.succeed).mock.calls;
-    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? "";
+    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? '';
     expect(lastSucceed).toMatch(/installed 1 skill/i);
   });
 
-  it("installs multiple skills from lockfile", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('installs multiple skills from lockfile', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
+        audit_score: 8.0
       },
-      "simple-skill@1.0.0": {
-        resolved: "https://storage.example.com/simple-skill-1.0.0.tgz",
+      'simple-skill@1.0.0': {
+        resolved: 'https://storage.example.com/simple-skill-1.0.0.tgz',
         integrity: fakeTarball2Integrity,
         permissions: {},
-        audit_score: 9.0,
-      },
+        audit_score: 9.0
+      }
     });
 
     // Mock API + tarball for first skill
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
     // Mock API + tarball for second skill
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "simple-skill",
-          version: "1.0.0",
+          name: 'simple-skill',
+          version: '1.0.0',
           integrity: fakeTarball2Integrity,
-          downloadUrl: "https://storage.example.com/simple-skill-1.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/simple-skill-1.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball2), { status: 200 }));
 
@@ -1299,75 +1299,75 @@ describe("installFromLockfile", () => {
     expect(mockFetch).toHaveBeenCalledTimes(4);
 
     // Both extraction directories should exist
-    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills", "@test-org", "my-skill"))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills", "simple-skill"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills', '@test-org', 'my-skill'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills', 'simple-skill'))).toBe(true);
 
-    const ora = (await import("ora")).default;
+    const ora = (await import('ora')).default;
     const spinner = ora();
     const succeedCalls = vi.mocked(spinner.succeed).mock.calls;
-    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? "";
+    const lastSucceed = succeedCalls[succeedCalls.length - 1]?.[0] ?? '';
     expect(lastSucceed).toMatch(/installed 2 skills/i);
   });
 
-  it("handles scoped package names with correct extraction paths", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('handles scoped package names with correct extraction paths', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     writeLockfile({
-      "@my-org/deep-skill@3.0.0": {
-        resolved: "https://storage.example.com/deep-skill-3.0.0.tgz",
+      '@my-org/deep-skill@3.0.0': {
+        resolved: 'https://storage.example.com/deep-skill-3.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 7.5,
-      },
+        audit_score: 7.5
+      }
     });
 
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@my-org/deep-skill",
-          version: "3.0.0",
+          name: '@my-org/deep-skill',
+          version: '3.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/deep-skill-3.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/deep-skill-3.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
     await installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir });
 
     // Scoped package: .tank/skills/@my-org/deep-skill
-    const extractDir = path.join(tmpDir, ".tank", "skills", "@my-org", "deep-skill");
+    const extractDir = path.join(tmpDir, '.tank', 'skills', '@my-org', 'deep-skill');
     expect(fs.existsSync(extractDir)).toBe(true);
   });
 
-  it("re-extracts when directory already exists (fresh install)", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('re-extracts when directory already exists (fresh install)', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     // Pre-create the extraction directory with a marker file
-    const existingDir = path.join(tmpDir, ".tank", "skills", "simple-skill");
+    const existingDir = path.join(tmpDir, '.tank', 'skills', 'simple-skill');
     fs.mkdirSync(existingDir, { recursive: true });
-    fs.writeFileSync(path.join(existingDir, "old-file.txt"), "old content");
+    fs.writeFileSync(path.join(existingDir, 'old-file.txt'), 'old content');
 
     writeLockfile({
-      "simple-skill@1.0.0": {
-        resolved: "https://storage.example.com/simple-skill-1.0.0.tgz",
+      'simple-skill@1.0.0': {
+        resolved: 'https://storage.example.com/simple-skill-1.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 9.0,
-      },
+        audit_score: 9.0
+      }
     });
 
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "simple-skill",
-          version: "1.0.0",
+          name: 'simple-skill',
+          version: '1.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/simple-skill-1.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/simple-skill-1.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
 
@@ -1376,69 +1376,69 @@ describe("installFromLockfile", () => {
     // Directory should still exist (re-created)
     expect(fs.existsSync(existingDir)).toBe(true);
     // Old file should be gone (directory was cleaned and re-extracted)
-    expect(fs.existsSync(path.join(existingDir, "old-file.txt"))).toBe(false);
+    expect(fs.existsSync(path.join(existingDir, 'old-file.txt'))).toBe(false);
   });
 
-  it("cleans up .tank/skills on integrity failure mid-install", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('cleans up .tank/skills on integrity failure mid-install', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     writeLockfile({
-      "@test-org/my-skill@2.0.0": {
-        resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+      '@test-org/my-skill@2.0.0': {
+        resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
         integrity: fakeTarball1Integrity,
         permissions: {},
-        audit_score: 8.0,
+        audit_score: 8.0
       },
-      "bad-skill@1.0.0": {
-        resolved: "https://storage.example.com/bad-skill-1.0.0.tgz",
-        integrity: "sha512-DEFINITELY_WRONG",
+      'bad-skill@1.0.0': {
+        resolved: 'https://storage.example.com/bad-skill-1.0.0.tgz',
+        integrity: 'sha512-DEFINITELY_WRONG',
         permissions: {},
-        audit_score: 5.0,
-      },
+        audit_score: 5.0
+      }
     });
 
     // First skill: API + tarball
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarball1Integrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball1), { status: 200 }));
     // Second skill: API + tarball (integrity won't match)
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "bad-skill",
-          version: "1.0.0",
-          integrity: "sha512-DEFINITELY_WRONG",
-          downloadUrl: "https://storage.example.com/bad-skill-1.0.0.tgz",
+          name: 'bad-skill',
+          version: '1.0.0',
+          integrity: 'sha512-DEFINITELY_WRONG',
+          downloadUrl: 'https://storage.example.com/bad-skill-1.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball2), { status: 200 }));
 
     await expect(installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir })).rejects.toThrow(/integrity/i);
 
     // Even though first skill was extracted, the entire .tank/skills should be cleaned up
-    expect(fs.existsSync(path.join(tmpDir, ".tank", "skills"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.tank', 'skills'))).toBe(false);
   });
 
-  it("errors when tank.lock file is missing", async () => {
-    const { installFromLockfile } = await import("../commands/install.js");
+  it('errors when tank.lock file is missing', async () => {
+    const { installFromLockfile } = await import('../commands/install.js');
 
     // No lockfile exists
     await expect(installFromLockfile({ directory: tmpDir, configDir, homedir: tmpDir })).rejects.toThrow(/tank\.lock/i);
   });
 });
 
-describe("installAll (no-args dispatch)", () => {
+describe('installAll (no-args dispatch)', () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -1448,45 +1448,45 @@ describe("installAll (no-args dispatch)", () => {
   let fakeTarballIntegrity: string;
 
   const validSkillsJson = {
-    name: "my-project",
-    version: "1.0.0",
-    description: "A test project",
+    name: 'my-project',
+    version: '1.0.0',
+    description: 'A test project',
     skills: {
-      "@test-org/my-skill": "^2.0.0",
+      '@test-org/my-skill': '^2.0.0'
     },
     permissions: {
-      network: { outbound: ["*.example.com"] },
-      filesystem: { read: ["./src/**"], write: ["./output/**"] },
-      subprocess: false,
-    },
+      network: { outbound: ['*.example.com'] },
+      filesystem: { read: ['./src/**'], write: ['./output/**'] },
+      subprocess: false
+    }
   };
 
   const versionsResponse = {
-    name: "@test-org/my-skill",
+    name: '@test-org/my-skill',
     versions: [
       {
-        version: "2.0.0",
-        integrity: "sha512-ghi789",
+        version: '2.0.0',
+        integrity: 'sha512-ghi789',
         auditScore: 7.0,
-        auditStatus: "published",
-        publishedAt: "2026-02-01T00:00:00Z",
-      },
-    ],
+        auditStatus: 'published',
+        publishedAt: '2026-02-01T00:00:00Z'
+      }
+    ]
   };
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-installall-test-"));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-installall-config-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-installall-test-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-installall-config-'));
 
-    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
 
-    fakeTarball = Buffer.from("fake-tarball-content-for-testing");
-    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
+    fakeTarball = Buffer.from('fake-tarball-content-for-testing');
+    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -1497,54 +1497,54 @@ describe("installAll (no-args dispatch)", () => {
   });
 
   function getAllOutput(): string {
-    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
+    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
   }
 
-  it("returns gracefully when neither tank.json nor tank.lock exists", async () => {
-    const { installAll } = await import("../commands/install.js");
+  it('returns gracefully when neither tank.json nor tank.lock exists', async () => {
+    const { installAll } = await import('../commands/install.js');
 
     await installAll({ directory: tmpDir, configDir, homedir: tmpDir });
 
-    expect(getAllOutput()).toContain("nothing to install");
+    expect(getAllOutput()).toContain('nothing to install');
   });
 
-  it("uses lockfile when tank.lock exists (deterministic mode)", async () => {
-    const { installAll } = await import("../commands/install.js");
+  it('uses lockfile when tank.lock exists (deterministic mode)', async () => {
+    const { installAll } = await import('../commands/install.js');
 
     // Write tank.json
-    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
 
     // Write tank.lock
     fs.writeFileSync(
-      path.join(tmpDir, "tank.lock"),
+      path.join(tmpDir, 'tank.lock'),
       JSON.stringify(
         {
           lockfileVersion: 1,
           skills: {
-            "@test-org/my-skill@2.0.0": {
-              resolved: "https://storage.example.com/my-skill-2.0.0.tgz",
+            '@test-org/my-skill@2.0.0': {
+              resolved: 'https://storage.example.com/my-skill-2.0.0.tgz',
               integrity: fakeTarballIntegrity,
               permissions: {},
-              audit_score: 7.0,
-            },
-          },
+              audit_score: 7.0
+            }
+          }
         },
         null,
-        2,
-      ),
+        2
+      )
     );
 
     // Mock API metadata + tarball download
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarballIntegrity,
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz'
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
@@ -1552,15 +1552,15 @@ describe("installAll (no-args dispatch)", () => {
 
     // Should have called API for metadata, then downloaded tarball
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0][0]).toBe("https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0");
-    expect(mockFetch.mock.calls[1][0]).toBe("https://storage.example.com/my-skill-2.0.0.tgz");
+    expect(mockFetch.mock.calls[0][0]).toBe('https://tankpkg.dev/api/v1/skills/%40test-org%2Fmy-skill/2.0.0');
+    expect(mockFetch.mock.calls[1][0]).toBe('https://storage.example.com/my-skill-2.0.0.tgz');
   });
 
-  it("resolves from tank.json when no lockfile exists (first install)", async () => {
-    const { installAll } = await import("../commands/install.js");
+  it('resolves from tank.json when no lockfile exists (first install)', async () => {
+    const { installAll } = await import('../commands/install.js');
 
     // Write tank.json with a skill dependency
-    fs.writeFileSync(path.join(tmpDir, "tank.json"), JSON.stringify(validSkillsJson, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'tank.json'), JSON.stringify(validSkillsJson, null, 2));
 
     // No tank.lock — should resolve via registry
     // Mock the 3-step install flow for @test-org/my-skill
@@ -1568,17 +1568,17 @@ describe("installAll (no-args dispatch)", () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "2.0.0",
+          name: '@test-org/my-skill',
+          version: '2.0.0',
           integrity: fakeTarballIntegrity,
-          permissions: { network: { outbound: ["*.example.com"] } },
+          permissions: { network: { outbound: ['*.example.com'] } },
           auditScore: 7.0,
-          auditStatus: "published",
-          downloadUrl: "https://storage.example.com/my-skill-2.0.0.tgz",
-          publishedAt: "2026-02-01T00:00:00Z",
+          auditStatus: 'published',
+          downloadUrl: 'https://storage.example.com/my-skill-2.0.0.tgz',
+          publishedAt: '2026-02-01T00:00:00Z'
         }),
-        { status: 200 },
-      ),
+        { status: 200 }
+      )
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
@@ -1588,62 +1588,62 @@ describe("installAll (no-args dispatch)", () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
 
     // Lockfile should now exist (created by installCommand)
-    expect(fs.existsSync(path.join(tmpDir, "tank.lock"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'tank.lock'))).toBe(true);
   });
 });
 
-describe("installCommand — additional error paths", () => {
+describe('installCommand — additional error paths', () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   const versionsResponse = {
-    name: "@test-org/my-skill",
+    name: '@test-org/my-skill',
     versions: [
       {
-        version: "2.0.0",
-        integrity: "sha512-ghi789",
+        version: '2.0.0',
+        integrity: 'sha512-ghi789',
         auditScore: 7.0,
-        auditStatus: "published",
-        publishedAt: "2026-02-01T00:00:00Z",
-      },
-    ],
+        auditStatus: 'published',
+        publishedAt: '2026-02-01T00:00:00Z'
+      }
+    ]
   };
 
   const versionMetadata = {
-    name: "@test-org/my-skill",
-    version: "2.0.0",
-    description: "A test skill",
-    integrity: "sha512-placeholder",
+    name: '@test-org/my-skill',
+    version: '2.0.0',
+    description: 'A test skill',
+    integrity: 'sha512-placeholder',
     permissions: {},
     auditScore: 7.0,
-    auditStatus: "published",
-    downloadUrl: "https://storage.example.com/download/my-skill-2.0.0.tgz",
-    publishedAt: "2026-02-01T00:00:00Z",
+    auditStatus: 'published',
+    downloadUrl: 'https://storage.example.com/download/my-skill-2.0.0.tgz',
+    publishedAt: '2026-02-01T00:00:00Z'
   };
 
   let fakeTarball: Buffer;
   let fakeTarballIntegrity: string;
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-extra-test-"));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-install-extra-config-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-extra-test-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-install-extra-config-'));
 
-    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
 
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
-      JSON.stringify({ name: "my-project", version: "1.0.0", skills: {} }, null, 2),
+      path.join(tmpDir, 'tank.json'),
+      JSON.stringify({ name: 'my-project', version: '1.0.0', skills: {} }, null, 2)
     );
 
-    fakeTarball = Buffer.from("fake-tarball-content-for-extra-tests");
-    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
+    fakeTarball = Buffer.from('fake-tarball-content-for-extra-tests');
+    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
     fakeTarballIntegrity = `sha512-${hash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -1653,89 +1653,89 @@ describe("installCommand — additional error paths", () => {
     errorSpy.mockRestore();
   });
 
-  it("throws network error when fetch rejects on versions endpoint", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('throws network error when fetch rejects on versions endpoint', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
-    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED: Connection refused"));
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED: Connection refused'));
 
-    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).rejects.toThrow(
-      /network/i,
+    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).rejects.toThrow(
+      /network/i
     );
   });
 
-  it("throws when tarball download returns non-ok status", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('throws when tarball download returns non-ok status', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
     );
-    mockFetch.mockResolvedValueOnce(new Response("Not Found", { status: 404, statusText: "Not Found" }));
+    mockFetch.mockResolvedValueOnce(new Response('Not Found', { status: 404, statusText: 'Not Found' }));
 
     await expect(
-      installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir, homedir: tmpDir }),
+      installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir, homedir: tmpDir })
     ).rejects.toThrow(/404|download|failed/i);
   });
 
-  it("throws network error when fetch rejects on tarball download", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('throws network error when fetch rejects on tarball download', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
     );
-    mockFetch.mockRejectedValueOnce(new Error("Connection reset"));
+    mockFetch.mockRejectedValueOnce(new Error('Connection reset'));
 
     await expect(
-      installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir, homedir: tmpDir }),
+      installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir, homedir: tmpDir })
     ).rejects.toThrow(/network/i);
   });
 
-  it("recovers gracefully when tank.lock contains invalid JSON", async () => {
-    const { installCommand } = await import("../commands/install.js");
+  it('recovers gracefully when tank.lock contains invalid JSON', async () => {
+    const { installCommand } = await import('../commands/install.js');
 
-    fs.writeFileSync(path.join(tmpDir, "tank.lock"), "{ this is not valid json !!!");
+    fs.writeFileSync(path.join(tmpDir, 'tank.lock'), '{ this is not valid json !!!');
 
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(versionsResponse), { status: 200 }));
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 }),
+      new Response(JSON.stringify({ ...versionMetadata, integrity: fakeTarballIntegrity }), { status: 200 })
     );
     mockFetch.mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball), { status: 200 }));
 
-    await expect(installCommand({ name: "@test-org/my-skill", directory: tmpDir, configDir })).resolves.toBeUndefined();
+    await expect(installCommand({ name: '@test-org/my-skill', directory: tmpDir, configDir })).resolves.toBeUndefined();
 
-    const lockRaw = fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8");
+    const lockRaw = fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8');
     const lock = JSON.parse(lockRaw);
     expect(lock.lockfileVersion).toBe(2);
-    expect(lock.skills["@test-org/my-skill@2.0.0"]).toBeDefined();
+    expect(lock.skills['@test-org/my-skill@2.0.0']).toBeDefined();
   });
 
-  it("throws when tank.json contains invalid JSON (installAll)", async () => {
-    const { installAll } = await import("../commands/install.js");
+  it('throws when tank.json contains invalid JSON (installAll)', async () => {
+    const { installAll } = await import('../commands/install.js');
 
-    fs.writeFileSync(path.join(tmpDir, "tank.json"), "{ invalid json here !!!");
+    fs.writeFileSync(path.join(tmpDir, 'tank.json'), '{ invalid json here !!!');
 
     await expect(installAll({ directory: tmpDir, configDir })).rejects.toThrow(/tank\.json|parse/i);
   });
 
-  it("prints nothing-to-install message when tank.json has empty skills map", async () => {
-    const { installAll } = await import("../commands/install.js");
+  it('prints nothing-to-install message when tank.json has empty skills map', async () => {
+    const { installAll } = await import('../commands/install.js');
 
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
-      JSON.stringify({ name: "my-project", version: "1.0.0", skills: {} }, null, 2),
+      path.join(tmpDir, 'tank.json'),
+      JSON.stringify({ name: 'my-project', version: '1.0.0', skills: {} }, null, 2)
     );
 
     await installAll({ directory: tmpDir, configDir });
 
     expect(mockFetch).not.toHaveBeenCalled();
 
-    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(" ")).join("\n");
+    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls].map((c) => c.join(' ')).join('\n');
     expect(output).toMatch(/no skills|nothing to install/i);
   });
 });
 
-describe("installCommand — transitive dependency resolution", () => {
+describe('installCommand — transitive dependency resolution', () => {
   let tmpDir: string;
   let configDir: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -1747,60 +1747,60 @@ describe("installCommand — transitive dependency resolution", () => {
   let fakeDepTarballIntegrity: string;
 
   const primaryVersionsResponse = {
-    name: "@test-org/my-skill",
+    name: '@test-org/my-skill',
     versions: [
       {
-        version: "1.0.0",
-        integrity: "sha512-abc",
+        version: '1.0.0',
+        integrity: 'sha512-abc',
         auditScore: 8.0,
-        auditStatus: "published",
-        publishedAt: "2026-01-01T00:00:00Z",
-      },
-    ],
+        auditStatus: 'published',
+        publishedAt: '2026-01-01T00:00:00Z'
+      }
+    ]
   };
 
   const depVersionsResponse = {
-    name: "@dep/helper",
+    name: '@dep/helper',
     versions: [
       {
-        version: "1.0.0",
-        integrity: "sha512-dep1",
+        version: '1.0.0',
+        integrity: 'sha512-dep1',
         auditScore: 9.0,
-        auditStatus: "published",
-        publishedAt: "2026-01-01T00:00:00Z",
+        auditStatus: 'published',
+        publishedAt: '2026-01-01T00:00:00Z'
       },
       {
-        version: "1.1.0",
-        integrity: "sha512-dep2",
+        version: '1.1.0',
+        integrity: 'sha512-dep2',
         auditScore: 9.0,
-        auditStatus: "published",
-        publishedAt: "2026-01-15T00:00:00Z",
-      },
-    ],
+        auditStatus: 'published',
+        publishedAt: '2026-01-15T00:00:00Z'
+      }
+    ]
   };
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-transitive-test-"));
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), "tank-transitive-config-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-transitive-test-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-transitive-config-'));
 
-    fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ registry: "https://tankpkg.dev" }));
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
 
     fs.writeFileSync(
-      path.join(tmpDir, "tank.json"),
-      JSON.stringify({ name: "my-project", version: "1.0.0", skills: {} }, null, 2),
+      path.join(tmpDir, 'tank.json'),
+      JSON.stringify({ name: 'my-project', version: '1.0.0', skills: {} }, null, 2)
     );
 
-    fakeTarball = Buffer.from("fake-tarball-transitive-test");
-    const hash = crypto.createHash("sha512").update(fakeTarball).digest("base64");
+    fakeTarball = Buffer.from('fake-tarball-transitive-test');
+    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
     fakeTarballIntegrity = `sha512-${hash}`;
 
-    fakeDepTarball = Buffer.from("fake-tarball-transitive-dep-test");
-    const depHash = crypto.createHash("sha512").update(fakeDepTarball).digest("base64");
+    fakeDepTarball = Buffer.from('fake-tarball-transitive-dep-test');
+    const depHash = crypto.createHash('sha512').update(fakeDepTarball).digest('base64');
     fakeDepTarballIntegrity = `sha512-${depHash}`;
 
     mockFetch.mockReset();
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -1811,7 +1811,7 @@ describe("installCommand — transitive dependency resolution", () => {
   });
 
   function makeMeta(name: string, version: string) {
-    const integrity = name.startsWith("@dep/") ? fakeDepTarballIntegrity : fakeTarballIntegrity;
+    const integrity = name.startsWith('@dep/') ? fakeDepTarballIntegrity : fakeTarballIntegrity;
 
     return {
       name,
@@ -1820,27 +1820,27 @@ describe("installCommand — transitive dependency resolution", () => {
       integrity,
       permissions: {},
       auditScore: 8.0,
-      auditStatus: "published",
+      auditStatus: 'published',
       downloadUrl: `https://storage.example.com/${name}-${version}.tgz`,
-      publishedAt: "2026-01-01T00:00:00Z",
+      publishedAt: '2026-01-01T00:00:00Z'
     };
   }
 
-  it("installs transitive dependencies declared in extracted tank.json", async () => {
-    const { installCommand } = await import("../commands/install.js");
-    const { extract } = await import("tar");
+  it('installs transitive dependencies declared in extracted tank.json', async () => {
+    const { installCommand } = await import('../commands/install.js');
+    const { extract } = await import('tar');
 
     // Primary skill's extract writes a tank.json with a dependency
     vi.mocked(extract)
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, "tank.json"),
+          path.join(cwd, 'tank.json'),
           JSON.stringify({
-            name: "@test-org/my-skill",
-            version: "1.0.0",
-            skills: { "@dep/helper": "^1.0.0" },
-          }),
+            name: '@test-org/my-skill',
+            version: '1.0.0',
+            skills: { '@dep/helper': '^1.0.0' }
+          })
         );
       })
       .mockImplementationOnce(async () => {
@@ -1851,133 +1851,133 @@ describe("installCommand — transitive dependency resolution", () => {
     //                  dep versions, dep meta, dep tarball
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(depVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@dep/helper", "1.1.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@dep/helper', '1.1.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeDepTarball)));
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(6);
 
-    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8"));
-    expect(lock.skills["@test-org/my-skill@1.0.0"]).toBeDefined();
-    expect(lock.skills["@dep/helper@1.1.0"]).toBeDefined();
+    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8'));
+    expect(lock.skills['@test-org/my-skill@1.0.0']).toBeDefined();
+    expect(lock.skills['@dep/helper@1.1.0']).toBeDefined();
   });
 
-  it("does not add transitive deps to project tank.json", async () => {
-    const { installCommand } = await import("../commands/install.js");
-    const { extract } = await import("tar");
+  it('does not add transitive deps to project tank.json', async () => {
+    const { installCommand } = await import('../commands/install.js');
+    const { extract } = await import('tar');
 
     vi.mocked(extract)
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, "tank.json"),
+          path.join(cwd, 'tank.json'),
           JSON.stringify({
-            name: "@test-org/my-skill",
-            version: "1.0.0",
-            skills: { "@dep/helper": "^1.0.0" },
-          }),
+            name: '@test-org/my-skill',
+            version: '1.0.0',
+            skills: { '@dep/helper': '^1.0.0' }
+          })
         );
       })
       .mockImplementationOnce(async () => {});
 
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(depVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@dep/helper", "1.1.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@dep/helper', '1.1.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeDepTarball)));
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
-    const skillsJson = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.json"), "utf-8"));
-    expect(skillsJson.skills["@test-org/my-skill"]).toBe("^1.0.0");
-    expect(skillsJson.skills["@dep/helper"]).toBeUndefined();
+    const skillsJson = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.json'), 'utf-8'));
+    expect(skillsJson.skills['@test-org/my-skill']).toBe('^1.0.0');
+    expect(skillsJson.skills['@dep/helper']).toBeUndefined();
   });
 
-  it("skips already-installed transitive deps", async () => {
-    const { installCommand } = await import("../commands/install.js");
-    const { extract } = await import("tar");
+  it('skips already-installed transitive deps', async () => {
+    const { installCommand } = await import('../commands/install.js');
+    const { extract } = await import('tar');
 
     // Pre-populate lockfile with the dependency already installed
     fs.writeFileSync(
-      path.join(tmpDir, "tank.lock"),
+      path.join(tmpDir, 'tank.lock'),
       JSON.stringify(
         {
           lockfileVersion: 1,
           skills: {
-            "@dep/helper@1.1.0": {
-              resolved: "https://storage.example.com/dep-helper-1.1.0.tgz",
+            '@dep/helper@1.1.0': {
+              resolved: 'https://storage.example.com/dep-helper-1.1.0.tgz',
               integrity: fakeTarballIntegrity,
               permissions: {},
-              audit_score: 9.0,
-            },
-          },
+              audit_score: 9.0
+            }
+          }
         },
         null,
-        2,
-      ),
+        2
+      )
     );
 
     vi.mocked(extract).mockImplementationOnce(async (opts: unknown) => {
       const { cwd } = opts as { cwd: string };
       fs.writeFileSync(
-        path.join(cwd, "tank.json"),
+        path.join(cwd, 'tank.json'),
         JSON.stringify({
-          name: "@test-org/my-skill",
-          version: "1.0.0",
-          skills: { "@dep/helper": "^1.0.0" },
-        }),
+          name: '@test-org/my-skill',
+          version: '1.0.0',
+          skills: { '@dep/helper': '^1.0.0' }
+        })
       );
     });
 
     // Primary: 3 fetches. Dep: only versions fetch (then skipped as already installed)
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(depVersionsResponse)));
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     // 3 for primary + 1 versions fetch for dep (skipped after resolution)
     expect(mockFetch).toHaveBeenCalledTimes(4);
   });
 
-  it("handles circular dependencies without infinite recursion", async () => {
-    const { installCommand } = await import("../commands/install.js");
-    const { extract } = await import("tar");
+  it('handles circular dependencies without infinite recursion', async () => {
+    const { installCommand } = await import('../commands/install.js');
+    const { extract } = await import('tar');
 
     const circularDepVersions = {
-      name: "@dep/circular",
+      name: '@dep/circular',
       versions: [
         {
-          version: "1.0.0",
-          integrity: "sha512-circ",
+          version: '1.0.0',
+          integrity: 'sha512-circ',
           auditScore: 8.0,
-          auditStatus: "published",
-          publishedAt: "2026-01-01T00:00:00Z",
-        },
-      ],
+          auditStatus: 'published',
+          publishedAt: '2026-01-01T00:00:00Z'
+        }
+      ]
     };
 
     // Primary depends on @dep/circular, @dep/circular depends back on primary
@@ -1985,23 +1985,23 @@ describe("installCommand — transitive dependency resolution", () => {
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, "tank.json"),
+          path.join(cwd, 'tank.json'),
           JSON.stringify({
-            name: "@test-org/my-skill",
-            version: "1.0.0",
-            skills: { "@dep/circular": "^1.0.0" },
-          }),
+            name: '@test-org/my-skill',
+            version: '1.0.0',
+            skills: { '@dep/circular': '^1.0.0' }
+          })
         );
       })
       .mockImplementationOnce(async (opts: unknown) => {
         const { cwd } = opts as { cwd: string };
         fs.writeFileSync(
-          path.join(cwd, "tank.json"),
+          path.join(cwd, 'tank.json'),
           JSON.stringify({
-            name: "@dep/circular",
-            version: "1.0.0",
-            skills: { "@test-org/my-skill": "^1.0.0" },
-          }),
+            name: '@dep/circular',
+            version: '1.0.0',
+            skills: { '@test-org/my-skill': '^1.0.0' }
+          })
         );
       });
 
@@ -2010,48 +2010,48 @@ describe("installCommand — transitive dependency resolution", () => {
     // @test-org/my-skill (cycle): versions fetch → already in lockfile → skip
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(circularDepVersions)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@dep/circular", "1.0.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@dep/circular', '1.0.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeDepTarball)))
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)));
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     // 3 primary + 3 dep + 1 cycle detection = 7
     expect(mockFetch).toHaveBeenCalledTimes(7);
 
-    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, "tank.lock"), "utf-8"));
-    expect(lock.skills["@test-org/my-skill@1.0.0"]).toBeDefined();
-    expect(lock.skills["@dep/circular@1.0.0"]).toBeDefined();
+    const lock = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tank.lock'), 'utf-8'));
+    expect(lock.skills['@test-org/my-skill@1.0.0']).toBeDefined();
+    expect(lock.skills['@dep/circular@1.0.0']).toBeDefined();
   });
 
-  it("works normally when skill has no dependencies", async () => {
-    const { installCommand } = await import("../commands/install.js");
-    const { extract } = await import("tar");
+  it('works normally when skill has no dependencies', async () => {
+    const { installCommand } = await import('../commands/install.js');
+    const { extract } = await import('tar');
 
     // Extract writes a tank.json with no skills field
     vi.mocked(extract).mockImplementationOnce(async (opts: unknown) => {
       const { cwd } = opts as { cwd: string };
-      fs.writeFileSync(path.join(cwd, "tank.json"), JSON.stringify({ name: "@test-org/my-skill", version: "1.0.0" }));
+      fs.writeFileSync(path.join(cwd, 'tank.json'), JSON.stringify({ name: '@test-org/my-skill', version: '1.0.0' }));
     });
 
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify(primaryVersionsResponse)))
-      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta("@test-org/my-skill", "1.0.0"))))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0'))))
       .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)));
 
     await installCommand({
-      name: "@test-org/my-skill",
+      name: '@test-org/my-skill',
       directory: tmpDir,
       configDir,
-      homedir: tmpDir,
+      homedir: tmpDir
     });
 
     // Only 3 fetches for the primary skill

--- a/packages/cli/src/bin/tank.ts
+++ b/packages/cli/src/bin/tank.ts
@@ -1,41 +1,42 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
-import { auditCommand } from '../commands/audit.js';
-import { doctorCommand } from '../commands/doctor.js';
-import { infoCommand } from '../commands/info.js';
-import { initCommand } from '../commands/init.js';
-import { installAll, installCommand } from '../commands/install.js';
-import { linkCommand } from '../commands/link.js';
-import { loginCommand } from '../commands/login.js';
-import { logoutCommand } from '../commands/logout.js';
-import { migrateCommand } from '../commands/migrate.js';
-import { permissionsCommand } from '../commands/permissions.js';
-import { publishCommand } from '../commands/publish.js';
-import { removeCommand } from '../commands/remove.js';
-import { scanCommand } from '../commands/scan.js';
-import { searchCommand } from '../commands/search.js';
-import { unlinkCommand } from '../commands/unlink.js';
-import { updateCommand } from '../commands/update.js';
-import { upgradeCommand } from '../commands/upgrade.js';
-import { verifyCommand } from '../commands/verify.js';
-import { whoamiCommand } from '../commands/whoami.js';
-import { flushLogs } from '../lib/debug-logger.js';
-import { checkForUpgrade } from '../lib/upgrade-check.js';
-import { VERSION } from '../version.js';
+import { Command } from "commander";
+import { auditCommand } from "../commands/audit.js";
+import { cacheCleanCommand } from "../commands/cache.js";
+import { doctorCommand } from "../commands/doctor.js";
+import { infoCommand } from "../commands/info.js";
+import { initCommand } from "../commands/init.js";
+import { installAll, installCommand } from "../commands/install.js";
+import { linkCommand } from "../commands/link.js";
+import { loginCommand } from "../commands/login.js";
+import { logoutCommand } from "../commands/logout.js";
+import { migrateCommand } from "../commands/migrate.js";
+import { permissionsCommand } from "../commands/permissions.js";
+import { publishCommand } from "../commands/publish.js";
+import { removeCommand } from "../commands/remove.js";
+import { scanCommand } from "../commands/scan.js";
+import { searchCommand } from "../commands/search.js";
+import { unlinkCommand } from "../commands/unlink.js";
+import { updateCommand } from "../commands/update.js";
+import { upgradeCommand } from "../commands/upgrade.js";
+import { verifyCommand } from "../commands/verify.js";
+import { whoamiCommand } from "../commands/whoami.js";
+import { flushLogs } from "../lib/debug-logger.js";
+import { checkForUpgrade } from "../lib/upgrade-check.js";
+import { VERSION } from "../version.js";
 
 const program = new Command();
 
-program.name('tank').description('Security-first package manager for AI agent skills').version(VERSION);
+program.name("tank").description("Security-first package manager for AI agent skills").version(VERSION);
 
 program
-  .command('init')
-  .description('Create a new tank.json in the current directory')
-  .option('-y, --yes', 'Skip prompts, use defaults')
-  .option('--name <name>', 'Skill name')
-  .option('--skill-version <version>', 'Skill version (default: 0.1.0)')
-  .option('--description <desc>', 'Skill description')
-  .option('--private', 'Make skill private')
-  .option('--force', 'Overwrite existing tank.json')
+  .command("init")
+  .description("Create a new tank.json in the current directory")
+  .option("-y, --yes", "Skip prompts, use defaults")
+  .option("--name <name>", "Skill name")
+  .option("--skill-version <version>", "Skill version (default: 0.1.0)")
+  .option("--description <desc>", "Skill description")
+  .option("--private", "Make skill private")
+  .option("--force", "Overwrite existing tank.json")
   .action(
     async (opts: {
       yes?: boolean;
@@ -52,19 +53,19 @@ program
           version: opts.skillVersion,
           description: opts.description,
           private: opts.private,
-          force: opts.force
+          force: opts.force,
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`Init failed: ${msg}`);
         process.exit(1);
       }
-    }
+    },
   );
 
 program
-  .command('login')
-  .description('Authenticate with the Tank registry via browser')
+  .command("login")
+  .description("Authenticate with the Tank registry via browser")
   .action(async () => {
     try {
       await loginCommand();
@@ -78,8 +79,8 @@ program
   });
 
 program
-  .command('whoami')
-  .description('Show the currently logged-in user')
+  .command("whoami")
+  .description("Show the currently logged-in user")
   .action(async () => {
     try {
       await whoamiCommand();
@@ -91,8 +92,8 @@ program
   });
 
 program
-  .command('logout')
-  .description('Remove authentication token from config')
+  .command("logout")
+  .description("Remove authentication token from config")
   .action(async () => {
     try {
       await logoutCommand();
@@ -104,18 +105,18 @@ program
   });
 
 program
-  .command('publish')
-  .alias('pub')
-  .description('Pack and publish a skill to the Tank registry')
-  .option('--dry-run', 'Validate and pack without uploading')
-  .option('--private', 'Publish skill as private')
-  .option('--visibility <mode>', 'Skill visibility (public|private)')
+  .command("publish")
+  .alias("pub")
+  .description("Pack and publish a skill to the Tank registry")
+  .option("--dry-run", "Validate and pack without uploading")
+  .option("--private", "Publish skill as private")
+  .option("--visibility <mode>", "Skill visibility (public|private)")
   .action(async (opts: { dryRun?: boolean; private?: boolean; visibility?: string }) => {
     try {
       await publishCommand({
         dryRun: opts.dryRun,
         private: opts.private,
-        visibility: opts.visibility
+        visibility: opts.visibility,
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -125,13 +126,13 @@ program
   });
 
 program
-  .command('install')
-  .alias('i')
-  .description('Install a skill from the Tank registry, or all skills from lockfile')
-  .argument('[name]', 'Skill name (e.g., @org/skill-name). Omit to install from lockfile.')
-  .argument('[version-range]', 'Semver range (default: *)', '*')
-  .option('-g, --global', 'Install skill globally (available to all projects)')
-  .option('-y, --yes', 'Auto-accept permission budget expansion')
+  .command("install")
+  .alias("i")
+  .description("Install a skill from the Tank registry, or all skills from lockfile")
+  .argument("[name]", "Skill name (e.g., @org/skill-name). Omit to install from lockfile.")
+  .argument("[version-range]", "Semver range (default: *)", "*")
+  .option("-g, --global", "Install skill globally (available to all projects)")
+  .option("-y, --yes", "Auto-accept permission budget expansion")
   .action(async (name: string | undefined, versionRange: string, opts: { global?: boolean; yes?: boolean }) => {
     try {
       if (name) {
@@ -147,11 +148,11 @@ program
   });
 
 program
-  .command('remove')
-  .aliases(['rm', 'r'])
-  .description('Remove an installed skill')
-  .argument('<name>', 'Skill name (e.g., @org/skill-name)')
-  .option('-g, --global', 'Remove a globally installed skill')
+  .command("remove")
+  .aliases(["rm", "r"])
+  .description("Remove an installed skill")
+  .argument("<name>", "Skill name (e.g., @org/skill-name)")
+  .option("-g, --global", "Remove a globally installed skill")
   .action(async (name: string, opts: { global?: boolean }) => {
     try {
       await removeCommand({ name, global: opts.global });
@@ -163,11 +164,11 @@ program
   });
 
 program
-  .command('update')
-  .alias('up')
-  .description('Update skills to latest versions within their ranges')
-  .argument('[name]', 'Skill name to update (omit to update all)')
-  .option('-g, --global', 'Update globally installed skills')
+  .command("update")
+  .alias("up")
+  .description("Update skills to latest versions within their ranges")
+  .argument("[name]", "Skill name to update (omit to update all)")
+  .option("-g, --global", "Update globally installed skills")
   .action(async (name: string | undefined, opts: { global?: boolean }) => {
     try {
       await updateCommand({ name, global: opts.global });
@@ -179,8 +180,8 @@ program
   });
 
 program
-  .command('verify')
-  .description('Verify installed skills match the lockfile')
+  .command("verify")
+  .description("Verify installed skills match the lockfile")
   .action(async () => {
     try {
       await verifyCommand();
@@ -192,9 +193,9 @@ program
   });
 
 program
-  .command('permissions')
-  .alias('perms')
-  .description('Display resolved permission summary for installed skills')
+  .command("permissions")
+  .alias("perms")
+  .description("Display resolved permission summary for installed skills")
   .action(async () => {
     try {
       await permissionsCommand();
@@ -206,10 +207,10 @@ program
   });
 
 program
-  .command('search')
-  .alias('s')
-  .description('Search for skills in the Tank registry')
-  .argument('<query>', 'Search query')
+  .command("search")
+  .alias("s")
+  .description("Search for skills in the Tank registry")
+  .argument("<query>", "Search query")
   .action(async (query: string) => {
     try {
       await searchCommand({ query });
@@ -221,10 +222,10 @@ program
   });
 
 program
-  .command('info')
-  .alias('show')
-  .description('Show detailed information about a skill')
-  .argument('<name>', 'Skill name (e.g., @org/skill-name)')
+  .command("info")
+  .alias("show")
+  .description("Show detailed information about a skill")
+  .argument("<name>", "Skill name (e.g., @org/skill-name)")
   .action(async (name: string) => {
     try {
       await infoCommand({ name });
@@ -236,9 +237,9 @@ program
   });
 
 program
-  .command('audit')
-  .description('Display security audit results for installed skills')
-  .argument('[name]', 'Skill name to audit (omit to audit all)')
+  .command("audit")
+  .description("Display security audit results for installed skills")
+  .argument("[name]", "Skill name to audit (omit to audit all)")
   .action(async (name: string | undefined) => {
     try {
       await auditCommand({ name });
@@ -250,9 +251,9 @@ program
   });
 
 program
-  .command('scan')
-  .description('Scan a local skill for security issues without publishing')
-  .option('-d, --directory <path>', 'Directory to scan (default: current directory)')
+  .command("scan")
+  .description("Scan a local skill for security issues without publishing")
+  .option("-d, --directory <path>", "Directory to scan (default: current directory)")
   .action(async (opts: { directory?: string }) => {
     try {
       await scanCommand({ directory: opts.directory });
@@ -264,11 +265,11 @@ program
   });
 
 program
-  .command('link')
-  .alias('ln')
-  .description('Link current skill to all detected AI agents for local development')
+  .command("link")
+  .alias("ln")
+  .description("Link current skill to all detected AI agents for local development")
   .addHelpText(
-    'after',
+    "after",
     `
 Creates symlinks from each agent's skills directory to this skill source,
 so changes are reflected immediately without re-publishing.
@@ -288,7 +289,7 @@ Examples:
   $ tank doctor                  Verify link health
   $ tank unlink                  Remove all symlinks
 
-See also: tank unlink, tank doctor`
+See also: tank unlink, tank doctor`,
   )
   .action(async () => {
     try {
@@ -301,10 +302,10 @@ See also: tank unlink, tank doctor`
   });
 
 program
-  .command('unlink')
-  .description('Remove skill symlinks from all AI agent directories')
+  .command("unlink")
+  .description("Remove skill symlinks from all AI agent directories")
   .addHelpText(
-    'after',
+    "after",
     `
 Removes the symlinks created by \`tank link\` from every detected agent.
 Must be run from the same skill directory that was originally linked.
@@ -312,7 +313,7 @@ Must be run from the same skill directory that was originally linked.
 Examples:
   $ cd my-skill && tank unlink   Remove links for this skill
 
-See also: tank link, tank doctor`
+See also: tank link, tank doctor`,
   )
   .action(async () => {
     try {
@@ -325,8 +326,23 @@ See also: tank link, tank doctor`
   });
 
 program
-  .command('doctor')
-  .description('Diagnose agent integration health')
+  .command("cache")
+  .description("Manage global tarball cache")
+  .command("clean")
+  .description("Delete all files from ~/.tank/cache")
+  .action(async () => {
+    try {
+      await cacheCleanCommand();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Cache clean failed: ${msg}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("doctor")
+  .description("Diagnose agent integration health")
   .action(async () => {
     try {
       await doctorCommand();
@@ -338,8 +354,8 @@ program
   });
 
 program
-  .command('migrate')
-  .description('Migrate skills.json → tank.json and skills.lock → tank.lock')
+  .command("migrate")
+  .description("Migrate skills.json → tank.json and skills.lock → tank.lock")
   .action(async () => {
     try {
       await migrateCommand();
@@ -351,11 +367,11 @@ program
   });
 
 program
-  .command('upgrade')
-  .description('Update tank to the latest version')
-  .argument('[version]', 'Target version (default: latest)')
-  .option('--dry-run', 'Check for updates without installing')
-  .option('--force', 'Reinstall even if already on the target version')
+  .command("upgrade")
+  .description("Update tank to the latest version")
+  .argument("[version]", "Target version (default: latest)")
+  .option("--dry-run", "Check for updates without installing")
+  .option("--force", "Reinstall even if already on the target version")
   .action(async (version: string | undefined, opts: { dryRun?: boolean; force?: boolean }) => {
     try {
       await upgradeCommand({ version, dryRun: opts.dryRun, force: opts.force });

--- a/packages/cli/src/bin/tank.ts
+++ b/packages/cli/src/bin/tank.ts
@@ -1,42 +1,42 @@
 #!/usr/bin/env node
-import { Command } from "commander";
-import { auditCommand } from "../commands/audit.js";
-import { cacheCleanCommand } from "../commands/cache.js";
-import { doctorCommand } from "../commands/doctor.js";
-import { infoCommand } from "../commands/info.js";
-import { initCommand } from "../commands/init.js";
-import { installAll, installCommand } from "../commands/install.js";
-import { linkCommand } from "../commands/link.js";
-import { loginCommand } from "../commands/login.js";
-import { logoutCommand } from "../commands/logout.js";
-import { migrateCommand } from "../commands/migrate.js";
-import { permissionsCommand } from "../commands/permissions.js";
-import { publishCommand } from "../commands/publish.js";
-import { removeCommand } from "../commands/remove.js";
-import { scanCommand } from "../commands/scan.js";
-import { searchCommand } from "../commands/search.js";
-import { unlinkCommand } from "../commands/unlink.js";
-import { updateCommand } from "../commands/update.js";
-import { upgradeCommand } from "../commands/upgrade.js";
-import { verifyCommand } from "../commands/verify.js";
-import { whoamiCommand } from "../commands/whoami.js";
-import { flushLogs } from "../lib/debug-logger.js";
-import { checkForUpgrade } from "../lib/upgrade-check.js";
-import { VERSION } from "../version.js";
+import { Command } from 'commander';
+import { auditCommand } from '../commands/audit.js';
+import { cacheCleanCommand } from '../commands/cache.js';
+import { doctorCommand } from '../commands/doctor.js';
+import { infoCommand } from '../commands/info.js';
+import { initCommand } from '../commands/init.js';
+import { installAll, installCommand } from '../commands/install.js';
+import { linkCommand } from '../commands/link.js';
+import { loginCommand } from '../commands/login.js';
+import { logoutCommand } from '../commands/logout.js';
+import { migrateCommand } from '../commands/migrate.js';
+import { permissionsCommand } from '../commands/permissions.js';
+import { publishCommand } from '../commands/publish.js';
+import { removeCommand } from '../commands/remove.js';
+import { scanCommand } from '../commands/scan.js';
+import { searchCommand } from '../commands/search.js';
+import { unlinkCommand } from '../commands/unlink.js';
+import { updateCommand } from '../commands/update.js';
+import { upgradeCommand } from '../commands/upgrade.js';
+import { verifyCommand } from '../commands/verify.js';
+import { whoamiCommand } from '../commands/whoami.js';
+import { flushLogs } from '../lib/debug-logger.js';
+import { checkForUpgrade } from '../lib/upgrade-check.js';
+import { VERSION } from '../version.js';
 
 const program = new Command();
 
-program.name("tank").description("Security-first package manager for AI agent skills").version(VERSION);
+program.name('tank').description('Security-first package manager for AI agent skills').version(VERSION);
 
 program
-  .command("init")
-  .description("Create a new tank.json in the current directory")
-  .option("-y, --yes", "Skip prompts, use defaults")
-  .option("--name <name>", "Skill name")
-  .option("--skill-version <version>", "Skill version (default: 0.1.0)")
-  .option("--description <desc>", "Skill description")
-  .option("--private", "Make skill private")
-  .option("--force", "Overwrite existing tank.json")
+  .command('init')
+  .description('Create a new tank.json in the current directory')
+  .option('-y, --yes', 'Skip prompts, use defaults')
+  .option('--name <name>', 'Skill name')
+  .option('--skill-version <version>', 'Skill version (default: 0.1.0)')
+  .option('--description <desc>', 'Skill description')
+  .option('--private', 'Make skill private')
+  .option('--force', 'Overwrite existing tank.json')
   .action(
     async (opts: {
       yes?: boolean;
@@ -53,19 +53,19 @@ program
           version: opts.skillVersion,
           description: opts.description,
           private: opts.private,
-          force: opts.force,
+          force: opts.force
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`Init failed: ${msg}`);
         process.exit(1);
       }
-    },
+    }
   );
 
 program
-  .command("login")
-  .description("Authenticate with the Tank registry via browser")
+  .command('login')
+  .description('Authenticate with the Tank registry via browser')
   .action(async () => {
     try {
       await loginCommand();
@@ -79,8 +79,8 @@ program
   });
 
 program
-  .command("whoami")
-  .description("Show the currently logged-in user")
+  .command('whoami')
+  .description('Show the currently logged-in user')
   .action(async () => {
     try {
       await whoamiCommand();
@@ -92,8 +92,8 @@ program
   });
 
 program
-  .command("logout")
-  .description("Remove authentication token from config")
+  .command('logout')
+  .description('Remove authentication token from config')
   .action(async () => {
     try {
       await logoutCommand();
@@ -105,18 +105,18 @@ program
   });
 
 program
-  .command("publish")
-  .alias("pub")
-  .description("Pack and publish a skill to the Tank registry")
-  .option("--dry-run", "Validate and pack without uploading")
-  .option("--private", "Publish skill as private")
-  .option("--visibility <mode>", "Skill visibility (public|private)")
+  .command('publish')
+  .alias('pub')
+  .description('Pack and publish a skill to the Tank registry')
+  .option('--dry-run', 'Validate and pack without uploading')
+  .option('--private', 'Publish skill as private')
+  .option('--visibility <mode>', 'Skill visibility (public|private)')
   .action(async (opts: { dryRun?: boolean; private?: boolean; visibility?: string }) => {
     try {
       await publishCommand({
         dryRun: opts.dryRun,
         private: opts.private,
-        visibility: opts.visibility,
+        visibility: opts.visibility
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -126,13 +126,13 @@ program
   });
 
 program
-  .command("install")
-  .alias("i")
-  .description("Install a skill from the Tank registry, or all skills from lockfile")
-  .argument("[name]", "Skill name (e.g., @org/skill-name). Omit to install from lockfile.")
-  .argument("[version-range]", "Semver range (default: *)", "*")
-  .option("-g, --global", "Install skill globally (available to all projects)")
-  .option("-y, --yes", "Auto-accept permission budget expansion")
+  .command('install')
+  .alias('i')
+  .description('Install a skill from the Tank registry, or all skills from lockfile')
+  .argument('[name]', 'Skill name (e.g., @org/skill-name). Omit to install from lockfile.')
+  .argument('[version-range]', 'Semver range (default: *)', '*')
+  .option('-g, --global', 'Install skill globally (available to all projects)')
+  .option('-y, --yes', 'Auto-accept permission budget expansion')
   .action(async (name: string | undefined, versionRange: string, opts: { global?: boolean; yes?: boolean }) => {
     try {
       if (name) {
@@ -148,11 +148,11 @@ program
   });
 
 program
-  .command("remove")
-  .aliases(["rm", "r"])
-  .description("Remove an installed skill")
-  .argument("<name>", "Skill name (e.g., @org/skill-name)")
-  .option("-g, --global", "Remove a globally installed skill")
+  .command('remove')
+  .aliases(['rm', 'r'])
+  .description('Remove an installed skill')
+  .argument('<name>', 'Skill name (e.g., @org/skill-name)')
+  .option('-g, --global', 'Remove a globally installed skill')
   .action(async (name: string, opts: { global?: boolean }) => {
     try {
       await removeCommand({ name, global: opts.global });
@@ -164,11 +164,11 @@ program
   });
 
 program
-  .command("update")
-  .alias("up")
-  .description("Update skills to latest versions within their ranges")
-  .argument("[name]", "Skill name to update (omit to update all)")
-  .option("-g, --global", "Update globally installed skills")
+  .command('update')
+  .alias('up')
+  .description('Update skills to latest versions within their ranges')
+  .argument('[name]', 'Skill name to update (omit to update all)')
+  .option('-g, --global', 'Update globally installed skills')
   .action(async (name: string | undefined, opts: { global?: boolean }) => {
     try {
       await updateCommand({ name, global: opts.global });
@@ -180,8 +180,8 @@ program
   });
 
 program
-  .command("verify")
-  .description("Verify installed skills match the lockfile")
+  .command('verify')
+  .description('Verify installed skills match the lockfile')
   .action(async () => {
     try {
       await verifyCommand();
@@ -193,9 +193,9 @@ program
   });
 
 program
-  .command("permissions")
-  .alias("perms")
-  .description("Display resolved permission summary for installed skills")
+  .command('permissions')
+  .alias('perms')
+  .description('Display resolved permission summary for installed skills')
   .action(async () => {
     try {
       await permissionsCommand();
@@ -207,10 +207,10 @@ program
   });
 
 program
-  .command("search")
-  .alias("s")
-  .description("Search for skills in the Tank registry")
-  .argument("<query>", "Search query")
+  .command('search')
+  .alias('s')
+  .description('Search for skills in the Tank registry')
+  .argument('<query>', 'Search query')
   .action(async (query: string) => {
     try {
       await searchCommand({ query });
@@ -222,10 +222,10 @@ program
   });
 
 program
-  .command("info")
-  .alias("show")
-  .description("Show detailed information about a skill")
-  .argument("<name>", "Skill name (e.g., @org/skill-name)")
+  .command('info')
+  .alias('show')
+  .description('Show detailed information about a skill')
+  .argument('<name>', 'Skill name (e.g., @org/skill-name)')
   .action(async (name: string) => {
     try {
       await infoCommand({ name });
@@ -237,9 +237,9 @@ program
   });
 
 program
-  .command("audit")
-  .description("Display security audit results for installed skills")
-  .argument("[name]", "Skill name to audit (omit to audit all)")
+  .command('audit')
+  .description('Display security audit results for installed skills')
+  .argument('[name]', 'Skill name to audit (omit to audit all)')
   .action(async (name: string | undefined) => {
     try {
       await auditCommand({ name });
@@ -251,9 +251,9 @@ program
   });
 
 program
-  .command("scan")
-  .description("Scan a local skill for security issues without publishing")
-  .option("-d, --directory <path>", "Directory to scan (default: current directory)")
+  .command('scan')
+  .description('Scan a local skill for security issues without publishing')
+  .option('-d, --directory <path>', 'Directory to scan (default: current directory)')
   .action(async (opts: { directory?: string }) => {
     try {
       await scanCommand({ directory: opts.directory });
@@ -265,11 +265,11 @@ program
   });
 
 program
-  .command("link")
-  .alias("ln")
-  .description("Link current skill to all detected AI agents for local development")
+  .command('link')
+  .alias('ln')
+  .description('Link current skill to all detected AI agents for local development')
   .addHelpText(
-    "after",
+    'after',
     `
 Creates symlinks from each agent's skills directory to this skill source,
 so changes are reflected immediately without re-publishing.
@@ -289,7 +289,7 @@ Examples:
   $ tank doctor                  Verify link health
   $ tank unlink                  Remove all symlinks
 
-See also: tank unlink, tank doctor`,
+See also: tank unlink, tank doctor`
   )
   .action(async () => {
     try {
@@ -302,10 +302,10 @@ See also: tank unlink, tank doctor`,
   });
 
 program
-  .command("unlink")
-  .description("Remove skill symlinks from all AI agent directories")
+  .command('unlink')
+  .description('Remove skill symlinks from all AI agent directories')
   .addHelpText(
-    "after",
+    'after',
     `
 Removes the symlinks created by \`tank link\` from every detected agent.
 Must be run from the same skill directory that was originally linked.
@@ -313,7 +313,7 @@ Must be run from the same skill directory that was originally linked.
 Examples:
   $ cd my-skill && tank unlink   Remove links for this skill
 
-See also: tank link, tank doctor`,
+See also: tank link, tank doctor`
   )
   .action(async () => {
     try {
@@ -326,10 +326,10 @@ See also: tank link, tank doctor`,
   });
 
 program
-  .command("cache")
-  .description("Manage global tarball cache")
-  .command("clean")
-  .description("Delete all files from ~/.tank/cache")
+  .command('cache')
+  .description('Manage global tarball cache')
+  .command('clean')
+  .description('Delete all files from ~/.tank/cache')
   .action(async () => {
     try {
       await cacheCleanCommand();
@@ -341,8 +341,8 @@ program
   });
 
 program
-  .command("doctor")
-  .description("Diagnose agent integration health")
+  .command('doctor')
+  .description('Diagnose agent integration health')
   .action(async () => {
     try {
       await doctorCommand();
@@ -354,8 +354,8 @@ program
   });
 
 program
-  .command("migrate")
-  .description("Migrate skills.json → tank.json and skills.lock → tank.lock")
+  .command('migrate')
+  .description('Migrate skills.json → tank.json and skills.lock → tank.lock')
   .action(async () => {
     try {
       await migrateCommand();
@@ -367,11 +367,11 @@ program
   });
 
 program
-  .command("upgrade")
-  .description("Update tank to the latest version")
-  .argument("[version]", "Target version (default: latest)")
-  .option("--dry-run", "Check for updates without installing")
-  .option("--force", "Reinstall even if already on the target version")
+  .command('upgrade')
+  .description('Update tank to the latest version')
+  .argument('[version]', 'Target version (default: latest)')
+  .option('--dry-run', 'Check for updates without installing')
+  .option('--force', 'Reinstall even if already on the target version')
   .action(async (version: string | undefined, opts: { dryRun?: boolean; force?: boolean }) => {
     try {
       await upgradeCommand({ version, dryRun: opts.dryRun, force: opts.force });

--- a/packages/cli/src/commands/cache.ts
+++ b/packages/cli/src/commands/cache.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
-import os from "node:os";
-import { getGlobalCacheDir } from "../lib/install-pipeline.js";
-import { logger } from "../lib/logger.js";
+import fs from 'node:fs';
+import os from 'node:os';
+import { getGlobalCacheDir } from '../lib/install-pipeline.js';
+import { logger } from '../lib/logger.js';
 
 export interface CacheCleanOptions {
   homedir?: string;
@@ -12,10 +12,10 @@ export async function cacheCleanCommand(options: CacheCleanOptions = {}): Promis
   const cacheDir = getGlobalCacheDir(resolvedHome);
 
   if (!fs.existsSync(cacheDir)) {
-    logger.info("Cache is already clean");
+    logger.info('Cache is already clean');
     return;
   }
 
   fs.rmSync(cacheDir, { recursive: true, force: true });
-  logger.success("Cache cleaned");
+  logger.success('Cache cleaned');
 }

--- a/packages/cli/src/commands/cache.ts
+++ b/packages/cli/src/commands/cache.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+import os from "node:os";
+import { getGlobalCacheDir } from "../lib/install-pipeline.js";
+import { logger } from "../lib/logger.js";
+
+export interface CacheCleanOptions {
+  homedir?: string;
+}
+
+export async function cacheCleanCommand(options: CacheCleanOptions = {}): Promise<void> {
+  const resolvedHome = options.homedir ?? os.homedir();
+  const cacheDir = getGlobalCacheDir(resolvedHome);
+
+  if (!fs.existsSync(cacheDir)) {
+    logger.info("Cache is already clean");
+    return;
+  }
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  logger.success("Cache cleaned");
+}

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,29 +1,29 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
   LOCKFILE_FILENAME,
   LOCKFILE_VERSION,
   MANIFEST_FILENAME,
   type Permissions,
   resolve,
-  type SkillsLock,
-} from "@internal/shared";
-import ora from "ora";
-import { detectInstalledAgents, getGlobalAgentSkillsDir, getGlobalSkillsDir } from "../lib/agents.js";
-import { getConfig } from "../lib/config.js";
+  type SkillsLock
+} from '@internal/shared';
+import ora from 'ora';
+import { detectInstalledAgents, getGlobalAgentSkillsDir, getGlobalSkillsDir } from '../lib/agents.js';
+import { getConfig } from '../lib/config.js';
 import {
   buildSkillKey,
   type RegistryFetcher,
   type RegistrySkillMeta,
   type RegistryVersionInfo,
   type ResolvedNode,
-  resolveDependencyTree,
-} from "../lib/dependency-resolver.js";
-import { prepareAgentSkillDir } from "../lib/frontmatter.js";
+  resolveDependencyTree
+} from '../lib/dependency-resolver.js';
+import { prepareAgentSkillDir } from '../lib/frontmatter.js';
 import {
-  downloadTarballWithCache,
   downloadAllParallel,
+  downloadTarballWithCache,
   extractSafely,
   getExtractDir,
   getGlobalCacheDir,
@@ -33,14 +33,14 @@ import {
   parseVersionFromLockKey,
   readExtractedDependencies,
   verifyExtractedDependencies,
-  writeLockfileWithResolvedGraph,
-} from "../lib/install-pipeline.js";
-import { linkSkillToAgents } from "../lib/linker.js";
-import { logger } from "../lib/logger.js";
-import { resolveLockfilePath, resolveManifestPath } from "../lib/manifest.js";
-import { collectPermissionViolations } from "../lib/permission-checker.js";
-import { mergePermissionsIntoBudget, promptForPermissionExpansion } from "../lib/permission-prompt.js";
-import { USER_AGENT } from "../version.js";
+  writeLockfileWithResolvedGraph
+} from '../lib/install-pipeline.js';
+import { linkSkillToAgents } from '../lib/linker.js';
+import { logger } from '../lib/logger.js';
+import { resolveLockfilePath, resolveManifestPath } from '../lib/manifest.js';
+import { collectPermissionViolations } from '../lib/permission-checker.js';
+import { mergePermissionsIntoBudget, promptForPermissionExpansion } from '../lib/permission-prompt.js';
+import { USER_AGENT } from '../version.js';
 
 export interface InstallOptions {
   name: string;
@@ -120,7 +120,7 @@ function createRegistryFetcher(registry: string, headers: Record<string, string>
       }
 
       if (!res.ok) {
-        if (res.status === 403) throw new Error("Token lacks required scope: skills:read");
+        if (res.status === 403) throw new Error('Token lacks required scope: skills:read');
         if (res.status === 404) throw new Error(`Skill not found or no access: ${name}`);
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(body?.error ?? res.statusText);
@@ -145,7 +145,7 @@ function createRegistryFetcher(registry: string, headers: Record<string, string>
       }
 
       if (!res.ok) {
-        if (res.status === 403) throw new Error("Token lacks required scope: skills:read");
+        if (res.status === 403) throw new Error('Token lacks required scope: skills:read');
         if (res.status === 404) throw new Error(`Skill not found or no access: ${name}@${version}`);
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(body?.error ?? res.statusText);
@@ -154,17 +154,17 @@ function createRegistryFetcher(registry: string, headers: Record<string, string>
       const data = (await res.json()) as RegistrySkillMeta;
       const normalized: RegistrySkillMeta = {
         ...data,
-        dependencies: data.dependencies ?? {},
+        dependencies: data.dependencies ?? {}
       };
       metadataCache.set(cacheKey, normalized);
       return normalized;
-    },
+    }
   };
 }
 
 function readSkillsJson(skillsJsonPath: string): Record<string, unknown> {
   try {
-    const raw = fs.readFileSync(skillsJsonPath, "utf-8");
+    const raw = fs.readFileSync(skillsJsonPath, 'utf-8');
     return JSON.parse(raw) as Record<string, unknown>;
   } catch {
     throw new Error(`Failed to read or parse ${path.basename(skillsJsonPath)}`);
@@ -188,7 +188,7 @@ function readLockOrFresh(lockPath: string): SkillsLock {
   }
 
   try {
-    const raw = fs.readFileSync(lockPath, "utf-8");
+    const raw = fs.readFileSync(lockPath, 'utf-8');
     return JSON.parse(raw) as SkillsLock;
   } catch {
     return { lockfileVersion: LOCKFILE_VERSION, skills: {} };
@@ -206,7 +206,7 @@ function buildLockedVersionByName(lock: SkillsLock): Map<string, string> {
 function createExtractDirResolver(
   directory: string,
   global: boolean,
-  resolvedHome: string,
+  resolvedHome: string
 ): (skillName: string) => string {
   return (skillName: string): string =>
     global ? getGlobalExtractDir(resolvedHome, skillName) : getExtractDir(directory, skillName);
@@ -216,7 +216,7 @@ async function validateResolvedNodes(
   resolvedNodes: ResolvedNode[],
   projectPermissions: Permissions | undefined,
   auditMinScore: number | undefined,
-  options?: { yes?: boolean; skillsJsonPath?: string; skillsJson?: Record<string, unknown> },
+  options?: { yes?: boolean; skillsJsonPath?: string; skillsJson?: Record<string, unknown> }
 ): Promise<void> {
   if (!projectPermissions) {
     logger.warn(`No permission budget defined in ${MANIFEST_FILENAME}. Install proceeding without permission checks.`);
@@ -224,24 +224,24 @@ async function validateResolvedNodes(
 
   if (projectPermissions) {
     const allViolations = resolvedNodes.flatMap((node) =>
-      collectPermissionViolations(projectPermissions, node.meta.permissions as Permissions, node.name),
+      collectPermissionViolations(projectPermissions, node.meta.permissions as Permissions, node.name)
     );
 
     if (allViolations.length > 0) {
       const isInteractive = !process.env.CI && process.stdout.isTTY === true;
       const decision = await promptForPermissionExpansion(allViolations, {
         yes: options?.yes,
-        isInteractive,
+        isInteractive
       });
 
-      if (decision === "accept" && options?.skillsJsonPath && options?.skillsJson) {
+      if (decision === 'accept' && options?.skillsJsonPath && options?.skillsJson) {
         const merged = mergePermissionsIntoBudget(projectPermissions, allViolations);
         options.skillsJson.permissions = merged;
         fs.writeFileSync(options.skillsJsonPath, `${JSON.stringify(options.skillsJson, null, 2)}\n`);
-      } else if (decision === "decline") {
+      } else if (decision === 'decline') {
         const first = allViolations[0];
         throw new Error(
-          `Permission denied: ${first.skillName} requests ${first.type} access to "${first.requested}", which is not in the project's permission budget`,
+          `Permission denied: ${first.skillName} requests ${first.type} access to "${first.requested}", which is not in the project's permission budget`
         );
       }
     }
@@ -253,7 +253,7 @@ async function validateResolvedNodes(
         logger.warn(`Audit score not yet available for ${node.name}. Install proceeding without audit score check.`);
       } else if (node.meta.auditScore < auditMinScore) {
         throw new Error(
-          `Audit score ${node.meta.auditScore} for ${node.name} is below minimum threshold ${auditMinScore} defined in ${MANIFEST_FILENAME}`,
+          `Audit score ${node.meta.auditScore} for ${node.name} is below minimum threshold ${auditMinScore} defined in ${MANIFEST_FILENAME}`
         );
       }
     }
@@ -290,7 +290,7 @@ async function runLegacyFallback(options: {
         configDir,
         global,
         homedir,
-        isTransitive: true,
+        isTransitive: true
       });
     }
   }
@@ -309,8 +309,8 @@ function linkInstalledRoots(options: {
 
   const agentSkillsBaseDir = global
     ? getGlobalAgentSkillsDir(resolvedHome)
-    : path.join(directory, ".tank", "agent-skills");
-  const linksDir = global ? path.join(resolvedHome, ".tank") : path.join(directory, ".tank");
+    : path.join(directory, '.tank', 'agent-skills');
+  const linksDir = global ? path.join(resolvedHome, '.tank') : path.join(directory, '.tank');
 
   for (const skillName of rootSkillNames) {
     try {
@@ -323,14 +323,14 @@ function linkInstalledRoots(options: {
         skillName,
         extractDir: extractDirForSkill(skillName),
         agentSkillsBaseDir,
-        description: node.meta.description,
+        description: node.meta.description
       });
       const linkResult = linkSkillToAgents({
         skillName,
         sourceDir: agentSkillDir,
         linksDir,
-        source: global ? "global" : "local",
-        homedir,
+        source: global ? 'global' : 'local',
+        homedir
       });
 
       if (linkResult.linked.length > 0) {
@@ -343,7 +343,7 @@ function linkInstalledRoots(options: {
       }
     } catch {
       if (rootSkillNames.length === 1) {
-        logger.warn("Agent linking skipped (non-fatal)");
+        logger.warn('Agent linking skipped (non-fatal)');
       } else {
         logger.warn(`Agent linking skipped for ${skillName} (non-fatal)`);
       }
@@ -352,7 +352,7 @@ function linkInstalledRoots(options: {
 
   const detectedAgents = detectInstalledAgents(homedir);
   if (detectedAgents.length === 0) {
-    logger.warn("No agents detected for linking");
+    logger.warn('No agents detected for linking');
   }
 }
 
@@ -374,14 +374,14 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     cacheDir,
     yes,
     skillsJsonPath,
-    skillsJson,
+    skillsJson
   } = options;
 
   if (!global) {
     await validateResolvedNodes(resolvedNodes, projectPermissions, auditMinScore, {
       yes,
       skillsJsonPath,
-      skillsJson,
+      skillsJson
     });
   }
 
@@ -418,8 +418,8 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
         `${node.name}@${node.version}`,
         {
           cacheDir,
-          forceRefresh: true,
-        },
+          forceRefresh: true
+        }
       );
       downloaded.set(node.name, refreshed);
       await extractSafely(refreshed.buffer, extractDir);
@@ -439,7 +439,7 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     directory,
     configDir,
     global,
-    homedir,
+    homedir
   });
 
   linkInstalledRoots({
@@ -449,7 +449,7 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     directory,
     global,
     resolvedHome,
-    homedir,
+    homedir
   });
 
   return updatedLock;
@@ -458,18 +458,18 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
 export async function installCommand(options: InstallOptions): Promise<void> {
   const {
     name,
-    versionRange = "*",
+    versionRange = '*',
     directory = process.cwd(),
     configDir,
     global = false,
     homedir,
     isTransitive = false,
-    yes,
+    yes
   } = options;
 
   const config = getConfig(configDir);
   const resolvedHome = homedir ?? os.homedir();
-  const requestHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
+  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
   if (config.token) {
     requestHeaders.Authorization = `Bearer ${config.token}`;
   }
@@ -477,14 +477,14 @@ export async function installCommand(options: InstallOptions): Promise<void> {
   const resolvedManifest = resolveManifestPath(directory);
   const skillsJsonPath = resolvedManifest.exists ? resolvedManifest.path : path.join(directory, MANIFEST_FILENAME);
   const skillsJson = global ? { skills: {} } : readOrCreateSkillsJson(skillsJsonPath);
-  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, ".tank")) : resolveLockfilePath(directory);
+  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, '.tank')) : resolveLockfilePath(directory);
   const lockPath = resolvedLock.exists
     ? resolvedLock.path
     : global
-      ? path.join(resolvedHome, ".tank", LOCKFILE_FILENAME)
+      ? path.join(resolvedHome, '.tank', LOCKFILE_FILENAME)
       : path.join(directory, LOCKFILE_FILENAME);
   const lock = readLockOrFresh(lockPath);
-  const spinner = ora("Resolving dependency graph...").start();
+  const spinner = ora('Resolving dependency graph...').start();
 
   try {
     const fetcher = createRegistryFetcher(config.registry, requestHeaders);
@@ -493,7 +493,7 @@ export async function installCommand(options: InstallOptions): Promise<void> {
     const requestedResolvedVersion = resolve(versionRange, requestedAvailableVersions);
     if (!requestedResolvedVersion) {
       throw new Error(
-        `No version of ${name} satisfies range "${versionRange}". Available: ${requestedAvailableVersions.join(", ")}`,
+        `No version of ${name} satisfies range "${versionRange}". Available: ${requestedAvailableVersions.join(', ')}`
       );
     }
 
@@ -510,7 +510,7 @@ export async function installCommand(options: InstallOptions): Promise<void> {
       const lockedVersionByName = buildLockedVersionByName(lock);
 
       for (const [skillName, range] of Object.entries(existingSkills)) {
-        if (typeof range !== "string") {
+        if (typeof range !== 'string') {
           continue;
         }
 
@@ -551,19 +551,19 @@ export async function installCommand(options: InstallOptions): Promise<void> {
       cacheDir: getGlobalCacheDir(resolvedHome),
       yes,
       skillsJsonPath,
-      skillsJson,
+      skillsJson
     });
 
     if (!global && !isTransitive) {
       const skills = (skillsJson.skills ?? {}) as Record<string, string>;
-      skills[name] = versionRange === "*" ? `^${rootNode.version}` : versionRange;
+      skills[name] = versionRange === '*' ? `^${rootNode.version}` : versionRange;
       skillsJson.skills = skills;
       fs.writeFileSync(skillsJsonPath, `${JSON.stringify(skillsJson, null, 2)}\n`);
     }
 
     spinner.succeed(`Installed ${name}@${rootNode.version}`);
   } catch (err) {
-    spinner.fail("Install failed");
+    spinner.fail('Install failed');
     throw err;
   }
 }
@@ -573,12 +573,12 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
   const resolvedHome = homedir ?? os.homedir();
   const config = getConfig(configDir);
 
-  const requestHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
+  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
   if (config.token) {
     requestHeaders.Authorization = `Bearer ${config.token}`;
   }
 
-  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, ".tank")) : resolveLockfilePath(directory);
+  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, '.tank')) : resolveLockfilePath(directory);
   const lockPath = resolvedLock.path;
   if (!resolvedLock.exists) {
     throw new Error(`No ${LOCKFILE_FILENAME} found in ${directory}`);
@@ -586,20 +586,20 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
 
   let lock: SkillsLock;
   try {
-    const raw = fs.readFileSync(lockPath, "utf-8");
+    const raw = fs.readFileSync(lockPath, 'utf-8');
     lock = JSON.parse(raw) as SkillsLock;
   } catch {
     throw new Error(`Failed to read or parse ${path.basename(lockPath)}`);
   }
 
-  const entries = Object.entries(lock.skills) as Array<[string, SkillsLock["skills"][string]]>;
+  const entries = Object.entries(lock.skills) as Array<[string, SkillsLock['skills'][string]]>;
   if (entries.length === 0) {
-    logger.info("No skills in lockfile");
+    logger.info('No skills in lockfile');
     return;
   }
 
-  const spinner = ora("Installing from lockfile...").start();
-  const skillsDir = global ? getGlobalSkillsDir(resolvedHome) : path.join(directory, ".tank", "skills");
+  const spinner = ora('Installing from lockfile...').start();
+  const skillsDir = global ? getGlobalSkillsDir(resolvedHome) : path.join(directory, '.tank', 'skills');
   const cacheDir = getGlobalCacheDir(resolvedHome);
 
   try {
@@ -614,7 +614,7 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
       let metaRes: Response;
       try {
         metaRes = await fetch(metaUrl, {
-          headers: requestHeaders,
+          headers: requestHeaders
         });
       } catch (err) {
         throw new Error(`Network error fetching ${key}: ${err instanceof Error ? err.message : String(err)}`);
@@ -649,7 +649,7 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
         logger.warn(`Cached tarball for ${key} failed to extract; re-downloading`);
         tarball = await downloadTarballWithCache(downloadUrl, entry.integrity, key, {
           cacheDir,
-          forceRefresh: true,
+          forceRefresh: true
         });
 
         if (fs.existsSync(extractDir)) {
@@ -665,18 +665,18 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
           const agentSkillDir = prepareAgentSkillDir({
             skillName,
             extractDir,
-            agentSkillsBaseDir,
+            agentSkillsBaseDir
           });
           const linkResult = linkSkillToAgents({
             skillName,
             sourceDir: agentSkillDir,
-            linksDir: path.join(resolvedHome, ".tank"),
-            source: "global",
-            homedir,
+            linksDir: path.join(resolvedHome, '.tank'),
+            source: 'global',
+            homedir
           });
           const detectedAgents = detectInstalledAgents(homedir);
           if (detectedAgents.length === 0) {
-            logger.warn("No agents detected for linking");
+            logger.warn('No agents detected for linking');
           }
           if (linkResult.linked.length > 0) {
             logger.info(`Linked to ${linkResult.linked.length} agent(s)`);
@@ -687,14 +687,14 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
             }
           }
         } catch {
-          logger.warn("Agent linking skipped (non-fatal)");
+          logger.warn('Agent linking skipped (non-fatal)');
         }
       }
     }
 
-    spinner.succeed(`Installed ${entries.length} skill${entries.length === 1 ? "" : "s"} from lockfile`);
+    spinner.succeed(`Installed ${entries.length} skill${entries.length === 1 ? '' : 's'} from lockfile`);
   } catch (err) {
-    spinner.fail("Install from lockfile failed");
+    spinner.fail('Install from lockfile failed');
     if (fs.existsSync(skillsDir)) {
       fs.rmSync(skillsDir, { recursive: true, force: true });
     }
@@ -706,16 +706,16 @@ export async function installAll(options: InstallAllOptions): Promise<void> {
   const { directory = process.cwd(), configDir, global = false, homedir, yes } = options;
   const resolvedHome = homedir ?? os.homedir();
   const config = getConfig(configDir);
-  const requestHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
+  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
   if (config.token) {
     requestHeaders.Authorization = `Bearer ${config.token}`;
   }
 
-  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, ".tank")) : resolveLockfilePath(directory);
+  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, '.tank')) : resolveLockfilePath(directory);
   const lockPath = resolvedLock.exists
     ? resolvedLock.path
     : global
-      ? path.join(resolvedHome, ".tank", LOCKFILE_FILENAME)
+      ? path.join(resolvedHome, '.tank', LOCKFILE_FILENAME)
       : path.join(directory, LOCKFILE_FILENAME);
   const resolvedManifest = resolveManifestPath(directory);
   const skillsJsonPath = resolvedManifest.path;
@@ -743,12 +743,12 @@ export async function installAll(options: InstallAllOptions): Promise<void> {
     return;
   }
 
-  const spinner = ora("Resolving dependency graph...").start();
+  const spinner = ora('Resolving dependency graph...').start();
 
   try {
     const rootDependencies: Record<string, string> = {};
     for (const [skillName, range] of skillEntries) {
-      if (typeof range === "string") {
+      if (typeof range === 'string') {
         rootDependencies[skillName] = range;
       }
     }
@@ -777,12 +777,12 @@ export async function installAll(options: InstallAllOptions): Promise<void> {
       cacheDir: getGlobalCacheDir(resolvedHome),
       yes,
       skillsJsonPath,
-      skillsJson,
+      skillsJson
     });
 
-    spinner.succeed(`Installed ${skillEntries.length} root skill${skillEntries.length === 1 ? "" : "s"}`);
+    spinner.succeed(`Installed ${skillEntries.length} root skill${skillEntries.length === 1 ? '' : 's'}`);
   } catch (err) {
-    spinner.fail("Install failed");
+    spinner.fail('Install failed');
     throw err;
   }
 }

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,45 +1,46 @@
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   LOCKFILE_FILENAME,
   LOCKFILE_VERSION,
   MANIFEST_FILENAME,
   type Permissions,
   resolve,
-  type SkillsLock
-} from '@internal/shared';
-import ora from 'ora';
-import { detectInstalledAgents, getGlobalAgentSkillsDir, getGlobalSkillsDir } from '../lib/agents.js';
-import { getConfig } from '../lib/config.js';
+  type SkillsLock,
+} from "@internal/shared";
+import ora from "ora";
+import { detectInstalledAgents, getGlobalAgentSkillsDir, getGlobalSkillsDir } from "../lib/agents.js";
+import { getConfig } from "../lib/config.js";
 import {
   buildSkillKey,
   type RegistryFetcher,
   type RegistrySkillMeta,
   type RegistryVersionInfo,
   type ResolvedNode,
-  resolveDependencyTree
-} from '../lib/dependency-resolver.js';
-import { prepareAgentSkillDir } from '../lib/frontmatter.js';
+  resolveDependencyTree,
+} from "../lib/dependency-resolver.js";
+import { prepareAgentSkillDir } from "../lib/frontmatter.js";
 import {
+  downloadTarballWithCache,
   downloadAllParallel,
   extractSafely,
   getExtractDir,
+  getGlobalCacheDir,
   getGlobalExtractDir,
   getResolvedNodesInOrder,
   parseLockKey,
   parseVersionFromLockKey,
   readExtractedDependencies,
   verifyExtractedDependencies,
-  writeLockfileWithResolvedGraph
-} from '../lib/install-pipeline.js';
-import { linkSkillToAgents } from '../lib/linker.js';
-import { logger } from '../lib/logger.js';
-import { resolveLockfilePath, resolveManifestPath } from '../lib/manifest.js';
-import { collectPermissionViolations } from '../lib/permission-checker.js';
-import { mergePermissionsIntoBudget, promptForPermissionExpansion } from '../lib/permission-prompt.js';
-import { USER_AGENT } from '../version.js';
+  writeLockfileWithResolvedGraph,
+} from "../lib/install-pipeline.js";
+import { linkSkillToAgents } from "../lib/linker.js";
+import { logger } from "../lib/logger.js";
+import { resolveLockfilePath, resolveManifestPath } from "../lib/manifest.js";
+import { collectPermissionViolations } from "../lib/permission-checker.js";
+import { mergePermissionsIntoBudget, promptForPermissionExpansion } from "../lib/permission-prompt.js";
+import { USER_AGENT } from "../version.js";
 
 export interface InstallOptions {
   name: string;
@@ -93,6 +94,7 @@ interface ExecuteInstallPipelineOptions {
   projectPermissions?: Permissions;
   auditMinScore?: number;
   spinner: ReturnType<typeof ora>;
+  cacheDir: string;
   yes?: boolean;
   skillsJsonPath?: string;
   skillsJson?: Record<string, unknown>;
@@ -118,7 +120,7 @@ function createRegistryFetcher(registry: string, headers: Record<string, string>
       }
 
       if (!res.ok) {
-        if (res.status === 403) throw new Error('Token lacks required scope: skills:read');
+        if (res.status === 403) throw new Error("Token lacks required scope: skills:read");
         if (res.status === 404) throw new Error(`Skill not found or no access: ${name}`);
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(body?.error ?? res.statusText);
@@ -143,7 +145,7 @@ function createRegistryFetcher(registry: string, headers: Record<string, string>
       }
 
       if (!res.ok) {
-        if (res.status === 403) throw new Error('Token lacks required scope: skills:read');
+        if (res.status === 403) throw new Error("Token lacks required scope: skills:read");
         if (res.status === 404) throw new Error(`Skill not found or no access: ${name}@${version}`);
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(body?.error ?? res.statusText);
@@ -152,17 +154,17 @@ function createRegistryFetcher(registry: string, headers: Record<string, string>
       const data = (await res.json()) as RegistrySkillMeta;
       const normalized: RegistrySkillMeta = {
         ...data,
-        dependencies: data.dependencies ?? {}
+        dependencies: data.dependencies ?? {},
       };
       metadataCache.set(cacheKey, normalized);
       return normalized;
-    }
+    },
   };
 }
 
 function readSkillsJson(skillsJsonPath: string): Record<string, unknown> {
   try {
-    const raw = fs.readFileSync(skillsJsonPath, 'utf-8');
+    const raw = fs.readFileSync(skillsJsonPath, "utf-8");
     return JSON.parse(raw) as Record<string, unknown>;
   } catch {
     throw new Error(`Failed to read or parse ${path.basename(skillsJsonPath)}`);
@@ -186,7 +188,7 @@ function readLockOrFresh(lockPath: string): SkillsLock {
   }
 
   try {
-    const raw = fs.readFileSync(lockPath, 'utf-8');
+    const raw = fs.readFileSync(lockPath, "utf-8");
     return JSON.parse(raw) as SkillsLock;
   } catch {
     return { lockfileVersion: LOCKFILE_VERSION, skills: {} };
@@ -204,7 +206,7 @@ function buildLockedVersionByName(lock: SkillsLock): Map<string, string> {
 function createExtractDirResolver(
   directory: string,
   global: boolean,
-  resolvedHome: string
+  resolvedHome: string,
 ): (skillName: string) => string {
   return (skillName: string): string =>
     global ? getGlobalExtractDir(resolvedHome, skillName) : getExtractDir(directory, skillName);
@@ -214,7 +216,7 @@ async function validateResolvedNodes(
   resolvedNodes: ResolvedNode[],
   projectPermissions: Permissions | undefined,
   auditMinScore: number | undefined,
-  options?: { yes?: boolean; skillsJsonPath?: string; skillsJson?: Record<string, unknown> }
+  options?: { yes?: boolean; skillsJsonPath?: string; skillsJson?: Record<string, unknown> },
 ): Promise<void> {
   if (!projectPermissions) {
     logger.warn(`No permission budget defined in ${MANIFEST_FILENAME}. Install proceeding without permission checks.`);
@@ -222,24 +224,24 @@ async function validateResolvedNodes(
 
   if (projectPermissions) {
     const allViolations = resolvedNodes.flatMap((node) =>
-      collectPermissionViolations(projectPermissions, node.meta.permissions as Permissions, node.name)
+      collectPermissionViolations(projectPermissions, node.meta.permissions as Permissions, node.name),
     );
 
     if (allViolations.length > 0) {
       const isInteractive = !process.env.CI && process.stdout.isTTY === true;
       const decision = await promptForPermissionExpansion(allViolations, {
         yes: options?.yes,
-        isInteractive
+        isInteractive,
       });
 
-      if (decision === 'accept' && options?.skillsJsonPath && options?.skillsJson) {
+      if (decision === "accept" && options?.skillsJsonPath && options?.skillsJson) {
         const merged = mergePermissionsIntoBudget(projectPermissions, allViolations);
         options.skillsJson.permissions = merged;
         fs.writeFileSync(options.skillsJsonPath, `${JSON.stringify(options.skillsJson, null, 2)}\n`);
-      } else if (decision === 'decline') {
+      } else if (decision === "decline") {
         const first = allViolations[0];
         throw new Error(
-          `Permission denied: ${first.skillName} requests ${first.type} access to "${first.requested}", which is not in the project's permission budget`
+          `Permission denied: ${first.skillName} requests ${first.type} access to "${first.requested}", which is not in the project's permission budget`,
         );
       }
     }
@@ -251,7 +253,7 @@ async function validateResolvedNodes(
         logger.warn(`Audit score not yet available for ${node.name}. Install proceeding without audit score check.`);
       } else if (node.meta.auditScore < auditMinScore) {
         throw new Error(
-          `Audit score ${node.meta.auditScore} for ${node.name} is below minimum threshold ${auditMinScore} defined in ${MANIFEST_FILENAME}`
+          `Audit score ${node.meta.auditScore} for ${node.name} is below minimum threshold ${auditMinScore} defined in ${MANIFEST_FILENAME}`,
         );
       }
     }
@@ -288,7 +290,7 @@ async function runLegacyFallback(options: {
         configDir,
         global,
         homedir,
-        isTransitive: true
+        isTransitive: true,
       });
     }
   }
@@ -307,8 +309,8 @@ function linkInstalledRoots(options: {
 
   const agentSkillsBaseDir = global
     ? getGlobalAgentSkillsDir(resolvedHome)
-    : path.join(directory, '.tank', 'agent-skills');
-  const linksDir = global ? path.join(resolvedHome, '.tank') : path.join(directory, '.tank');
+    : path.join(directory, ".tank", "agent-skills");
+  const linksDir = global ? path.join(resolvedHome, ".tank") : path.join(directory, ".tank");
 
   for (const skillName of rootSkillNames) {
     try {
@@ -321,14 +323,14 @@ function linkInstalledRoots(options: {
         skillName,
         extractDir: extractDirForSkill(skillName),
         agentSkillsBaseDir,
-        description: node.meta.description
+        description: node.meta.description,
       });
       const linkResult = linkSkillToAgents({
         skillName,
         sourceDir: agentSkillDir,
         linksDir,
-        source: global ? 'global' : 'local',
-        homedir
+        source: global ? "global" : "local",
+        homedir,
       });
 
       if (linkResult.linked.length > 0) {
@@ -341,7 +343,7 @@ function linkInstalledRoots(options: {
       }
     } catch {
       if (rootSkillNames.length === 1) {
-        logger.warn('Agent linking skipped (non-fatal)');
+        logger.warn("Agent linking skipped (non-fatal)");
       } else {
         logger.warn(`Agent linking skipped for ${skillName} (non-fatal)`);
       }
@@ -350,7 +352,7 @@ function linkInstalledRoots(options: {
 
   const detectedAgents = detectInstalledAgents(homedir);
   if (detectedAgents.length === 0) {
-    logger.warn('No agents detected for linking');
+    logger.warn("No agents detected for linking");
   }
 }
 
@@ -369,22 +371,23 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     projectPermissions,
     auditMinScore,
     spinner,
+    cacheDir,
     yes,
     skillsJsonPath,
-    skillsJson
+    skillsJson,
   } = options;
 
   if (!global) {
     await validateResolvedNodes(resolvedNodes, projectPermissions, auditMinScore, {
       yes,
       skillsJsonPath,
-      skillsJson
+      skillsJson,
     });
   }
 
   const extractDirForSkill = createExtractDirResolver(directory, global, resolvedHome);
   const resolvedNodeByName = new Map(resolvedNodes.map((node) => [node.name, node]));
-  const downloaded = await downloadAllParallel(nodesToInstall, spinner);
+  const downloaded = await downloadAllParallel(nodesToInstall, spinner, { cacheDir });
 
   for (const node of nodesToInstall) {
     const payload = downloaded.get(node.name);
@@ -395,7 +398,32 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     spinner.text = `Extracting ${node.name}@${node.version}...`;
     const extractDir = extractDirForSkill(node.name);
     fs.mkdirSync(extractDir, { recursive: true });
-    await extractSafely(payload.buffer, extractDir);
+    try {
+      await extractSafely(payload.buffer, extractDir);
+    } catch (err) {
+      if (!payload.fromCache) {
+        throw err;
+      }
+
+      logger.warn(`Cached tarball for ${node.name}@${node.version} failed to extract; re-downloading`);
+
+      if (fs.existsSync(extractDir)) {
+        fs.rmSync(extractDir, { recursive: true, force: true });
+      }
+      fs.mkdirSync(extractDir, { recursive: true });
+
+      const refreshed = await downloadTarballWithCache(
+        node.meta.downloadUrl,
+        node.meta.integrity,
+        `${node.name}@${node.version}`,
+        {
+          cacheDir,
+          forceRefresh: true,
+        },
+      );
+      downloaded.set(node.name, refreshed);
+      await extractSafely(refreshed.buffer, extractDir);
+    }
     verifyExtractedDependencies(extractDir, node);
   }
 
@@ -411,7 +439,7 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     directory,
     configDir,
     global,
-    homedir
+    homedir,
   });
 
   linkInstalledRoots({
@@ -421,7 +449,7 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     directory,
     global,
     resolvedHome,
-    homedir
+    homedir,
   });
 
   return updatedLock;
@@ -430,18 +458,18 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
 export async function installCommand(options: InstallOptions): Promise<void> {
   const {
     name,
-    versionRange = '*',
+    versionRange = "*",
     directory = process.cwd(),
     configDir,
     global = false,
     homedir,
     isTransitive = false,
-    yes
+    yes,
   } = options;
 
   const config = getConfig(configDir);
   const resolvedHome = homedir ?? os.homedir();
-  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+  const requestHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
   if (config.token) {
     requestHeaders.Authorization = `Bearer ${config.token}`;
   }
@@ -449,14 +477,14 @@ export async function installCommand(options: InstallOptions): Promise<void> {
   const resolvedManifest = resolveManifestPath(directory);
   const skillsJsonPath = resolvedManifest.exists ? resolvedManifest.path : path.join(directory, MANIFEST_FILENAME);
   const skillsJson = global ? { skills: {} } : readOrCreateSkillsJson(skillsJsonPath);
-  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, '.tank')) : resolveLockfilePath(directory);
+  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, ".tank")) : resolveLockfilePath(directory);
   const lockPath = resolvedLock.exists
     ? resolvedLock.path
     : global
-      ? path.join(resolvedHome, '.tank', LOCKFILE_FILENAME)
+      ? path.join(resolvedHome, ".tank", LOCKFILE_FILENAME)
       : path.join(directory, LOCKFILE_FILENAME);
   const lock = readLockOrFresh(lockPath);
-  const spinner = ora('Resolving dependency graph...').start();
+  const spinner = ora("Resolving dependency graph...").start();
 
   try {
     const fetcher = createRegistryFetcher(config.registry, requestHeaders);
@@ -465,7 +493,7 @@ export async function installCommand(options: InstallOptions): Promise<void> {
     const requestedResolvedVersion = resolve(versionRange, requestedAvailableVersions);
     if (!requestedResolvedVersion) {
       throw new Error(
-        `No version of ${name} satisfies range "${versionRange}". Available: ${requestedAvailableVersions.join(', ')}`
+        `No version of ${name} satisfies range "${versionRange}". Available: ${requestedAvailableVersions.join(", ")}`,
       );
     }
 
@@ -482,7 +510,7 @@ export async function installCommand(options: InstallOptions): Promise<void> {
       const lockedVersionByName = buildLockedVersionByName(lock);
 
       for (const [skillName, range] of Object.entries(existingSkills)) {
-        if (typeof range !== 'string') {
+        if (typeof range !== "string") {
           continue;
         }
 
@@ -520,21 +548,22 @@ export async function installCommand(options: InstallOptions): Promise<void> {
       projectPermissions,
       auditMinScore,
       spinner,
+      cacheDir: getGlobalCacheDir(resolvedHome),
       yes,
       skillsJsonPath,
-      skillsJson
+      skillsJson,
     });
 
     if (!global && !isTransitive) {
       const skills = (skillsJson.skills ?? {}) as Record<string, string>;
-      skills[name] = versionRange === '*' ? `^${rootNode.version}` : versionRange;
+      skills[name] = versionRange === "*" ? `^${rootNode.version}` : versionRange;
       skillsJson.skills = skills;
       fs.writeFileSync(skillsJsonPath, `${JSON.stringify(skillsJson, null, 2)}\n`);
     }
 
     spinner.succeed(`Installed ${name}@${rootNode.version}`);
   } catch (err) {
-    spinner.fail('Install failed');
+    spinner.fail("Install failed");
     throw err;
   }
 }
@@ -544,12 +573,12 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
   const resolvedHome = homedir ?? os.homedir();
   const config = getConfig(configDir);
 
-  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+  const requestHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
   if (config.token) {
     requestHeaders.Authorization = `Bearer ${config.token}`;
   }
 
-  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, '.tank')) : resolveLockfilePath(directory);
+  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, ".tank")) : resolveLockfilePath(directory);
   const lockPath = resolvedLock.path;
   if (!resolvedLock.exists) {
     throw new Error(`No ${LOCKFILE_FILENAME} found in ${directory}`);
@@ -557,20 +586,21 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
 
   let lock: SkillsLock;
   try {
-    const raw = fs.readFileSync(lockPath, 'utf-8');
+    const raw = fs.readFileSync(lockPath, "utf-8");
     lock = JSON.parse(raw) as SkillsLock;
   } catch {
     throw new Error(`Failed to read or parse ${path.basename(lockPath)}`);
   }
 
-  const entries = Object.entries(lock.skills);
+  const entries = Object.entries(lock.skills) as Array<[string, SkillsLock["skills"][string]]>;
   if (entries.length === 0) {
-    logger.info('No skills in lockfile');
+    logger.info("No skills in lockfile");
     return;
   }
 
-  const spinner = ora('Installing from lockfile...').start();
-  const skillsDir = global ? getGlobalSkillsDir(resolvedHome) : path.join(directory, '.tank', 'skills');
+  const spinner = ora("Installing from lockfile...").start();
+  const skillsDir = global ? getGlobalSkillsDir(resolvedHome) : path.join(directory, ".tank", "skills");
+  const cacheDir = getGlobalCacheDir(resolvedHome);
 
   try {
     for (const [key, entry] of entries) {
@@ -584,7 +614,7 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
       let metaRes: Response;
       try {
         metaRes = await fetch(metaUrl, {
-          headers: requestHeaders
+          headers: requestHeaders,
         });
       } catch (err) {
         throw new Error(`Network error fetching ${key}: ${err instanceof Error ? err.message : String(err)}`);
@@ -600,16 +630,7 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
 
       const metadata = (await metaRes.json()) as VersionMetadata;
       const downloadUrl = metadata.downloadUrl;
-      const downloadRes = await fetch(downloadUrl);
-      if (!downloadRes.ok) {
-        throw new Error(`Failed to download ${key}: ${downloadRes.status} ${downloadRes.statusText}`);
-      }
-
-      const tarballBuffer = Buffer.from(await downloadRes.arrayBuffer());
-      const computedIntegrity = buildIntegrity(tarballBuffer);
-      if (computedIntegrity !== entry.integrity) {
-        throw new Error(`Integrity mismatch for ${key}. Expected: ${entry.integrity}, Got: ${computedIntegrity}`);
-      }
+      let tarball = await downloadTarballWithCache(downloadUrl, entry.integrity, key, { cacheDir });
 
       const extractDir = global ? getGlobalExtractDir(resolvedHome, skillName) : getExtractDir(directory, skillName);
 
@@ -618,7 +639,25 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
       }
       fs.mkdirSync(extractDir, { recursive: true });
 
-      await extractSafely(tarballBuffer, extractDir);
+      try {
+        await extractSafely(tarball.buffer, extractDir);
+      } catch (err) {
+        if (!tarball.fromCache) {
+          throw err;
+        }
+
+        logger.warn(`Cached tarball for ${key} failed to extract; re-downloading`);
+        tarball = await downloadTarballWithCache(downloadUrl, entry.integrity, key, {
+          cacheDir,
+          forceRefresh: true,
+        });
+
+        if (fs.existsSync(extractDir)) {
+          fs.rmSync(extractDir, { recursive: true, force: true });
+        }
+        fs.mkdirSync(extractDir, { recursive: true });
+        await extractSafely(tarball.buffer, extractDir);
+      }
 
       if (global) {
         try {
@@ -626,18 +665,18 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
           const agentSkillDir = prepareAgentSkillDir({
             skillName,
             extractDir,
-            agentSkillsBaseDir
+            agentSkillsBaseDir,
           });
           const linkResult = linkSkillToAgents({
             skillName,
             sourceDir: agentSkillDir,
-            linksDir: path.join(resolvedHome, '.tank'),
-            source: 'global',
-            homedir
+            linksDir: path.join(resolvedHome, ".tank"),
+            source: "global",
+            homedir,
           });
           const detectedAgents = detectInstalledAgents(homedir);
           if (detectedAgents.length === 0) {
-            logger.warn('No agents detected for linking');
+            logger.warn("No agents detected for linking");
           }
           if (linkResult.linked.length > 0) {
             logger.info(`Linked to ${linkResult.linked.length} agent(s)`);
@@ -648,14 +687,14 @@ export async function installFromLockfile(options: LockfileInstallOptions): Prom
             }
           }
         } catch {
-          logger.warn('Agent linking skipped (non-fatal)');
+          logger.warn("Agent linking skipped (non-fatal)");
         }
       }
     }
 
-    spinner.succeed(`Installed ${entries.length} skill${entries.length === 1 ? '' : 's'} from lockfile`);
+    spinner.succeed(`Installed ${entries.length} skill${entries.length === 1 ? "" : "s"} from lockfile`);
   } catch (err) {
-    spinner.fail('Install from lockfile failed');
+    spinner.fail("Install from lockfile failed");
     if (fs.existsSync(skillsDir)) {
       fs.rmSync(skillsDir, { recursive: true, force: true });
     }
@@ -667,16 +706,16 @@ export async function installAll(options: InstallAllOptions): Promise<void> {
   const { directory = process.cwd(), configDir, global = false, homedir, yes } = options;
   const resolvedHome = homedir ?? os.homedir();
   const config = getConfig(configDir);
-  const requestHeaders: Record<string, string> = { 'User-Agent': USER_AGENT };
+  const requestHeaders: Record<string, string> = { "User-Agent": USER_AGENT };
   if (config.token) {
     requestHeaders.Authorization = `Bearer ${config.token}`;
   }
 
-  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, '.tank')) : resolveLockfilePath(directory);
+  const resolvedLock = global ? resolveLockfilePath(path.join(resolvedHome, ".tank")) : resolveLockfilePath(directory);
   const lockPath = resolvedLock.exists
     ? resolvedLock.path
     : global
-      ? path.join(resolvedHome, '.tank', LOCKFILE_FILENAME)
+      ? path.join(resolvedHome, ".tank", LOCKFILE_FILENAME)
       : path.join(directory, LOCKFILE_FILENAME);
   const resolvedManifest = resolveManifestPath(directory);
   const skillsJsonPath = resolvedManifest.path;
@@ -704,12 +743,12 @@ export async function installAll(options: InstallAllOptions): Promise<void> {
     return;
   }
 
-  const spinner = ora('Resolving dependency graph...').start();
+  const spinner = ora("Resolving dependency graph...").start();
 
   try {
     const rootDependencies: Record<string, string> = {};
     for (const [skillName, range] of skillEntries) {
-      if (typeof range === 'string') {
+      if (typeof range === "string") {
         rootDependencies[skillName] = range;
       }
     }
@@ -735,19 +774,15 @@ export async function installAll(options: InstallAllOptions): Promise<void> {
       projectPermissions,
       auditMinScore,
       spinner,
+      cacheDir: getGlobalCacheDir(resolvedHome),
       yes,
       skillsJsonPath,
-      skillsJson
+      skillsJson,
     });
 
-    spinner.succeed(`Installed ${skillEntries.length} root skill${skillEntries.length === 1 ? '' : 's'}`);
+    spinner.succeed(`Installed ${skillEntries.length} root skill${skillEntries.length === 1 ? "" : "s"}`);
   } catch (err) {
-    spinner.fail('Install failed');
+    spinner.fail("Install failed");
     throw err;
   }
-}
-
-function buildIntegrity(buffer: Buffer): string {
-  const hash = crypto.createHash('sha512').update(buffer).digest('base64');
-  return `sha512-${hash}`;
 }

--- a/packages/cli/src/lib/install-pipeline.ts
+++ b/packages/cli/src/lib/install-pipeline.ts
@@ -1,11 +1,11 @@
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-import { LEGACY_MANIFEST_FILENAME, MANIFEST_FILENAME, type Permissions, type SkillsLock } from "@internal/shared";
-import type ora from "ora";
-import { extract } from "tar";
-import { buildSkillKey, type ResolvedNode } from "./dependency-resolver.js";
-import { logger } from "./logger.js";
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { LEGACY_MANIFEST_FILENAME, MANIFEST_FILENAME, type Permissions, type SkillsLock } from '@internal/shared';
+import type ora from 'ora';
+import { extract } from 'tar';
+import { buildSkillKey, type ResolvedNode } from './dependency-resolver.js';
+import { logger } from './logger.js';
 
 export interface DownloadedTarball {
   buffer: Buffer;
@@ -19,7 +19,7 @@ interface DownloadTarballWithCacheOptions {
 }
 
 function isVerboseMode(): boolean {
-  return process.env.TANK_DEBUG === "1" || process.env.TANK_DEBUG === "true";
+  return process.env.TANK_DEBUG === '1' || process.env.TANK_DEBUG === 'true';
 }
 
 function verboseCacheLog(message: string): void {
@@ -29,21 +29,21 @@ function verboseCacheLog(message: string): void {
 }
 
 function integrityToSha512Hex(integrity: string): string {
-  if (!integrity.startsWith("sha512-")) {
+  if (!integrity.startsWith('sha512-')) {
     throw new Error(`Invalid integrity format: ${integrity}`);
   }
 
-  const base64 = integrity.slice("sha512-".length);
-  return Buffer.from(base64, "base64").toString("hex");
+  const base64 = integrity.slice('sha512-'.length);
+  return Buffer.from(base64, 'base64').toString('hex');
 }
 
 function buildIntegrity(buffer: Buffer): string {
-  const hash = crypto.createHash("sha512").update(buffer).digest("base64");
+  const hash = crypto.createHash('sha512').update(buffer).digest('base64');
   return `sha512-${hash}`;
 }
 
 export function getGlobalCacheDir(homedir: string): string {
-  return path.join(homedir, ".tank", "cache");
+  return path.join(homedir, '.tank', 'cache');
 }
 
 function getTarballCachePath(cacheDir: string, integrity: string): string {
@@ -83,7 +83,7 @@ async function downloadTarball(url: string, skillLabel: string): Promise<Buffer>
     res = await fetch(url);
   } catch (err) {
     throw new Error(
-      `Network error downloading tarball for ${skillLabel}: ${err instanceof Error ? err.message : String(err)}`,
+      `Network error downloading tarball for ${skillLabel}: ${err instanceof Error ? err.message : String(err)}`
     );
   }
 
@@ -98,7 +98,7 @@ export async function downloadTarballWithCache(
   downloadUrl: string,
   expectedIntegrity: string,
   skillLabel: string,
-  options: DownloadTarballWithCacheOptions,
+  options: DownloadTarballWithCacheOptions
 ): Promise<DownloadedTarball> {
   const cachePath = getTarballCachePath(options.cacheDir, expectedIntegrity);
 
@@ -126,7 +126,7 @@ export async function downloadTarballWithCache(
 export async function downloadAllParallel(
   nodes: ResolvedNode[],
   spinner: ReturnType<typeof ora>,
-  options: { cacheDir: string },
+  options: { cacheDir: string }
 ): Promise<Map<string, DownloadedTarball>> {
   const results = new Map<string, DownloadedTarball>();
   const CONCURRENCY_LIMIT = 8;
@@ -140,8 +140,8 @@ export async function downloadAllParallel(
         node.meta.integrity,
         `${node.name}@${node.version}`,
         {
-          cacheDir: options.cacheDir,
-        },
+          cacheDir: options.cacheDir
+        }
       );
       return { name: node.name, downloaded };
     });
@@ -165,7 +165,7 @@ export function verifyExtractedDependencies(extractDir: string, node: ResolvedNo
   }
 
   try {
-    const raw = fs.readFileSync(extractedManifestPath, "utf-8");
+    const raw = fs.readFileSync(extractedManifestPath, 'utf-8');
     const manifest = JSON.parse(raw) as Record<string, unknown>;
     const extractedDeps = (manifest.skills ?? {}) as Record<string, string>;
     const apiDeps = node.meta.dependencies;
@@ -189,16 +189,16 @@ export function readExtractedDependencies(extractDir: string): Record<string, st
   }
 
   try {
-    const raw = fs.readFileSync(extractedManifestPath, "utf-8");
+    const raw = fs.readFileSync(extractedManifestPath, 'utf-8');
     const manifest = JSON.parse(raw) as Record<string, unknown>;
     const extractedDeps = manifest.skills;
-    if (!extractedDeps || typeof extractedDeps !== "object") {
+    if (!extractedDeps || typeof extractedDeps !== 'object') {
       return {};
     }
 
     const deps: Record<string, string> = {};
     for (const [depName, depRange] of Object.entries(extractedDeps as Record<string, unknown>)) {
-      if (typeof depRange === "string") {
+      if (typeof depRange === 'string') {
         deps[depName] = depRange;
       }
     }
@@ -211,7 +211,7 @@ export function readExtractedDependencies(extractDir: string): Record<string, st
 export function writeLockfileWithResolvedGraph(
   lock: SkillsLock,
   nodes: ResolvedNode[],
-  downloaded: Map<string, { buffer: Buffer; integrity: string }>,
+  downloaded: Map<string, { buffer: Buffer; integrity: string }>
 ): SkillsLock {
   for (const node of nodes) {
     const key = buildSkillKey(node.name, node.version);
@@ -227,7 +227,7 @@ export function writeLockfileWithResolvedGraph(
       integrity,
       permissions: node.meta.permissions as Permissions,
       audit_score: node.meta.auditScore ?? null,
-      dependencies: node.dependencies,
+      dependencies: node.dependencies
     };
   }
 
@@ -235,7 +235,7 @@ export function writeLockfileWithResolvedGraph(
   for (const key of Object.keys(lock.skills).sort()) {
     sortedSkills[key] = lock.skills[key];
   }
-  lock.skills = sortedSkills as SkillsLock["skills"];
+  lock.skills = sortedSkills as SkillsLock['skills'];
   return lock;
 }
 
@@ -244,7 +244,7 @@ export function writeLockfileWithResolvedGraph(
  * Rejects: absolute paths, path traversal (..), symlinks/hardlinks.
  */
 export async function extractSafely(tarball: Buffer, destDir: string): Promise<void> {
-  const tmpTarball = path.join(destDir, ".tmp-tarball.tgz");
+  const tmpTarball = path.join(destDir, '.tmp-tarball.tgz');
   fs.writeFileSync(tmpTarball, tarball);
 
   try {
@@ -255,16 +255,16 @@ export async function extractSafely(tarball: Buffer, destDir: string): Promise<v
         if (path.isAbsolute(entryPath)) {
           throw new Error(`Absolute path in tarball: ${entryPath}`);
         }
-        if (entryPath.split("/").includes("..") || entryPath.split(path.sep).includes("..")) {
+        if (entryPath.split('/').includes('..') || entryPath.split(path.sep).includes('..')) {
           throw new Error(`Path traversal in tarball: ${entryPath}`);
         }
         return true;
       },
       onReadEntry: (entry) => {
-        if (entry.type === "SymbolicLink" || entry.type === "Link") {
+        if (entry.type === 'SymbolicLink' || entry.type === 'Link') {
           throw new Error(`Symlink/hardlink in tarball: ${entry.path}`);
         }
-      },
+      }
     });
   } finally {
     if (fs.existsSync(tmpTarball)) {
@@ -274,24 +274,24 @@ export async function extractSafely(tarball: Buffer, destDir: string): Promise<v
 }
 
 export function getExtractDir(projectDir: string, skillName: string): string {
-  if (skillName.startsWith("@")) {
-    const [scope, name] = skillName.split("/");
-    return path.join(projectDir, ".tank", "skills", scope, name);
+  if (skillName.startsWith('@')) {
+    const [scope, name] = skillName.split('/');
+    return path.join(projectDir, '.tank', 'skills', scope, name);
   }
-  return path.join(projectDir, ".tank", "skills", skillName);
+  return path.join(projectDir, '.tank', 'skills', skillName);
 }
 
 export function getGlobalExtractDir(homedir: string, skillName: string): string {
-  const globalDir = path.join(homedir, ".tank", "skills");
-  if (skillName.startsWith("@")) {
-    const [scope, name] = skillName.split("/");
+  const globalDir = path.join(homedir, '.tank', 'skills');
+  if (skillName.startsWith('@')) {
+    const [scope, name] = skillName.split('/');
     return path.join(globalDir, scope, name);
   }
   return path.join(globalDir, skillName);
 }
 
 export function parseLockKey(key: string): string {
-  const lastAt = key.lastIndexOf("@");
+  const lastAt = key.lastIndexOf('@');
   if (lastAt <= 0) {
     throw new Error(`Invalid lockfile key: ${key}`);
   }
@@ -299,7 +299,7 @@ export function parseLockKey(key: string): string {
 }
 
 export function parseVersionFromLockKey(key: string): string {
-  const lastAt = key.lastIndexOf("@");
+  const lastAt = key.lastIndexOf('@');
   if (lastAt <= 0 || lastAt === key.length - 1) {
     throw new Error(`Invalid lockfile key: ${key}`);
   }

--- a/packages/cli/src/lib/install-pipeline.ts
+++ b/packages/cli/src/lib/install-pipeline.ts
@@ -1,50 +1,154 @@
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import path from 'node:path';
-import { LEGACY_MANIFEST_FILENAME, MANIFEST_FILENAME, type Permissions, type SkillsLock } from '@internal/shared';
-import type ora from 'ora';
-import { extract } from 'tar';
-import { buildSkillKey, type ResolvedNode } from './dependency-resolver.js';
-import { logger } from './logger.js';
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { LEGACY_MANIFEST_FILENAME, MANIFEST_FILENAME, type Permissions, type SkillsLock } from "@internal/shared";
+import type ora from "ora";
+import { extract } from "tar";
+import { buildSkillKey, type ResolvedNode } from "./dependency-resolver.js";
+import { logger } from "./logger.js";
+
+export interface DownloadedTarball {
+  buffer: Buffer;
+  integrity: string;
+  fromCache: boolean;
+}
+
+interface DownloadTarballWithCacheOptions {
+  cacheDir: string;
+  forceRefresh?: boolean;
+}
+
+function isVerboseMode(): boolean {
+  return process.env.TANK_DEBUG === "1" || process.env.TANK_DEBUG === "true";
+}
+
+function verboseCacheLog(message: string): void {
+  if (isVerboseMode()) {
+    logger.info(`[cache] ${message}`);
+  }
+}
+
+function integrityToSha512Hex(integrity: string): string {
+  if (!integrity.startsWith("sha512-")) {
+    throw new Error(`Invalid integrity format: ${integrity}`);
+  }
+
+  const base64 = integrity.slice("sha512-".length);
+  return Buffer.from(base64, "base64").toString("hex");
+}
+
+function buildIntegrity(buffer: Buffer): string {
+  const hash = crypto.createHash("sha512").update(buffer).digest("base64");
+  return `sha512-${hash}`;
+}
+
+export function getGlobalCacheDir(homedir: string): string {
+  return path.join(homedir, ".tank", "cache");
+}
+
+function getTarballCachePath(cacheDir: string, integrity: string): string {
+  const sha512Hex = integrityToSha512Hex(integrity);
+  return path.join(cacheDir, `${sha512Hex}.tgz`);
+}
+
+function readTarballFromCache(cachePath: string, integrity: string): Buffer | null {
+  if (!fs.existsSync(cachePath)) {
+    return null;
+  }
+
+  try {
+    const cached = fs.readFileSync(cachePath);
+    if (buildIntegrity(cached) !== integrity) {
+      fs.rmSync(cachePath, { force: true });
+      verboseCacheLog(`Cache integrity mismatch at ${cachePath}; removed entry`);
+      return null;
+    }
+    return cached;
+  } catch {
+    fs.rmSync(cachePath, { force: true });
+    return null;
+  }
+}
+
+function writeTarballToCache(cachePath: string, tarball: Buffer): void {
+  fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+  const tmpPath = `${cachePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, tarball);
+  fs.renameSync(tmpPath, cachePath);
+}
+
+async function downloadTarball(url: string, skillLabel: string): Promise<Buffer> {
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    throw new Error(
+      `Network error downloading tarball for ${skillLabel}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to download ${skillLabel}: ${res.status} ${res.statusText}`);
+  }
+
+  return Buffer.from(await res.arrayBuffer());
+}
+
+export async function downloadTarballWithCache(
+  downloadUrl: string,
+  expectedIntegrity: string,
+  skillLabel: string,
+  options: DownloadTarballWithCacheOptions,
+): Promise<DownloadedTarball> {
+  const cachePath = getTarballCachePath(options.cacheDir, expectedIntegrity);
+
+  if (options.forceRefresh) {
+    fs.rmSync(cachePath, { force: true });
+  }
+
+  const cached = readTarballFromCache(cachePath, expectedIntegrity);
+  if (cached) {
+    verboseCacheLog(`Cache hit for ${skillLabel}`);
+    return { buffer: cached, integrity: expectedIntegrity, fromCache: true };
+  }
+
+  verboseCacheLog(`Cache miss for ${skillLabel}`);
+  const downloaded = await downloadTarball(downloadUrl, skillLabel);
+  const computedIntegrity = buildIntegrity(downloaded);
+  if (computedIntegrity !== expectedIntegrity) {
+    throw new Error(`Integrity mismatch for ${skillLabel}. Expected: ${expectedIntegrity}, Got: ${computedIntegrity}`);
+  }
+
+  writeTarballToCache(cachePath, downloaded);
+  return { buffer: downloaded, integrity: computedIntegrity, fromCache: false };
+}
 
 export async function downloadAllParallel(
   nodes: ResolvedNode[],
-  spinner: ReturnType<typeof ora>
-): Promise<Map<string, { buffer: Buffer; integrity: string }>> {
-  const results = new Map<string, { buffer: Buffer; integrity: string }>();
+  spinner: ReturnType<typeof ora>,
+  options: { cacheDir: string },
+): Promise<Map<string, DownloadedTarball>> {
+  const results = new Map<string, DownloadedTarball>();
   const CONCURRENCY_LIMIT = 8;
 
   for (let i = 0; i < nodes.length; i += CONCURRENCY_LIMIT) {
     const batch = nodes.slice(i, i + CONCURRENCY_LIMIT);
     const promises = batch.map(async (node) => {
-      spinner.text = `Downloading ${node.name}@${node.version}...`;
-      let res: Response;
-      try {
-        res = await fetch(node.meta.downloadUrl);
-      } catch (err) {
-        throw new Error(
-          `Network error downloading tarball for ${node.name}@${node.version}: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-      if (!res.ok) {
-        throw new Error(`Failed to download ${node.name}@${node.version}: ${res.status} ${res.statusText}`);
-      }
-
-      const buffer = Buffer.from(await res.arrayBuffer());
-      const hash = crypto.createHash('sha512').update(buffer).digest('base64');
-      const computedIntegrity = `sha512-${hash}`;
-      if (computedIntegrity !== node.meta.integrity) {
-        throw new Error(
-          `Integrity mismatch for ${node.name}@${node.version}. Expected: ${node.meta.integrity}, Got: ${computedIntegrity}`
-        );
-      }
-
-      return { name: node.name, buffer, integrity: computedIntegrity };
+      spinner.text = `Preparing ${node.name}@${node.version}...`;
+      const downloaded = await downloadTarballWithCache(
+        node.meta.downloadUrl,
+        node.meta.integrity,
+        `${node.name}@${node.version}`,
+        {
+          cacheDir: options.cacheDir,
+        },
+      );
+      return { name: node.name, downloaded };
     });
 
     const batchResults = await Promise.all(promises);
     for (const result of batchResults) {
-      results.set(result.name, { buffer: result.buffer, integrity: result.integrity });
+      results.set(result.name, result.downloaded);
     }
   }
 
@@ -61,7 +165,7 @@ export function verifyExtractedDependencies(extractDir: string, node: ResolvedNo
   }
 
   try {
-    const raw = fs.readFileSync(extractedManifestPath, 'utf-8');
+    const raw = fs.readFileSync(extractedManifestPath, "utf-8");
     const manifest = JSON.parse(raw) as Record<string, unknown>;
     const extractedDeps = (manifest.skills ?? {}) as Record<string, string>;
     const apiDeps = node.meta.dependencies;
@@ -85,16 +189,16 @@ export function readExtractedDependencies(extractDir: string): Record<string, st
   }
 
   try {
-    const raw = fs.readFileSync(extractedManifestPath, 'utf-8');
+    const raw = fs.readFileSync(extractedManifestPath, "utf-8");
     const manifest = JSON.parse(raw) as Record<string, unknown>;
     const extractedDeps = manifest.skills;
-    if (!extractedDeps || typeof extractedDeps !== 'object') {
+    if (!extractedDeps || typeof extractedDeps !== "object") {
       return {};
     }
 
     const deps: Record<string, string> = {};
     for (const [depName, depRange] of Object.entries(extractedDeps as Record<string, unknown>)) {
-      if (typeof depRange === 'string') {
+      if (typeof depRange === "string") {
         deps[depName] = depRange;
       }
     }
@@ -107,7 +211,7 @@ export function readExtractedDependencies(extractDir: string): Record<string, st
 export function writeLockfileWithResolvedGraph(
   lock: SkillsLock,
   nodes: ResolvedNode[],
-  downloaded: Map<string, { buffer: Buffer; integrity: string }>
+  downloaded: Map<string, { buffer: Buffer; integrity: string }>,
 ): SkillsLock {
   for (const node of nodes) {
     const key = buildSkillKey(node.name, node.version);
@@ -123,7 +227,7 @@ export function writeLockfileWithResolvedGraph(
       integrity,
       permissions: node.meta.permissions as Permissions,
       audit_score: node.meta.auditScore ?? null,
-      dependencies: node.dependencies
+      dependencies: node.dependencies,
     };
   }
 
@@ -131,7 +235,7 @@ export function writeLockfileWithResolvedGraph(
   for (const key of Object.keys(lock.skills).sort()) {
     sortedSkills[key] = lock.skills[key];
   }
-  lock.skills = sortedSkills as SkillsLock['skills'];
+  lock.skills = sortedSkills as SkillsLock["skills"];
   return lock;
 }
 
@@ -140,7 +244,7 @@ export function writeLockfileWithResolvedGraph(
  * Rejects: absolute paths, path traversal (..), symlinks/hardlinks.
  */
 export async function extractSafely(tarball: Buffer, destDir: string): Promise<void> {
-  const tmpTarball = path.join(destDir, '.tmp-tarball.tgz');
+  const tmpTarball = path.join(destDir, ".tmp-tarball.tgz");
   fs.writeFileSync(tmpTarball, tarball);
 
   try {
@@ -151,16 +255,16 @@ export async function extractSafely(tarball: Buffer, destDir: string): Promise<v
         if (path.isAbsolute(entryPath)) {
           throw new Error(`Absolute path in tarball: ${entryPath}`);
         }
-        if (entryPath.split('/').includes('..') || entryPath.split(path.sep).includes('..')) {
+        if (entryPath.split("/").includes("..") || entryPath.split(path.sep).includes("..")) {
           throw new Error(`Path traversal in tarball: ${entryPath}`);
         }
         return true;
       },
       onReadEntry: (entry) => {
-        if (entry.type === 'SymbolicLink' || entry.type === 'Link') {
+        if (entry.type === "SymbolicLink" || entry.type === "Link") {
           throw new Error(`Symlink/hardlink in tarball: ${entry.path}`);
         }
-      }
+      },
     });
   } finally {
     if (fs.existsSync(tmpTarball)) {
@@ -170,24 +274,24 @@ export async function extractSafely(tarball: Buffer, destDir: string): Promise<v
 }
 
 export function getExtractDir(projectDir: string, skillName: string): string {
-  if (skillName.startsWith('@')) {
-    const [scope, name] = skillName.split('/');
-    return path.join(projectDir, '.tank', 'skills', scope, name);
+  if (skillName.startsWith("@")) {
+    const [scope, name] = skillName.split("/");
+    return path.join(projectDir, ".tank", "skills", scope, name);
   }
-  return path.join(projectDir, '.tank', 'skills', skillName);
+  return path.join(projectDir, ".tank", "skills", skillName);
 }
 
 export function getGlobalExtractDir(homedir: string, skillName: string): string {
-  const globalDir = path.join(homedir, '.tank', 'skills');
-  if (skillName.startsWith('@')) {
-    const [scope, name] = skillName.split('/');
+  const globalDir = path.join(homedir, ".tank", "skills");
+  if (skillName.startsWith("@")) {
+    const [scope, name] = skillName.split("/");
     return path.join(globalDir, scope, name);
   }
   return path.join(globalDir, skillName);
 }
 
 export function parseLockKey(key: string): string {
-  const lastAt = key.lastIndexOf('@');
+  const lastAt = key.lastIndexOf("@");
   if (lastAt <= 0) {
     throw new Error(`Invalid lockfile key: ${key}`);
   }
@@ -195,7 +299,7 @@ export function parseLockKey(key: string): string {
 }
 
 export function parseVersionFromLockKey(key: string): string {
-  const lastAt = key.lastIndexOf('@');
+  const lastAt = key.lastIndexOf("@");
   if (lastAt <= 0 || lastAt === key.length - 1) {
     throw new Error(`Invalid lockfile key: ${key}`);
   }


### PR DESCRIPTION
## Summary
- Add a global content-addressable tarball cache at `~/.tank/cache/{sha512-hex}.tgz` for `tank install` and lockfile installs.
- Reuse cache on hit, persist verified tarballs on miss, and self-heal corrupted cached entries by invalidating and re-downloading when cached extraction fails.
- Add `tank cache clean` and update IDD/BDD artifacts and CLI tests/docs for cache hit, miss, corruption fallback, and cache cleaning.

## Verification
- `bun run --filter '@internal/shared' build`
- `bun run --filter '@tankpkg/cli' build`
- `bun run --filter '@tankpkg/cli' test -- --run`

Fixes #114