### PR TITLE
feat: host versioned JSON Schemas for skills manifests and lockfiles

### DIFF
--- a/.bdd/features/schemas/schema-hosting.feature
+++ b/.bdd/features/schemas/schema-hosting.feature
@@ -1,0 +1,27 @@
+@schemas
+Feature: Versioned JSON Schemas for skill manifests and lockfiles
+  As a Tank user configuring editor validation
+  I need stable, versioned schema URLs for manifest and lockfile formats
+  So that my editor can autocomplete and validate files consistently across machines
+
+  @high
+  Scenario: Web build generates versioned schema files from shared Zod definitions
+    Given shared Zod schemas define the manifest and lockfile contracts
+    When the schema generation build step runs
+    Then public/schemas/v1/skills.json is generated
+    And public/schemas/v1/skills.lock is generated
+    And both generated files are valid JSON Schema documents
+
+  @high
+  Scenario: Generated manifest schema is suitable for editor validation
+    Given the generated file public/schemas/v1/skills.json exists
+    When an editor resolves "$schema" to https://www.tankpkg.dev/schemas/v1/skills.json
+    Then the schema declares object properties for manifest fields
+    And the schema validates a real project tank.json manifest
+
+  @high
+  Scenario: tank init writes a schema URL into generated manifest files
+    Given a user initializes a new skill project
+    When tank init writes tank.json
+    Then tank.json contains "$schema": "https://www.tankpkg.dev/schemas/v1/skills.json"
+    And the generated file still passes runtime Zod validation

--- a/.idd/modules/init/INTENT.md
+++ b/.idd/modules/init/INTENT.md
@@ -44,17 +44,20 @@ shared/src/schemas/skills-json.ts      # skillsJsonSchema — Zod schema for tan
 | C8  | Generated manifest includes `skills: {}` (empty dependency map)                                      | Ready to declare dependencies immediately                               | BDD assertion |
 | C9  | `visibility` defaults to `public` for unscoped names, `private` for scoped names in interactive mode | Sensible defaults aligned with typical use cases                        | BDD assertion |
 | C10 | Invalid name or version inputs return a clear validation error message                               | Developer knows exactly what format is required                         | BDD scenario  |
+| C11 | Generated `tank.json` includes `"$schema": "https://www.tankpkg.dev/schemas/v1/skills.json"`         | Editors can validate/autocomplete manifest fields from a stable URL     | BDD assertion |
+| C12 | `$schema` URL is versioned (`/schemas/v1/`) and does not depend on local filesystem paths            | Team and CI editors resolve the same schema everywhere                  | BDD scenario  |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                                         | Expected Output                                                             |
-| --- | ------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| E1  | `init-skill({ name: "@org/my-skill", version: "1.0.0" })`     | Creates `tank.json` with name, version, permissions block, empty skills map |
-| E2  | `init-skill({ name: "my-skill" })` (unscoped)                 | Creates valid `tank.json` with unscoped name                                |
-| E3  | `init-skill({ name: "UPPERCASE" })`                           | Fails with name validation error (must be lowercase)                        |
-| E4  | `init-skill({ version: "not-semver" })`                       | Fails with version validation error                                         |
-| E5  | `init-skill` when `tank.json` already exists                  | Fails with "already exists" error; file not modified                        |
-| E6  | `init-skill({ force: true })` when `tank.json` already exists | Overwrites existing file; reports "Created tank.json"                       |
-| E7  | `init-skill({ name: "@org/skill", description: "My skill" })` | `tank.json` includes description field                                      |
+| #   | Input                                                         | Expected Output                                                                              |
+| --- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| E1  | `init-skill({ name: "@org/my-skill", version: "1.0.0" })`     | Creates `tank.json` with name, version, permissions block, empty skills map                  |
+| E2  | `init-skill({ name: "my-skill" })` (unscoped)                 | Creates valid `tank.json` with unscoped name                                                 |
+| E3  | `init-skill({ name: "UPPERCASE" })`                           | Fails with name validation error (must be lowercase)                                         |
+| E4  | `init-skill({ version: "not-semver" })`                       | Fails with version validation error                                                          |
+| E5  | `init-skill` when `tank.json` already exists                  | Fails with "already exists" error; file not modified                                         |
+| E6  | `init-skill({ force: true })` when `tank.json` already exists | Overwrites existing file; reports "Created tank.json"                                        |
+| E7  | `init-skill({ name: "@org/skill", description: "My skill" })` | `tank.json` includes description field                                                       |
+| E8  | `tank init --yes --name @org/skill`                           | Created `tank.json` includes `$schema` with `https://www.tankpkg.dev/schemas/v1/skills.json` |

--- a/.idd/modules/publish/INTENT.md
+++ b/.idd/modules/publish/INTENT.md
@@ -40,20 +40,23 @@ packages/web/lib/storage/provider.ts          # Signed URL generation (Supabase 
 | C10 | Step 2 is a direct PUT to signed URL (not proxied through API)                                                    | Avoids proxying large tarballs through Next.js                       | Architecture |
 | C11 | `POST /confirm` only succeeds if version is `pending-upload` status                                               | Idempotency guard: prevents double-confirm                           | BDD scenario |
 | C12 | Scan is triggered synchronously inside confirm; on scan failure → `scan-failed` status but publish still succeeds | Graceful degradation: registry must not go down when scanner is slow | Code review  |
+| C13 | Skills manifest and lockfile JSON Schemas are generated from shared Zod schemas (single source of truth)          | Prevents schema drift between editor UX and runtime validation       | BDD scenario |
+| C14 | Generated schemas are served as static assets at `/schemas/v1/skills.json` and `/schemas/v1/skills.lock`          | Predictable, cacheable URLs without API route complexity             | BDD scenario |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                                            | Expected Output                                              |
-| --- | ---------------------------------------------------------------- | ------------------------------------------------------------ |
-| E1  | `tank publish` in a valid skill directory, authenticated         | 3-step flow completes; success message includes name@version |
-| E2  | `tank publish` without token                                     | Error: "Not logged in. Run: tank login"                      |
-| E3  | `tank publish` with `tank.json` missing `version` field          | 400: invalid manifest, fieldErrors listed                    |
-| E4  | `tank publish` scoped `@nonexistent-org/skill`                   | 404: org not found                                           |
-| E5  | `tank publish` version already in registry                       | 409: "Version already exists"                                |
-| E6  | PATCH bump (`1.0.0 → 1.0.1`) that adds `network.outbound`        | 400: permission escalation, violations array                 |
-| E7  | MAJOR bump (`1.0.0 → 2.0.0`) that adds `network.outbound`        | 200: allowed                                                 |
-| E8  | `tank publish --dry-run`                                         | Prints size/file count, does NOT create a version record     |
-| E9  | `tank publish --private`                                         | Skill created with `visibility = 'private'`                  |
-| E10 | Duplicate confirm call (confirm called twice for same versionId) | 400: "Version is already confirmed or published"             |
+| #   | Input                                                                                  | Expected Output                                               |
+| --- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| E1  | `tank publish` in a valid skill directory, authenticated                               | 3-step flow completes; success message includes name@version  |
+| E2  | `tank publish` without token                                                           | Error: "Not logged in. Run: tank login"                       |
+| E3  | `tank publish` with `tank.json` missing `version` field                                | 400: invalid manifest, fieldErrors listed                     |
+| E4  | `tank publish` scoped `@nonexistent-org/skill`                                         | 404: org not found                                            |
+| E5  | `tank publish` version already in registry                                             | 409: "Version already exists"                                 |
+| E6  | PATCH bump (`1.0.0 → 1.0.1`) that adds `network.outbound`                              | 400: permission escalation, violations array                  |
+| E7  | MAJOR bump (`1.0.0 → 2.0.0`) that adds `network.outbound`                              | 200: allowed                                                  |
+| E8  | `tank publish --dry-run`                                                               | Prints size/file count, does NOT create a version record      |
+| E9  | `tank publish --private`                                                               | Skill created with `visibility = 'private'`                   |
+| E10 | Duplicate confirm call (confirm called twice for same versionId)                       | 400: "Version is already confirmed or published"              |
+| E11 | Web build generates `/public/schemas/v1/skills.json` and `skills.lock` from shared Zod | Published site serves schema files for editor `$schema` usage |

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -9,6 +9,7 @@ vi.mock('@inquirer/prompts', () => ({
 }));
 
 const originalCwd = process.cwd;
+const MANIFEST_SCHEMA_URL = 'https://www.tankpkg.dev/schemas/v1/skills.json';
 
 describe('init command', () => {
   let tmpDir: string;
@@ -60,6 +61,7 @@ describe('init command', () => {
     expect(content.name).toBe('@test-org/my-cool-skill');
     expect(content.version).toBe('1.0.0');
     expect(content.description).toBe('A cool skill');
+    expect(content.$schema).toBe(MANIFEST_SCHEMA_URL);
     expect(content.skills).toEqual({});
     expect(content.permissions).toEqual({
       network: { outbound: [] },
@@ -80,7 +82,7 @@ describe('init command', () => {
 
   it('generates output that passes strict schema validation', async () => {
     const { initCommand } = await import('../commands/init.js');
-    const { skillsJsonSchema } = await import('@internal/shared');
+    const { skillsJsonSchema } = await import('../../../shared/src/schemas/skills-json.js');
     mockPrompts('@test-org/my-skill', '1.2.3', 'A test skill', 'Author Name', false);
 
     await initCommand();
@@ -272,6 +274,7 @@ describe('init command', () => {
       expect(content.name).toBe('@test-org/my-cool-skill');
       expect(content.version).toBe('1.0.0');
       expect(content.description).toBe('A cool skill');
+      expect(content.$schema).toBe(MANIFEST_SCHEMA_URL);
       expect(content.visibility).toBe('public');
       expect(content.skills).toEqual({});
       expect(content.permissions).toEqual({
@@ -291,6 +294,7 @@ describe('init command', () => {
       const content = readOutput();
       expect(content.name).toBe('@test-org/default-skill');
       expect(content.version).toBe('0.1.0');
+      expect(content.$schema).toBe(MANIFEST_SCHEMA_URL);
       expect(content).not.toHaveProperty('description');
       expect(content.visibility).toBe('public');
       expect(content.skills).toEqual({});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { confirm, input } from '@inquirer/prompts';
-import { MANIFEST_FILENAME, skillsJsonSchema } from '@internal/shared';
+import { MANIFEST_FILENAME, MANIFEST_SCHEMA_URL, skillsJsonSchema } from '@internal/shared';
 import { getConfig } from '../lib/config.js';
 import { logger } from '../lib/logger.js';
 import { resolveManifestPath } from '../lib/manifest.js';
@@ -63,6 +63,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     }
 
     const manifest: Record<string, unknown> = {
+      $schema: MANIFEST_SCHEMA_URL,
       name,
       version,
       ...(description ? { description } : {}),
@@ -141,6 +142,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   void author;
 
   const manifest: Record<string, unknown> = {
+    $schema: MANIFEST_SCHEMA_URL,
     name,
     version,
     ...(description ? { description } : {}),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,12 +10,14 @@
   },
   "scripts": {
     "build": "tsdown",
+    "generate:schemas": "bun run scripts/generate-json-schemas.ts",
     "test": "vitest run",
     "lint": "biome check src/",
     "lint:fix": "biome check --fix src/",
     "format": "biome format --write src/"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
     "@types/semver": "^7.7.1",
     "vitest": "^4"
   },

--- a/packages/shared/scripts/generate-json-schemas.ts
+++ b/packages/shared/scripts/generate-json-schemas.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateVersionedSchemas } from '../src/lib/schema-generator.js';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const outputDir = path.resolve(scriptDir, '../../web/public/schemas/v1');
+
+const { manifestPath, lockfilePath } = generateVersionedSchemas(outputDir);
+
+console.log(`Generated schema: ${manifestPath}`);
+console.log(`Generated schema: ${lockfilePath}`);

--- a/packages/shared/src/__tests__/schema-generator.test.ts
+++ b/packages/shared/src/__tests__/schema-generator.test.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Ajv from 'ajv';
+import { afterEach, describe, expect, it } from 'vitest';
+import { LOCKFILE_SCHEMA_URL, MANIFEST_SCHEMA_URL } from '../constants/registry.js';
+import { buildLockfileSchema, buildManifestSchema, generateVersionedSchemas } from '../lib/schema-generator.js';
+
+describe('schema generator', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it('builds manifest and lockfile schema documents with stable ids', () => {
+    const manifest = buildManifestSchema();
+    const lockfile = buildLockfileSchema();
+
+    expect(manifest.$id).toBe(MANIFEST_SCHEMA_URL);
+    expect(lockfile.$id).toBe(LOCKFILE_SCHEMA_URL);
+    expect(manifest.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    expect(lockfile.$schema).toBe('http://json-schema.org/draft-07/schema#');
+  });
+
+  it('writes versioned schema files to disk', () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-schema-gen-'));
+    tempDirs.push(outputDir);
+
+    const { manifestPath, lockfilePath } = generateVersionedSchemas(outputDir);
+
+    expect(manifestPath).toBe(path.join(outputDir, 'skills.json'));
+    expect(lockfilePath).toBe(path.join(outputDir, 'skills.lock'));
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    expect(fs.existsSync(lockfilePath)).toBe(true);
+  });
+
+  it('validates real fixture files using generated schemas', () => {
+    const manifestSchema = buildManifestSchema();
+    const lockfileSchema = buildLockfileSchema();
+
+    const fixtureManifest = JSON.parse(
+      fs.readFileSync(path.resolve(process.cwd(), '../../e2e/fixtures/test-skill/skills.json'), 'utf-8')
+    ) as Record<string, unknown>;
+    const fixtureLockfile = JSON.parse(
+      fs.readFileSync(path.resolve(process.cwd(), '../../e2e/fixtures/test-skill/test/skills.lock'), 'utf-8')
+    ) as Record<string, unknown>;
+
+    const ajv = new Ajv({ strict: false, validateFormats: false });
+    const validateManifest = ajv.compile(manifestSchema);
+    const validateLockfile = ajv.compile(lockfileSchema);
+
+    expect(validateManifest(fixtureManifest)).toBe(true);
+    expect(validateLockfile(fixtureLockfile)).toBe(true);
+  });
+});

--- a/packages/shared/src/__tests__/skills-json.test.ts
+++ b/packages/shared/src/__tests__/skills-json.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { MANIFEST_SCHEMA_URL } from '../constants/registry.js';
 import { skillsJsonSchema } from '../schemas/skills-json.js';
 
 describe('skillsJsonSchema', () => {
@@ -25,6 +26,15 @@ describe('skillsJsonSchema', () => {
 
   it('accepts valid manifest with only required fields (name, version)', () => {
     const result = skillsJsonSchema.safeParse({
+      name: '@my-org/my-skill',
+      version: '1.0.0'
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts canonical $schema url for editor validation', () => {
+    const result = skillsJsonSchema.safeParse({
+      $schema: MANIFEST_SCHEMA_URL,
       name: '@my-org/my-skill',
       version: '1.0.0'
     });

--- a/packages/shared/src/__tests__/skills-lock.test.ts
+++ b/packages/shared/src/__tests__/skills-lock.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { LOCKFILE_SCHEMA_URL } from '../constants/registry.js';
 import { skillsLockSchema } from '../schemas/skills-lock.js';
 
 describe('skillsLockSchema', () => {
@@ -69,6 +70,15 @@ describe('skillsLockSchema', () => {
 
   it('accepts lockfileVersion 2', () => {
     const result = skillsLockSchema.safeParse({
+      lockfileVersion: 2,
+      skills: {}
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts canonical $schema url for editor validation', () => {
+    const result = skillsLockSchema.safeParse({
+      $schema: LOCKFILE_SCHEMA_URL,
       lockfileVersion: 2,
       skills: {}
     });

--- a/packages/shared/src/constants/registry.ts
+++ b/packages/shared/src/constants/registry.ts
@@ -1,13 +1,16 @@
-export const REGISTRY_URL = 'https://tankpkg.dev';
-export const REGISTRY_API_VERSION = 'v1';
+export const REGISTRY_URL = "https://tankpkg.dev";
+export const REGISTRY_API_VERSION = "v1";
 export const MAX_PACKAGE_SIZE = 50 * 1024 * 1024; // 50MB
 export const MAX_FILE_COUNT = 1000;
 export const MAX_NAME_LENGTH = 214;
 export const MAX_DESCRIPTION_LENGTH = 500;
 export const LOCKFILE_VERSION = 2;
+export const SCHEMA_BASE_URL = "https://www.tankpkg.dev/schemas/v1";
+export const MANIFEST_SCHEMA_URL = `${SCHEMA_BASE_URL}/skills.json`;
+export const LOCKFILE_SCHEMA_URL = `${SCHEMA_BASE_URL}/skills.lock`;
 
 // Manifest and lockfile filenames
-export const MANIFEST_FILENAME = 'tank.json';
-export const LEGACY_MANIFEST_FILENAME = 'skills.json';
-export const LOCKFILE_FILENAME = 'tank.lock';
-export const LEGACY_LOCKFILE_FILENAME = 'skills.lock';
+export const MANIFEST_FILENAME = "tank.json";
+export const LEGACY_MANIFEST_FILENAME = "skills.json";
+export const LOCKFILE_FILENAME = "tank.lock";
+export const LEGACY_LOCKFILE_FILENAME = "skills.lock";

--- a/packages/shared/src/constants/registry.ts
+++ b/packages/shared/src/constants/registry.ts
@@ -1,16 +1,16 @@
-export const REGISTRY_URL = "https://tankpkg.dev";
-export const REGISTRY_API_VERSION = "v1";
+export const REGISTRY_URL = 'https://tankpkg.dev';
+export const REGISTRY_API_VERSION = 'v1';
 export const MAX_PACKAGE_SIZE = 50 * 1024 * 1024; // 50MB
 export const MAX_FILE_COUNT = 1000;
 export const MAX_NAME_LENGTH = 214;
 export const MAX_DESCRIPTION_LENGTH = 500;
 export const LOCKFILE_VERSION = 2;
-export const SCHEMA_BASE_URL = "https://www.tankpkg.dev/schemas/v1";
+export const SCHEMA_BASE_URL = 'https://www.tankpkg.dev/schemas/v1';
 export const MANIFEST_SCHEMA_URL = `${SCHEMA_BASE_URL}/skills.json`;
 export const LOCKFILE_SCHEMA_URL = `${SCHEMA_BASE_URL}/skills.lock`;
 
 // Manifest and lockfile filenames
-export const MANIFEST_FILENAME = "tank.json";
-export const LEGACY_MANIFEST_FILENAME = "skills.json";
-export const LOCKFILE_FILENAME = "tank.lock";
-export const LEGACY_LOCKFILE_FILENAME = "skills.lock";
+export const MANIFEST_FILENAME = 'tank.json';
+export const LEGACY_MANIFEST_FILENAME = 'skills.json';
+export const LOCKFILE_FILENAME = 'tank.lock';
+export const LEGACY_LOCKFILE_FILENAME = 'skills.lock';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,26 +1,29 @@
 // Constants
 
 // Brand configuration
-export type { BrandColors, BrandConfig, BrandEnvVars, BrandLogo, BrandSocial } from './brand.js';
-export { DEFAULT_BRAND, hexToOklch, isValidHexColor } from './brand.js';
-export { DEFAULT_PERMISSIONS, PERMISSION_CATEGORIES, type PermissionCategory } from './constants/permissions.js';
+export type { BrandColors, BrandConfig, BrandEnvVars, BrandLogo, BrandSocial } from "./brand.js";
+export { DEFAULT_BRAND, hexToOklch, isValidHexColor } from "./brand.js";
+export { DEFAULT_PERMISSIONS, PERMISSION_CATEGORIES, type PermissionCategory } from "./constants/permissions.js";
 export {
   LEGACY_LOCKFILE_FILENAME,
   LEGACY_MANIFEST_FILENAME,
   LOCKFILE_FILENAME,
+  LOCKFILE_SCHEMA_URL,
   LOCKFILE_VERSION,
   MANIFEST_FILENAME,
+  MANIFEST_SCHEMA_URL,
   MAX_DESCRIPTION_LENGTH,
   MAX_FILE_COUNT,
   MAX_NAME_LENGTH,
   MAX_PACKAGE_SIZE,
   REGISTRY_API_VERSION,
-  REGISTRY_URL
-} from './constants/registry.js';
+  REGISTRY_URL,
+  SCHEMA_BASE_URL,
+} from "./constants/registry.js";
 // Resolver
-export { resolve, sortVersions } from './lib/resolver.js';
+export { resolve, sortVersions } from "./lib/resolver.js";
 // URL helpers
-export { encodeSkillName } from './lib/url.js';
+export { encodeSkillName } from "./lib/url.js";
 
 // Admin types
 export {
@@ -38,23 +41,23 @@ export {
   type UserRole,
   type UserStatus,
   userRoleSchema,
-  userStatusSchema
-} from './schemas/permissions.js';
-export { type SkillsJson, skillsJsonSchema } from './schemas/skills-json.js';
+  userStatusSchema,
+} from "./schemas/permissions.js";
+export { type SkillsJson, skillsJsonSchema } from "./schemas/skills-json.js";
 export {
   type LockedSkill,
   type LockedSkillV1,
   type SkillsLock,
   skillsLockSchema,
-  skillsLockV1Schema
-} from './schemas/skills-lock.js';
+  skillsLockV1Schema,
+} from "./schemas/skills-lock.js";
 export type {
   PublishConfirmRequest,
   PublishStartRequest,
   PublishStartResponse,
   SearchResponse,
   SearchResult,
-  SkillInfoResponse
-} from './types/api.js';
+  SkillInfoResponse,
+} from "./types/api.js";
 // Types
-export type { Publisher, Skill, SkillVersion } from './types/skill.js';
+export type { Publisher, Skill, SkillVersion } from "./types/skill.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,9 +1,9 @@
 // Constants
 
 // Brand configuration
-export type { BrandColors, BrandConfig, BrandEnvVars, BrandLogo, BrandSocial } from "./brand.js";
-export { DEFAULT_BRAND, hexToOklch, isValidHexColor } from "./brand.js";
-export { DEFAULT_PERMISSIONS, PERMISSION_CATEGORIES, type PermissionCategory } from "./constants/permissions.js";
+export type { BrandColors, BrandConfig, BrandEnvVars, BrandLogo, BrandSocial } from './brand.js';
+export { DEFAULT_BRAND, hexToOklch, isValidHexColor } from './brand.js';
+export { DEFAULT_PERMISSIONS, PERMISSION_CATEGORIES, type PermissionCategory } from './constants/permissions.js';
 export {
   LEGACY_LOCKFILE_FILENAME,
   LEGACY_MANIFEST_FILENAME,
@@ -18,12 +18,12 @@ export {
   MAX_PACKAGE_SIZE,
   REGISTRY_API_VERSION,
   REGISTRY_URL,
-  SCHEMA_BASE_URL,
-} from "./constants/registry.js";
+  SCHEMA_BASE_URL
+} from './constants/registry.js';
 // Resolver
-export { resolve, sortVersions } from "./lib/resolver.js";
+export { resolve, sortVersions } from './lib/resolver.js';
 // URL helpers
-export { encodeSkillName } from "./lib/url.js";
+export { encodeSkillName } from './lib/url.js';
 
 // Admin types
 export {
@@ -41,23 +41,23 @@ export {
   type UserRole,
   type UserStatus,
   userRoleSchema,
-  userStatusSchema,
-} from "./schemas/permissions.js";
-export { type SkillsJson, skillsJsonSchema } from "./schemas/skills-json.js";
+  userStatusSchema
+} from './schemas/permissions.js';
+export { type SkillsJson, skillsJsonSchema } from './schemas/skills-json.js';
 export {
   type LockedSkill,
   type LockedSkillV1,
   type SkillsLock,
   skillsLockSchema,
-  skillsLockV1Schema,
-} from "./schemas/skills-lock.js";
+  skillsLockV1Schema
+} from './schemas/skills-lock.js';
 export type {
   PublishConfirmRequest,
   PublishStartRequest,
   PublishStartResponse,
   SearchResponse,
   SearchResult,
-  SkillInfoResponse,
-} from "./types/api.js";
+  SkillInfoResponse
+} from './types/api.js';
 // Types
-export type { Publisher, Skill, SkillVersion } from "./types/skill.js";
+export type { Publisher, Skill, SkillVersion } from './types/skill.js';

--- a/packages/shared/src/lib/schema-generator.ts
+++ b/packages/shared/src/lib/schema-generator.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+import { LOCKFILE_SCHEMA_URL, MANIFEST_SCHEMA_URL } from '../constants/registry.js';
+import { skillsJsonSchema } from '../schemas/skills-json.js';
+import { skillsLockSchema } from '../schemas/skills-lock.js';
+
+type JsonSchemaDocument = z.core.JSONSchema.BaseSchema;
+
+function buildSchemaDocument(schema: z.ZodType, id: string): JsonSchemaDocument {
+  const document = z.toJSONSchema(schema, {
+    target: 'draft-7'
+  }) as JsonSchemaDocument;
+  return {
+    ...document,
+    $id: id
+  };
+}
+
+export function buildManifestSchema(): JsonSchemaDocument {
+  return buildSchemaDocument(skillsJsonSchema, MANIFEST_SCHEMA_URL);
+}
+
+export function buildLockfileSchema(): JsonSchemaDocument {
+  return buildSchemaDocument(skillsLockSchema, LOCKFILE_SCHEMA_URL);
+}
+
+export function generateVersionedSchemas(outputDir: string): { manifestPath: string; lockfilePath: string } {
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const manifestPath = path.join(outputDir, 'skills.json');
+  const lockfilePath = path.join(outputDir, 'skills.lock');
+
+  fs.writeFileSync(manifestPath, JSON.stringify(buildManifestSchema(), null, 2) + '\n');
+  fs.writeFileSync(lockfilePath, JSON.stringify(buildLockfileSchema(), null, 2) + '\n');
+
+  return { manifestPath, lockfilePath };
+}

--- a/packages/shared/src/schemas/skills-json.ts
+++ b/packages/shared/src/schemas/skills-json.ts
@@ -1,28 +1,30 @@
-import { z } from 'zod';
-import { permissionsSchema } from './permissions.js';
+import { z } from "zod";
+import { MANIFEST_SCHEMA_URL } from "../constants/registry.js";
+import { permissionsSchema } from "./permissions.js";
 
 const NAME_PATTERN = /^@[a-z0-9-]+\/[a-z0-9][a-z0-9-]*$/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;
 
 export const skillsJsonSchema = z
   .object({
+    $schema: z.literal(MANIFEST_SCHEMA_URL).optional(),
     name: z
       .string()
-      .min(1, 'Name must not be empty')
-      .max(214, 'Name must be 214 characters or fewer')
-      .regex(NAME_PATTERN, 'Name must be scoped (@org/name), lowercase alphanumeric and hyphens'),
-    version: z.string().regex(SEMVER_PATTERN, 'Version must be valid semver'),
-    description: z.string().max(500, 'Description must be 500 characters or fewer').optional(),
+      .min(1, "Name must not be empty")
+      .max(214, "Name must be 214 characters or fewer")
+      .regex(NAME_PATTERN, "Name must be scoped (@org/name), lowercase alphanumeric and hyphens"),
+    version: z.string().regex(SEMVER_PATTERN, "Version must be valid semver"),
+    description: z.string().max(500, "Description must be 500 characters or fewer").optional(),
     skills: z.record(z.string(), z.string()).optional(),
     permissions: permissionsSchema.optional(),
-    repository: z.string().url('Repository must be a valid URL').optional(),
-    visibility: z.enum(['public', 'private']).optional(),
+    repository: z.string().url("Repository must be a valid URL").optional(),
+    visibility: z.enum(["public", "private"]).optional(),
     audit: z
       .object({
-        min_score: z.number().min(0).max(10)
+        min_score: z.number().min(0).max(10),
       })
       .strict()
-      .optional()
+      .optional(),
   })
   .strict();
 

--- a/packages/shared/src/schemas/skills-json.ts
+++ b/packages/shared/src/schemas/skills-json.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
-import { MANIFEST_SCHEMA_URL } from "../constants/registry.js";
-import { permissionsSchema } from "./permissions.js";
+import { z } from 'zod';
+import { MANIFEST_SCHEMA_URL } from '../constants/registry.js';
+import { permissionsSchema } from './permissions.js';
 
 const NAME_PATTERN = /^@[a-z0-9-]+\/[a-z0-9][a-z0-9-]*$/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;
@@ -10,21 +10,21 @@ export const skillsJsonSchema = z
     $schema: z.literal(MANIFEST_SCHEMA_URL).optional(),
     name: z
       .string()
-      .min(1, "Name must not be empty")
-      .max(214, "Name must be 214 characters or fewer")
-      .regex(NAME_PATTERN, "Name must be scoped (@org/name), lowercase alphanumeric and hyphens"),
-    version: z.string().regex(SEMVER_PATTERN, "Version must be valid semver"),
-    description: z.string().max(500, "Description must be 500 characters or fewer").optional(),
+      .min(1, 'Name must not be empty')
+      .max(214, 'Name must be 214 characters or fewer')
+      .regex(NAME_PATTERN, 'Name must be scoped (@org/name), lowercase alphanumeric and hyphens'),
+    version: z.string().regex(SEMVER_PATTERN, 'Version must be valid semver'),
+    description: z.string().max(500, 'Description must be 500 characters or fewer').optional(),
     skills: z.record(z.string(), z.string()).optional(),
     permissions: permissionsSchema.optional(),
-    repository: z.string().url("Repository must be a valid URL").optional(),
-    visibility: z.enum(["public", "private"]).optional(),
+    repository: z.string().url('Repository must be a valid URL').optional(),
+    visibility: z.enum(['public', 'private']).optional(),
     audit: z
       .object({
-        min_score: z.number().min(0).max(10),
+        min_score: z.number().min(0).max(10)
       })
       .strict()
-      .optional(),
+      .optional()
   })
   .strict();
 

--- a/packages/shared/src/schemas/skills-lock.ts
+++ b/packages/shared/src/schemas/skills-lock.ts
@@ -1,18 +1,20 @@
-import { z } from 'zod';
-import { permissionsSchema } from './permissions.js';
+import { z } from "zod";
+import { LOCKFILE_SCHEMA_URL } from "../constants/registry.js";
+import { permissionsSchema } from "./permissions.js";
 
 // ── v1 (legacy, read-only) ──────────────────────────────────────────────────
 
 export const lockedSkillV1Schema = z.object({
   resolved: z.string().url(),
-  integrity: z.string().regex(/^sha512-/, 'Integrity must start with sha512-'),
+  integrity: z.string().regex(/^sha512-/, "Integrity must start with sha512-"),
   permissions: permissionsSchema,
-  audit_score: z.number().min(0).max(10).nullable()
+  audit_score: z.number().min(0).max(10).nullable(),
 });
 
 export const skillsLockV1Schema = z.object({
+  $schema: z.literal(LOCKFILE_SCHEMA_URL).optional(),
   lockfileVersion: z.literal(1),
-  skills: z.record(z.string(), lockedSkillV1Schema)
+  skills: z.record(z.string(), lockedSkillV1Schema),
 });
 
 // ── v2 (current) ────────────────────────────────────────────────────────────
@@ -21,16 +23,17 @@ export const skillsLockV1Schema = z.object({
 
 export const lockedSkillSchema = z.object({
   resolved: z.string().url(),
-  integrity: z.string().regex(/^sha512-/, 'Integrity must start with sha512-'),
+  integrity: z.string().regex(/^sha512-/, "Integrity must start with sha512-"),
   permissions: permissionsSchema,
   audit_score: z.number().min(0).max(10).nullable(),
   /** Resolved dependency edges: skill name → resolved version. */
-  dependencies: z.record(z.string(), z.string()).optional()
+  dependencies: z.record(z.string(), z.string()).optional(),
 });
 
 export const skillsLockSchema = z.object({
+  $schema: z.literal(LOCKFILE_SCHEMA_URL).optional(),
   lockfileVersion: z.union([z.literal(1), z.literal(2)]),
-  skills: z.record(z.string(), lockedSkillSchema)
+  skills: z.record(z.string(), lockedSkillSchema),
 });
 
 export type LockedSkillV1 = z.infer<typeof lockedSkillV1Schema>;

--- a/packages/shared/src/schemas/skills-lock.ts
+++ b/packages/shared/src/schemas/skills-lock.ts
@@ -1,20 +1,20 @@
-import { z } from "zod";
-import { LOCKFILE_SCHEMA_URL } from "../constants/registry.js";
-import { permissionsSchema } from "./permissions.js";
+import { z } from 'zod';
+import { LOCKFILE_SCHEMA_URL } from '../constants/registry.js';
+import { permissionsSchema } from './permissions.js';
 
 // ── v1 (legacy, read-only) ──────────────────────────────────────────────────
 
 export const lockedSkillV1Schema = z.object({
   resolved: z.string().url(),
-  integrity: z.string().regex(/^sha512-/, "Integrity must start with sha512-"),
+  integrity: z.string().regex(/^sha512-/, 'Integrity must start with sha512-'),
   permissions: permissionsSchema,
-  audit_score: z.number().min(0).max(10).nullable(),
+  audit_score: z.number().min(0).max(10).nullable()
 });
 
 export const skillsLockV1Schema = z.object({
   $schema: z.literal(LOCKFILE_SCHEMA_URL).optional(),
   lockfileVersion: z.literal(1),
-  skills: z.record(z.string(), lockedSkillV1Schema),
+  skills: z.record(z.string(), lockedSkillV1Schema)
 });
 
 // ── v2 (current) ────────────────────────────────────────────────────────────
@@ -23,17 +23,17 @@ export const skillsLockV1Schema = z.object({
 
 export const lockedSkillSchema = z.object({
   resolved: z.string().url(),
-  integrity: z.string().regex(/^sha512-/, "Integrity must start with sha512-"),
+  integrity: z.string().regex(/^sha512-/, 'Integrity must start with sha512-'),
   permissions: permissionsSchema,
   audit_score: z.number().min(0).max(10).nullable(),
   /** Resolved dependency edges: skill name → resolved version. */
-  dependencies: z.record(z.string(), z.string()).optional(),
+  dependencies: z.record(z.string(), z.string()).optional()
 });
 
 export const skillsLockSchema = z.object({
   $schema: z.literal(LOCKFILE_SCHEMA_URL).optional(),
   lockfileVersion: z.union([z.literal(1), z.literal(2)]),
-  skills: z.record(z.string(), lockedSkillSchema),
+  skills: z.record(z.string(), lockedSkillSchema)
 });
 
 export type LockedSkillV1 = z.infer<typeof lockedSkillV1Schema>;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "bun run generate:schemas && next build",
+    "generate:schemas": "bun run --cwd ../shared generate:schemas",
     "start": "next start",
     "test": "vitest run",
     "lint": "npx react-doctor .",

--- a/packages/web/public/schemas/v1/skills.json
+++ b/packages/web/public/schemas/v1/skills.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://www.tankpkg.dev/schemas/v1/skills.json"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 214,
+      "pattern": "^@[a-z0-9-]+\\/[a-z0-9][a-z0-9-]*$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$"
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 500
+    },
+    "skills": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "properties": {
+        "network": {
+          "type": "object",
+          "properties": {
+            "outbound": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "filesystem": {
+          "type": "object",
+          "properties": {
+            "read": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "write": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "subprocess": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "repository": {
+      "type": "string",
+      "format": "uri"
+    },
+    "visibility": {
+      "type": "string",
+      "enum": [
+        "public",
+        "private"
+      ]
+    },
+    "audit": {
+      "type": "object",
+      "properties": {
+        "min_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10
+        }
+      },
+      "required": [
+        "min_score"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "name",
+    "version"
+  ],
+  "additionalProperties": false,
+  "$id": "https://www.tankpkg.dev/schemas/v1/skills.json"
+}

--- a/packages/web/public/schemas/v1/skills.json
+++ b/packages/web/public/schemas/v1/skills.json
@@ -74,10 +74,7 @@
     },
     "visibility": {
       "type": "string",
-      "enum": [
-        "public",
-        "private"
-      ]
+      "enum": ["public", "private"]
     },
     "audit": {
       "type": "object",
@@ -88,16 +85,11 @@
           "maximum": 10
         }
       },
-      "required": [
-        "min_score"
-      ],
+      "required": ["min_score"],
       "additionalProperties": false
     }
   },
-  "required": [
-    "name",
-    "version"
-  ],
+  "required": ["name", "version"],
   "additionalProperties": false,
   "$id": "https://www.tankpkg.dev/schemas/v1/skills.json"
 }

--- a/packages/web/public/schemas/v1/skills.lock
+++ b/packages/web/public/schemas/v1/skills.lock
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://www.tankpkg.dev/schemas/v1/skills.lock"
+    },
+    "lockfileVersion": {
+      "anyOf": [
+        {
+          "type": "number",
+          "const": 1
+        },
+        {
+          "type": "number",
+          "const": 2
+        }
+      ]
+    },
+    "skills": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "resolved": {
+            "type": "string",
+            "format": "uri"
+          },
+          "integrity": {
+            "type": "string",
+            "pattern": "^sha512-"
+          },
+          "permissions": {
+            "type": "object",
+            "properties": {
+              "network": {
+                "type": "object",
+                "properties": {
+                  "outbound": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "filesystem": {
+                "type": "object",
+                "properties": {
+                  "read": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "write": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "subprocess": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "audit_score": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 10
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "dependencies": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "resolved",
+          "integrity",
+          "permissions",
+          "audit_score"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "lockfileVersion",
+    "skills"
+  ],
+  "additionalProperties": false,
+  "$id": "https://www.tankpkg.dev/schemas/v1/skills.lock"
+}


### PR DESCRIPTION
## Summary
- generate versioned static JSON Schemas from shared Zod schemas into `packages/web/public/schemas/v1/skills.json` and `packages/web/public/schemas/v1/skills.lock`
- include `\"$schema\"` in `tank init` output and keep runtime validation aligned by allowing canonical schema URLs in shared schemas
- add IDD/BDD artifacts and tests that validate generated schemas against real fixture `skills.json` and `skills.lock`

## Verification
- `bun --filter=@internal/shared run test`
- `bun --filter=@tankpkg/cli run test src/__tests__/init.test.ts`
- `bun --filter=@internal/web run build`

Fixes #85