### PR TITLE
fix: copy Nitro build output to root for Vercel Build Output API

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "buildCommand": "bun turbo build --filter=registry...",
-  "outputDirectory": "apps/registry/.vercel/output",
+  "buildCommand": "bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
   "installCommand": "bun install",
   "devCommand": "bun --filter registry run dev",
   "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; exit 0"


### PR DESCRIPTION
Vercel Build Output API expects .vercel/output/ at repo root. Nitro writes to apps/registry/.vercel/output/. Adds cp -r after turbo build.