### PR TITLE
fix(scanner): correct detect-secrets import function name

### DIFF
--- a/packages/scanner/lib/scan/stage4_secrets.py
+++ b/packages/scanner/lib/scan/stage4_secrets.py
@@ -112,10 +112,10 @@ def run_detect_secrets(temp_dir: str) -> list[Finding]:
             }
         ) as settings:
             # Scan the temp directory
-            from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_plugin_class
+            from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_class
             from detect_secrets.core.scan import get_files_to_scan
 
-            plugin_map = get_mapping_from_secret_type_to_plugin_class()
+            plugin_map = get_mapping_from_secret_type_to_class()
 
             for file_path in get_files_to_scan([temp_dir], settings):
                 try:

--- a/packages/scanner/tests/test_detect_secrets_available.py
+++ b/packages/scanner/tests/test_detect_secrets_available.py
@@ -1,0 +1,46 @@
+"""Regression test for detect-secrets library availability.
+
+This test verifies that the detect-secrets library is properly installed
+and importable. It was added after a production incident where secrets
+scanning was skipped due to an ImportError.
+
+Bug: detect-secrets library not available - skipping comprehensive secret scan
+Root cause: Wrong function name in import - used `get_mapping_from_secret_type_to_plugin_class`
+            instead of `get_mapping_from_secret_type_to_class`
+"""
+
+import pytest
+
+
+class TestDetectSecretsAvailable:
+    """Tests that verify detect-secrets library is available at runtime."""
+
+    def test_detect_secrets_importable(self):
+        """detect-secrets library must be importable for Stage 4 secrets scanning."""
+        try:
+            from detect_secrets.settings import transient_settings
+
+            assert transient_settings is not None
+        except ImportError as e:
+            pytest.fail(
+                f"detect-secrets library not available: {e}. This is a critical dependency for Stage 4 secrets scanning."
+            )
+
+    def test_detect_secrets_core_importable(self):
+        """detect-secrets core scanning functions must be importable."""
+        try:
+            from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_class
+            from detect_secrets.core.scan import get_files_to_scan
+
+            assert get_mapping_from_secret_type_to_class is not None
+            assert get_files_to_scan is not None
+        except ImportError as e:
+            pytest.fail(f"detect-secrets core modules not available: {e}")
+
+    def test_detect_secrets_version_via_pip(self):
+        """Verify detect-secrets is installed via pip show."""
+        import subprocess
+
+        result = subprocess.run(["pip", "show", "detect-secrets"], capture_output=True, text=True)
+        assert result.returncode == 0, "detect-secrets not installed"
+        assert "detect-secrets" in result.stdout


### PR DESCRIPTION
## Summary
- Fix typo in detect-secrets import function name in `stage4_secrets.py`
- Add regression test to prevent future import failures

## Root Cause
The error "detect-secrets library not available - skipping comprehensive secret scan" was NOT caused by missing dependencies. The library was installed, but the import failed due to a typo:
- **Incorrect**: `get_mapping_from_secret_type_to_plugin_class`
- **Correct**: `get_mapping_from_secret_type_to_class`

## Test Plan
- [x] All 18 scanner tests pass locally
- [x] New regression test verifies detect-secrets is importable
- [x] `test_secrets_hardcoded` now properly detects hardcoded credentials

🤖 Generated with [Claude Code](https://claude.ai/code)