### PR TITLE
fix(ci): disable Supabase Edge Runtime in local development config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -350,7 +350,7 @@ authorization_url_path = "/oauth/consent"
 allow_dynamic_registration = false
 
 [edge_runtime]
-enabled = true
+enabled = false
 # Supported request policies: `oneshot`, `per_worker`.
 # `per_worker` (default) — enables hot reload during local development.
 # `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).


### PR DESCRIPTION
## Summary
- Disables Supabase Edge Runtime in `supabase/config.toml` 
- Fixes 502 error during `supabase start` in CI performance tests

## Root Cause
Edge Runtime was enabled (`enabled = true`) but the project has no edge functions (no `supabase/functions/` directory). The Edge Runtime container was crashing with a 502 error.

The project only uses Supabase for storage (signed URLs for package uploads/downloads), not edge functions.

## Test Plan
- [ ] CI performance job passes with `supabase start` succeeding