### PR TITLE
fix(web): replace numeric security score with trust badge in sidebar

### DIFF
--- a/packages/web/app/(registry)/skills/[...name]/page.tsx
+++ b/packages/web/app/(registry)/skills/[...name]/page.tsx
@@ -9,6 +9,7 @@ import {
   ScanningToolsStrip,
   ScanPipeline,
   SecurityOverview,
+  SecuritySidebarSummary,
   TrustBadge,
   VerifiedPublisherBadge
 } from '@/components/security';
@@ -632,105 +633,24 @@ export default async function SkillDetailPage({ params }: SkillDetailPageProps) 
               </dl>
             </div>
 
-            {data.latestVersion?.auditScore != null && (
+            {scanDetails && (
               <>
                 <Separator />
                 <div>
                   <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
                     Security
                   </h3>
-                  {/* Score with progress bar */}
-                  <div className="flex items-center gap-2 mb-2">
-                    <span
-                      className={`text-2xl font-bold ${
-                        data.latestVersion.auditScore >= 8
-                          ? 'text-green-600'
-                          : data.latestVersion.auditScore >= 6
-                            ? 'text-yellow-600'
-                            : data.latestVersion.auditScore >= 4
-                              ? 'text-orange-600'
-                              : 'text-red-600'
-                      }`}>
-                      {data.latestVersion.auditScore}
-                    </span>
-                    <span className="text-sm text-muted-foreground">/10</span>
-                  </div>
-                  <div className="h-2 bg-muted rounded-full overflow-hidden mb-3">
-                    <div
-                      className={`h-full transition-all ${
-                        data.latestVersion.auditScore >= 8
-                          ? 'bg-green-500'
-                          : data.latestVersion.auditScore >= 6
-                            ? 'bg-yellow-500'
-                            : data.latestVersion.auditScore >= 4
-                              ? 'bg-orange-500'
-                              : 'bg-red-500'
-                      }`}
-                      style={{ width: `${(data.latestVersion.auditScore / 10) * 100}%` }}
-                    />
-                  </div>
-
-                  {/* Verdict badge */}
-                  {scanDetails?.verdict && (
-                    <div
-                      className={`inline-flex px-2 py-1 rounded text-xs font-medium text-white mb-2 ${
-                        scanDetails.verdict === 'pass'
-                          ? 'bg-green-600'
-                          : scanDetails.verdict === 'pass_with_notes'
-                            ? 'bg-yellow-600'
-                            : scanDetails.verdict === 'flagged'
-                              ? 'bg-orange-600'
-                              : 'bg-red-600'
-                      }`}>
-                      {scanDetails.verdict.replace('_', ' ').toUpperCase()}
-                    </div>
-                  )}
-
-                  {/* Finding counts summary */}
-                  <div className="text-xs space-y-1 mb-3">
-                    {(scanDetails?.criticalCount ?? 0) > 0 && (
-                      <div className="flex items-center gap-2 text-red-600">
-                        <span>●</span>
-                        <span>
-                          {scanDetails?.criticalCount} critical finding
-                          {(scanDetails?.criticalCount ?? 0) !== 1 ? 's' : ''}
-                        </span>
-                      </div>
-                    )}
-                    {(scanDetails?.highCount ?? 0) > 0 && (
-                      <div className="flex items-center gap-2 text-orange-600">
-                        <span>●</span>
-                        <span>
-                          {scanDetails?.highCount} high finding{(scanDetails?.highCount ?? 0) !== 1 ? 's' : ''}
-                        </span>
-                      </div>
-                    )}
-                    {(scanDetails?.mediumCount ?? 0) > 0 && (
-                      <div className="flex items-center gap-2 text-yellow-600">
-                        <span>●</span>
-                        <span>
-                          {scanDetails?.mediumCount} medium finding{(scanDetails?.mediumCount ?? 0) !== 1 ? 's' : ''}
-                        </span>
-                      </div>
-                    )}
-                    {(scanDetails?.lowCount ?? 0) > 0 && (
-                      <div className="flex items-center gap-2 text-blue-600">
-                        <span>●</span>
-                        <span>
-                          {scanDetails?.lowCount} low finding{(scanDetails?.lowCount ?? 0) !== 1 ? 's' : ''}
-                        </span>
-                      </div>
-                    )}
-                    {(scanDetails?.findings?.length ?? 0) === 0 && (
-                      <div className="flex items-center gap-2 text-green-600">
-                        <span>✓</span>
-                        <span>No security issues</span>
-                      </div>
-                    )}
-                  </div>
-
+                  <SecuritySidebarSummary
+                    verdict={scanDetails.verdict}
+                    criticalCount={scanDetails.criticalCount}
+                    highCount={scanDetails.highCount}
+                    mediumCount={scanDetails.mediumCount}
+                    lowCount={scanDetails.lowCount}
+                  />
                   {hasSecurityData && (
-                    <p className="text-xs text-muted-foreground">Open the Security tab above for the full report.</p>
+                    <p className="text-xs text-muted-foreground mt-3">
+                      Open the Security tab above for the full report.
+                    </p>
                   )}
                 </div>
               </>

--- a/packages/web/components/security/SecuritySidebarSummary.tsx
+++ b/packages/web/components/security/SecuritySidebarSummary.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { computeTrustLevel } from '@/lib/trust-level';
+import { TrustBadge } from './TrustBadge';
+
+interface SecuritySidebarSummaryProps {
+  verdict: string | null;
+  criticalCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+}
+
+/**
+ * Compact security summary for skill page sidebar.
+ * Replaces the old numeric score display with trust-level-based status.
+ */
+export function SecuritySidebarSummary({
+  verdict,
+  criticalCount,
+  highCount,
+  mediumCount,
+  lowCount
+}: SecuritySidebarSummaryProps) {
+  const trustLevel = computeTrustLevel(verdict, criticalCount, highCount, mediumCount, lowCount);
+  const totalFindings = criticalCount + highCount + mediumCount + lowCount;
+
+  // Build description based on trust level and findings
+  const getDescription = (): string => {
+    if (trustLevel === 'pending') {
+      return 'Awaiting security scan';
+    }
+    if (trustLevel === 'verified') {
+      return 'Clean security scan';
+    }
+    if (totalFindings === 0) {
+      return 'No security issues';
+    }
+
+    // Build findings summary
+    const parts: string[] = [];
+    if (criticalCount > 0) parts.push(`${criticalCount} critical`);
+    if (highCount > 0) parts.push(`${highCount} high`);
+    if (mediumCount > 0) parts.push(`${mediumCount} medium`);
+    if (lowCount > 0) parts.push(`${lowCount} low`);
+
+    return `${parts.join(', ')} ${totalFindings === 1 ? 'finding' : 'findings'}`;
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Trust Badge */}
+      <TrustBadge
+        trustLevel={trustLevel}
+        findings={{ critical: criticalCount, high: highCount, medium: mediumCount, low: lowCount }}
+        size="sm"
+      />
+
+      {/* Description */}
+      <p className="text-xs text-muted-foreground">{getDescription()}</p>
+    </div>
+  );
+}

--- a/packages/web/components/security/index.ts
+++ b/packages/web/components/security/index.ts
@@ -5,5 +5,6 @@ export { computeQualityChecks } from './quality-checks-utils';
 export { ScanningToolsStrip } from './ScanningToolsStrip';
 export { ScanPipeline } from './ScanPipeline';
 export { SecurityOverview } from './SecurityOverview';
+export { SecuritySidebarSummary } from './SecuritySidebarSummary';
 export { TrustBadge } from './TrustBadge';
 export { VerifiedPublisherBadge } from './VerifiedPublisherBadge';


### PR DESCRIPTION
## Summary

- Remove misleading X/10 numeric score display from skill page sidebar
- Add `SecuritySidebarSummary` component using trust-level-based status
- Shows "Verified", "Review Recommended", "Concerns", or "Unsafe" instead of numbers
- Reduces ~100 lines of inline code to 15-line component call

## Problem

The numeric score was confusing users:
- "8" looked like "8 failed" rather than "score of 8 out of 10"
- Score didn't match verdict (e.g., 6/10 but "PASS WITH NOTES")

## Solution

Replace the score with a trust-level-based display using existing `TrustBadge` component:

**Before:**
```
Security
─────────
8/10  [=====-====]
PASS WITH NOTES
● 2 medium findings
```

**After:**
```
Security
─────────
⚠️ Review Recommended
2 medium findings
```

## Test Plan

- [x] Build passes
- [x] Lint passes
- [x] All 295 tests pass
- [x] Code review completed