### PR TITLE
fix: use relative path for build-docs script

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3001",
-    "build": "bun scripts/build-docs.ts && vite build",
+    "build": "bun ./scripts/build-docs.ts && vite build",
     "start": "node .output/server/index.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Bun needs ./scripts/ not scripts/ when run from turbo CWD.