### PR TITLE
fix: vercelignore docs pattern excludes content/docs

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -8,12 +8,11 @@
 .claude
 node_modules
 infra
-docs
+/docs
 idd
-scripts
+/scripts
 Formula
 action
-build
 apps/web
 apps/cli/build
 apps/registry-legacy


### PR DESCRIPTION
Bare 'docs' pattern in .vercelignore removes apps/registry/content/docs/ after git clone, breaking build-docs.mjs. Changed to '/docs' and '/scripts' for root-only matching.