### PR TITLE
fix(web): enable GitHub login, admin stats, login redirect & token creation

### DIFF
--- a/apps/registry/src/api/routes/v1/cli-auth.ts
+++ b/apps/registry/src/api/routes/v1/cli-auth.ts
@@ -152,6 +152,7 @@ export const cliAuthRoutes = new Hono()
       }
 
       const apiKeyResult = await auth.api.createApiKey({
+        headers: c.req.raw.headers,
         body: {
           name: 'CLI Token',
           userId: session.userId,

--- a/apps/registry/src/lib/auth/tokens.ts
+++ b/apps/registry/src/lib/auth/tokens.ts
@@ -37,7 +37,7 @@ export const listTokensFn = createServerFn({ method: 'GET' }).handler(async () =
 export const createTokenFn = createServerFn({ method: 'POST' })
   .inputValidator((input: { name: string; expiresInDays?: number; scopes?: string[] }) => input)
   .handler(async ({ data }) => {
-    const { session } = await requireSession();
+    const { session, headers } = await requireSession();
     const { name, expiresInDays, scopes } = data;
 
     const normalizedScopes = normalizeScopes(scopes);
@@ -47,6 +47,7 @@ export const createTokenFn = createServerFn({ method: 'POST' })
         : 90;
 
     const result = await auth.api.createApiKey({
+      headers,
       body: {
         name,
         userId: session.user.id,

--- a/apps/registry/src/query/admin.ts
+++ b/apps/registry/src/query/admin.ts
@@ -1,0 +1,25 @@
+import { createServerFn } from '@tanstack/react-start';
+import { getRequestHeaders } from '@tanstack/react-start/server';
+import { sql } from 'drizzle-orm';
+import { isAdmin } from '~/lib/auth/authz';
+import { auth } from '~/lib/auth/core';
+import { db } from '~/lib/db';
+
+export const getAdminStatsFn = createServerFn({ method: 'GET' }).handler(async () => {
+  const headers = getRequestHeaders();
+  const session = await auth.api.getSession({ headers });
+  if (!session) throw new Error('Unauthorized');
+  if (!(await isAdmin(session.user.id))) throw new Error('Forbidden');
+
+  const [[usersRow], [skillsRow], [auditRow]] = await Promise.all([
+    db.execute<{ count: number }>(sql`SELECT count(*)::int AS count FROM "user"`),
+    db.execute<{ count: number }>(sql`SELECT count(*)::int AS count FROM skills`),
+    db.execute<{ count: number }>(sql`SELECT count(*)::int AS count FROM audit_events`)
+  ]);
+
+  return {
+    users: usersRow?.count ?? 0,
+    skills: skillsRow?.count ?? 0,
+    auditEvents: auditRow?.count ?? 0
+  };
+});

--- a/apps/registry/src/routes/cli-login.tsx
+++ b/apps/registry/src/routes/cli-login.tsx
@@ -6,9 +6,9 @@ export const Route = createFileRoute('/cli-login')({
   validateSearch: (search: Record<string, unknown>) => ({
     session: (search.session as string) || ''
   }),
-  beforeLoad: async () => {
+  beforeLoad: async ({ search }) => {
     const session = await getSession();
-    if (!session) throw redirect({ to: '/login' });
+    if (!session) throw redirect({ to: '/login', search: { redirect: `/cli-login?session=${search.session}` } });
   },
   head: () => ({ meta: [{ title: 'Authorize CLI | Tank' }] }),
   component: CliLoginPage

--- a/apps/registry/src/routes/login.tsx
+++ b/apps/registry/src/routes/login.tsx
@@ -10,6 +10,9 @@ const settings = routeHead({
 });
 
 export const Route = createFileRoute('/login')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    redirect: (search.redirect as string) || ''
+  }),
   loader: async () => {
     const { providers, oidcProviderId } = await getAuthProviders();
     return { providers, oidcProviderId };
@@ -20,10 +23,15 @@ export const Route = createFileRoute('/login')({
 
 function LoginPage() {
   const { providers, oidcProviderId } = Route.useLoaderData();
+  const { redirect } = Route.useSearch();
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <LoginScreen enabledProviders={new Set(providers)} oidcProviderId={oidcProviderId} />
+      <LoginScreen
+        enabledProviders={new Set(providers)}
+        oidcProviderId={oidcProviderId}
+        redirect={redirect || undefined}
+      />
     </div>
   );
 }

--- a/apps/registry/src/screens/admin-screen.tsx
+++ b/apps/registry/src/screens/admin-screen.tsx
@@ -1,14 +1,38 @@
 import { FileText, Package, Users } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+import { getAdminStatsFn } from '~/query/admin';
 
-const adminCards = [
-  { title: 'Users', icon: Users, value: '--', description: 'Registered accounts' },
-  { title: 'Packages', icon: Package, value: '--', description: 'Published skills' },
-  { title: 'Audit Logs', icon: FileText, value: '--', description: 'Recent events' }
-] as const;
+interface AdminStats {
+  users: number;
+  skills: number;
+  auditEvents: number;
+}
 
 export function AdminScreen() {
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await getAdminStatsFn();
+      setStats(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load stats');
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const cards = [
+    { title: 'Users', icon: Users, value: stats?.users ?? '--', description: 'Registered accounts' },
+    { title: 'Packages', icon: Package, value: stats?.skills ?? '--', description: 'Published skills' },
+    { title: 'Audit Logs', icon: FileText, value: stats?.auditEvents ?? '--', description: 'Recent events' }
+  ] as const;
+
   return (
     <section className="tank-shell py-10 space-y-8">
       <div>
@@ -16,8 +40,14 @@ export function AdminScreen() {
         <p className="mt-1 text-ink-soft">System overview and management.</p>
       </div>
 
+      {error && (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {adminCards.map((card) => (
+        {cards.map((card) => (
           <Card key={card.title}>
             <CardHeader className="flex flex-row items-center justify-between pb-2">
               <CardTitle className="text-sm font-medium text-muted-foreground">{card.title}</CardTitle>

--- a/apps/registry/src/screens/login-screen.tsx
+++ b/apps/registry/src/screens/login-screen.tsx
@@ -10,9 +10,10 @@ import { authClient } from '~/lib/auth/client';
 interface LoginScreenProps {
   enabledProviders: Set<string>;
   oidcProviderId: string;
+  redirect?: string;
 }
 
-export function LoginScreen({ enabledProviders, oidcProviderId }: LoginScreenProps) {
+export function LoginScreen({ enabledProviders, oidcProviderId, redirect }: LoginScreenProps) {
   const githubEnabled = enabledProviders.has('github');
   const oidcEnabled = enabledProviders.has('oidc');
   const [mode, setMode] = useState<'signin' | 'signup'>('signin');
@@ -28,7 +29,7 @@ export function LoginScreen({ enabledProviders, oidcProviderId }: LoginScreenPro
         const result = await authClient.signIn.email({
           email: value.email,
           password: value.password,
-          callbackURL: '/dashboard'
+          callbackURL: redirect || '/dashboard'
         });
         if (result.error) {
           setError(result.error.message || 'Failed to sign in');
@@ -38,7 +39,7 @@ export function LoginScreen({ enabledProviders, oidcProviderId }: LoginScreenPro
           name: value.name || value.email.split('@')[0] || 'User',
           email: value.email,
           password: value.password,
-          callbackURL: '/dashboard'
+          callbackURL: redirect || '/dashboard'
         });
         if (result.error) {
           setError(result.error.message || 'Failed to create account');
@@ -57,7 +58,7 @@ export function LoginScreen({ enabledProviders, oidcProviderId }: LoginScreenPro
     setError(null);
     setIsLoading(true);
     try {
-      const result = await authClient.signIn.social({ provider: 'github', callbackURL: '/dashboard' });
+      const result = await authClient.signIn.social({ provider: 'github', callbackURL: redirect || '/dashboard' });
       if (result.error) setError(result.error.message || 'Failed to sign in with GitHub');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred. Please try again.');


### PR DESCRIPTION
## Summary

- **GitHub OAuth**: Added `AUTH_PROVIDERS=credentials,github`, `APP_URL`, `BETTER_AUTH_URL` env vars on Vercel so the GitHub login button appears and OAuth callbacks work correctly
- **Login redirect**: Login page now accepts `?redirect=` param and uses it as `callbackURL` — fixes CLI auth flow where session code was lost
- **CLI login**: Preserves session code through the auth redirect chain (`/cli-login → /login?redirect=/cli-login?session=xxx → callback`)
- **Admin dashboard**: Now fetches real user/skill/audit event counts from the database instead of showing `--` placeholders
- **Token creation**: Pass `headers` to `auth.api.createApiKey` in both dashboard token creation and CLI exchange endpoint

## Files Changed

| File | Change |
|------|--------|
| `routes/login.tsx` | Accept `?redirect` search param |
| `screens/login-screen.tsx` | Use `redirect` prop as `callbackURL` |
| `routes/cli-login.tsx` | Preserve session code in redirect URL |
| `screens/admin-screen.tsx` | Fetch real stats via server function |
| `query/admin.ts` | New — admin stats server function |
| `lib/auth/tokens.ts` | Pass headers to createApiKey |
| `api/routes/v1/cli-auth.ts` | Pass headers to createApiKey in exchange |

## Testing

- `tsc --noEmit` passes cleanly
- Vercel env vars already configured (AUTH_PROVIDERS, APP_URL, BETTER_AUTH_URL)
- Needs production verification after merge