### PR TITLE
fix: .vercelignore scripts exclusion too broad

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -10,7 +10,7 @@ node_modules
 infra
 docs
 idd
-scripts
+/scripts
 Formula
 action
 build


### PR DESCRIPTION
scripts matched apps/registry/scripts/ — build-docs.mjs was excluded from upload.