### PR TITLE
fix(web): barrel must import from utils, not 'use client' module

### DIFF
--- a/packages/web/components/security/index.ts
+++ b/packages/web/components/security/index.ts
@@ -1,6 +1,7 @@
 export { FindingsList } from './FindingsList';
-export type { QualityCategory, QualityCategoryName } from './QualityChecks';
-export { computeQualityChecks, QualityChecks } from './QualityChecks';
+export { QualityChecks } from './QualityChecks';
+export type { QualityCategory, QualityCategoryName } from './quality-checks-utils';
+export { computeQualityChecks } from './quality-checks-utils';
 export { ScanningToolsStrip } from './ScanningToolsStrip';
 export { ScanPipeline } from './ScanPipeline';
 export { SecurityOverview } from './SecurityOverview';


### PR DESCRIPTION
## Summary
- Follow-up to #191 — re-exporting `computeQualityChecks` through a `'use client'` file still taints it as a client reference
- Fix: barrel `index.ts` now imports types + function directly from `quality-checks-utils.ts`, bypassing the client boundary entirely
- Verified locally: `bun run build` + `curl` on `/skills/@tank/tailscale-expert` → HTTP 200, zero RSC errors