### PR TITLE
feat(onprem): add self-hosted mode with setup wizard, gated behind TANK_MODE

### DIFF
--- a/apps/registry/Dockerfile
+++ b/apps/registry/Dockerfile
@@ -32,7 +32,19 @@ COPY --from=deps /app/apps/registry/node_modules ./apps/registry/node_modules
 RUN bun run --filter=@internals/schemas build && \
     bun run --filter=@internals/helpers build && \
     rm -rf apps/registry/.output && \
-    bun run --filter=registry build
+    bun run --filter=registry build && \
+    bun build apps/registry/src/lib/db/schema.ts \
+      --outdir apps/registry/dist-db --target=node --format=esm --external=drizzle-orm && \
+    cat > apps/registry/dist-db/drizzle.config.js << 'DRIZZLE_EOF'
+import { defineConfig } from "drizzle-kit";
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error("DATABASE_URL is required");
+export default defineConfig({
+  dialect: "postgresql",
+  schema: ["./src/lib/db/schema.js"],
+  dbCredentials: { url: databaseUrl },
+});
+DRIZZLE_EOF
 
 # Stage 3: Production
 FROM oven/bun:1-alpine AS runner
@@ -41,9 +53,19 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 RUN addgroup --system --gid 1001 bunjs && \
-    adduser --system --uid 1001 tanstack
+    adduser --system --uid 1001 tanstack && \
+    bun add esbuild esbuild-register @esbuild-kit/esm-loader @esbuild-kit/core-utils postgres && \
+    chown -R tanstack:bunjs /app/node_modules
 
 COPY --from=builder --chown=tanstack:bunjs /app/apps/registry/.output ./.output
+COPY --from=builder --chown=tanstack:bunjs /app/apps/registry/scripts/entrypoint.sh ./entrypoint.sh
+COPY --from=builder --chown=tanstack:bunjs /app/apps/registry/scripts/load-settings-from-db.ts ./scripts/load-settings-from-db.ts
+COPY --from=builder --chown=tanstack:bunjs /app/apps/registry/dist-db/drizzle.config.js ./drizzle.config.js
+COPY --from=builder --chown=tanstack:bunjs /app/apps/registry/dist-db/schema.js ./src/lib/db/schema.js
+COPY --from=deps --chown=tanstack:bunjs /app/apps/registry/node_modules/drizzle-orm ./node_modules/drizzle-orm
+COPY --from=deps --chown=tanstack:bunjs /app/apps/registry/node_modules/drizzle-kit ./node_modules/drizzle-kit
+
+RUN chmod +x entrypoint.sh
 
 USER tanstack
 
@@ -55,4 +77,4 @@ ENV HOST=0.0.0.0
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/api/health || exit 1
 
-CMD ["bun", ".output/server/index.mjs"]
+ENTRYPOINT ["sh", "./entrypoint.sh"]

--- a/apps/registry/scripts/entrypoint.sh
+++ b/apps/registry/scripts/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+if [ "$AUTO_MIGRATE" = "true" ]; then
+  echo "[Tank] AUTO_MIGRATE=true — running headless setup..."
+
+  echo "[Tank] Pushing database schema..."
+  bun ./node_modules/drizzle-kit/bin.cjs push --force --config=drizzle.config.js 2>&1 || {
+    echo "[Tank] ERROR: Schema push failed. Is DATABASE_URL correct?"
+    exit 1
+  }
+
+  if [ -n "$FIRST_ADMIN_EMAIL" ]; then
+    if [ -z "$FIRST_ADMIN_PASSWORD" ]; then
+      echo "[Tank] ERROR: FIRST_ADMIN_PASSWORD required for headless setup"
+      exit 1
+    fi
+    echo "[Tank] Creating admin: $FIRST_ADMIN_EMAIL"
+    bun run scripts/bootstrap-headless.ts 2>&1 || {
+      echo "[Tank] WARNING: Admin bootstrap failed (user may already exist)"
+    }
+  fi
+
+  echo "[Tank] Headless setup complete."
+fi
+
+if [ -n "$DATABASE_URL" ]; then
+  bun run scripts/load-settings-from-db.ts > /tmp/tank-env.txt 2>/dev/null || true
+fi
+
+if [ -f /tmp/tank-env.txt ] && [ -s /tmp/tank-env.txt ]; then
+  exec env $(cat /tmp/tank-env.txt | grep -E '^[A-Z_]+=' | tr '\n' ' ') bun .output/server/index.mjs
+else
+  exec bun .output/server/index.mjs
+fi

--- a/apps/registry/scripts/load-settings-from-db.ts
+++ b/apps/registry/scripts/load-settings-from-db.ts
@@ -1,0 +1,112 @@
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+import { decrypt } from '../src/lib/crypto';
+import { systemConfig } from '../src/lib/db/schema';
+
+function sanitize(value: string): string {
+  return value.replace(/[`$\\"\n\r]/g, '');
+}
+
+const dbUrl = process.env.DATABASE_URL;
+if (!dbUrl) process.exit(0);
+
+const masterKey = process.env.BETTER_AUTH_SECRET;
+if (!masterKey) process.exit(0);
+
+try {
+  const client = postgres(dbUrl);
+  const db = drizzle(client, { schema: { systemConfig } });
+
+  const [config] = await db.select().from(systemConfig).where(eq(systemConfig.id, 1)).limit(1);
+  await client.end();
+
+  if (!config?.setupCompleted) process.exit(0);
+
+  const exports: string[] = [];
+
+  if (config.instanceUrl) {
+    exports.push(`BETTER_AUTH_URL=${sanitize(config.instanceUrl)}`);
+    exports.push(`VITE_PUBLIC_APP_URL=${sanitize(config.instanceUrl)}`);
+  }
+
+  if (config.githubEnabled && config.githubClientId) {
+    exports.push(`GITHUB_CLIENT_ID=${sanitize(config.githubClientId)}`);
+    if (config.githubClientSecretEnc) {
+      exports.push(`GITHUB_CLIENT_SECRET=${sanitize(decrypt(config.githubClientSecretEnc, masterKey))}`);
+    }
+  }
+
+  if (config.oidcEnabled && config.oidcClientId) {
+    if (config.oidcDiscoveryUrl) exports.push(`OIDC_DISCOVERY_URL=${sanitize(config.oidcDiscoveryUrl)}`);
+    exports.push(`OIDC_CLIENT_ID=${sanitize(config.oidcClientId)}`);
+    if (config.oidcClientSecretEnc) {
+      exports.push(`OIDC_CLIENT_SECRET=${sanitize(decrypt(config.oidcClientSecretEnc, masterKey))}`);
+    }
+    if (config.oidcProviderId) {
+      exports.push(`OIDC_PROVIDER_ID=${sanitize(config.oidcProviderId)}`);
+      exports.push(`NEXT_PUBLIC_OIDC_PROVIDER_ID=${sanitize(config.oidcProviderId)}`);
+    }
+  }
+
+  if (config.scannerProvider && config.scannerProvider !== 'disabled') {
+    if (config.scannerApiKeyEnc) {
+      const key = sanitize(decrypt(config.scannerApiKeyEnc, masterKey));
+      switch (config.scannerProvider) {
+        case 'groq':
+          exports.push(`GROQ_API_KEY=${key}`);
+          break;
+        case 'openrouter':
+          exports.push(`OPENROUTER_API_KEY=${key}`);
+          break;
+        case 'custom':
+          exports.push(`LLM_API_KEY=${key}`);
+          if (config.scannerBaseUrl) exports.push(`LLM_BASE_URL=${sanitize(config.scannerBaseUrl)}`);
+          if (config.scannerModel) exports.push(`LLM_MODEL=${sanitize(config.scannerModel)}`);
+          break;
+      }
+    }
+    if (config.scannerProvider === 'litellm' && config.scannerLitellmUrl) {
+      exports.push(`LITELLM_URL=${sanitize(config.scannerLitellmUrl)}`);
+    }
+  }
+
+  if (config.storageBackend) {
+    exports.push(`STORAGE_BACKEND=${sanitize(config.storageBackend)}`);
+    if (config.storageEndpoint) exports.push(`S3_ENDPOINT=${sanitize(config.storageEndpoint)}`);
+    if (config.storageRegion) exports.push(`S3_REGION=${sanitize(config.storageRegion)}`);
+    if (config.storageBucket) exports.push(`S3_BUCKET=${sanitize(config.storageBucket)}`);
+    if (config.storageAccessKey) exports.push(`S3_ACCESS_KEY=${sanitize(config.storageAccessKey)}`);
+    if (config.storageSecretKeyEnc) {
+      exports.push(`S3_SECRET_KEY=${sanitize(decrypt(config.storageSecretKeyEnc, masterKey))}`);
+    }
+    if (config.supabaseUrl) exports.push(`SUPABASE_URL=${sanitize(config.supabaseUrl)}`);
+    if (config.supabaseServiceKeyEnc) {
+      exports.push(`SUPABASE_SERVICE_ROLE_KEY=${sanitize(decrypt(config.supabaseServiceKeyEnc, masterKey))}`);
+    }
+    if (config.storageBackend === 'filesystem') {
+      exports.push(`STORAGE_FS_PATH=${process.env.STORAGE_FS_PATH || '/app/data/packages'}`);
+    }
+  }
+
+  // Build AUTH_PROVIDERS from base + enabled providers
+  const providers = new Set(
+    (process.env.AUTH_PROVIDERS || 'credentials')
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean)
+  );
+  if (config.githubEnabled && config.githubClientId) providers.add('github');
+  if (config.oidcEnabled && config.oidcClientId) providers.add('oidc');
+  const providersStr = [...providers].join(',');
+  if (providersStr !== (process.env.AUTH_PROVIDERS || 'credentials')) {
+    exports.push(`AUTH_PROVIDERS=${providersStr}`);
+  }
+
+  for (const line of exports) {
+    console.log(line);
+  }
+} catch {
+  process.exit(0);
+}

--- a/apps/registry/src/api/app.ts
+++ b/apps/registry/src/api/app.ts
@@ -5,6 +5,8 @@ import { auth } from '~/lib/auth/core';
 import { requireAdmin } from './middleware/require-admin';
 import { adminRoutes } from './routes/admin';
 import { ogRoutes } from './routes/og';
+import { setupRoutes } from './routes/setup';
+import { storageRoutes } from './routes/storage';
 import { v1Routes } from './routes/v1';
 
 export const app = new Hono()
@@ -12,6 +14,14 @@ export const app = new Hono()
   .use('*', cors({ origin: (origin) => origin, credentials: true }))
   .all('/auth/*', (c) => auth.handler(c.req.raw))
   .get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }))
+  .use('/setup/*', async (c, next) => {
+    if (process.env.TANK_MODE !== 'selfhosted') {
+      return c.json({ error: 'Not found' }, 404);
+    }
+    return next();
+  })
+  .route('/setup', setupRoutes)
+  .route('/storage', storageRoutes)
   .route('/og', ogRoutes)
   .route('/v1', v1Routes)
   .use('/admin/*', requireAdmin())

--- a/apps/registry/src/api/routes/setup.ts
+++ b/apps/registry/src/api/routes/setup.ts
@@ -1,0 +1,270 @@
+import { Hono } from 'hono';
+
+import { auth } from '~/lib/auth/core';
+import { db } from '~/lib/db';
+import { systemConfig, user } from '~/lib/db/schema';
+import { encryptSecret, getSystemConfig, isSetupCompleted, upsertSystemConfig } from '~/lib/setup';
+
+export const setupRoutes = new Hono()
+  .use('*', async (c, next) => {
+    if (c.req.method === 'GET') return next();
+    const { isSetupCompleted } = await import('~/lib/setup');
+    const completed = await isSetupCompleted();
+    if (completed) {
+      return c.json({ error: 'Setup already completed' }, 403);
+    }
+    return next();
+  })
+  .get('/detect-network', async (c) => {
+    const { networkInterfaces, hostname } = await import('node:os');
+    const nets = networkInterfaces();
+    const addresses: { label: string; url: string }[] = [];
+    const port = process.env.APP_PORT || process.env.PORT || '3000';
+
+    const host = hostname();
+    if (host) addresses.push({ label: `Hostname: ${host}`, url: `http://${host}:${port}` });
+
+    for (const [name, interfaces] of Object.entries(nets)) {
+      if (!interfaces) continue;
+      for (const iface of interfaces) {
+        if (iface.internal || iface.family !== 'IPv4') continue;
+        addresses.push({ label: `${name}: ${iface.address}`, url: `http://${iface.address}:${port}` });
+      }
+    }
+
+    addresses.push({ label: 'Localhost', url: `http://localhost:${port}` });
+    return c.json({ addresses });
+  })
+
+  .get('/status', async (c) => {
+    const completed = await isSetupCompleted();
+    const dbUrl = process.env.DATABASE_URL || '';
+    return c.json({
+      completed,
+      currentStep: completed ? null : await detectCurrentStep(),
+      defaults: {
+        databaseUrl: dbUrl ? dbUrl.replace(/:[^:@/]+@/, ':***@') : '',
+        hasDatabaseUrl: !!dbUrl
+      }
+    });
+  })
+
+  .post('/test-db', async (c) => {
+    const body = await c.req.json<{ databaseUrl?: string; useEnv?: boolean }>();
+    const databaseUrl = body.useEnv ? process.env.DATABASE_URL : body.databaseUrl;
+    if (!databaseUrl) return c.json({ ok: false, error: 'No database URL provided' }, 400);
+    try {
+      const testClient = (await import('postgres')).default(databaseUrl);
+      await testClient`SELECT 1`;
+      await testClient.end();
+      return c.json({ ok: true });
+    } catch (e) {
+      return c.json({ ok: false, error: e instanceof Error ? e.message : 'Connection failed' }, 400);
+    }
+  })
+
+  .post('/check-db', async (c) => {
+    const body = await c.req.json<{ databaseUrl?: string; useEnv?: boolean }>();
+    const databaseUrl = body.useEnv ? process.env.DATABASE_URL : body.databaseUrl;
+    if (!databaseUrl) return c.json({ ok: false, error: 'No database URL provided' }, 400);
+    try {
+      const pg = (await import('postgres')).default(databaseUrl);
+      const tables = await pg`
+        SELECT tablename FROM pg_catalog.pg_tables
+        WHERE schemaname = 'public'
+        ORDER BY tablename
+      `;
+      await pg.end();
+
+      const tableNames = tables.map((r) => (r as Record<string, string>).tablename);
+      const hasTankTables = tableNames.some((t: string) => t === 'user' || t === 'skill' || t === 'system_config');
+      const hasSystemConfig = tableNames.includes('system_config');
+
+      return c.json({
+        ok: true,
+        tableCount: tableNames.length,
+        tables: tableNames,
+        hasTankTables,
+        hasSystemConfig,
+        empty: tableNames.length === 0
+      });
+    } catch (e) {
+      return c.json({ ok: false, error: e instanceof Error ? e.message : 'Check failed' }, 400);
+    }
+  })
+
+  .post('/init-db', async (c) => {
+    try {
+      const { execSync } = await import('node:child_process');
+      execSync('/usr/local/bin/bun ./node_modules/drizzle-kit/bin.cjs push --force --config=drizzle.config.js 2>&1', {
+        env: { ...process.env, HOME: '/app' },
+        cwd: '/app',
+        timeout: 60_000
+      });
+      await db.insert(systemConfig).values({ id: 1 }).onConflictDoNothing();
+      return c.json({ ok: true });
+    } catch (e: unknown) {
+      const err = e as { stdout?: Buffer; message?: string };
+      const detail = err.stdout?.toString() || err.message || 'Schema push failed';
+      return c.json({ ok: false, error: detail }, 500);
+    }
+  })
+
+  .post('/instance-url', async (c) => {
+    const { instanceUrl } = await c.req.json<{ instanceUrl: string }>();
+    if (!instanceUrl) return c.json({ error: 'Instance URL is required' }, 400);
+    await upsertSystemConfig({ instanceUrl });
+    return c.json({ ok: true });
+  })
+
+  .post('/storage', async (c) => {
+    const body = await c.req.json<{
+      backend: string;
+      endpoint?: string;
+      region?: string;
+      bucket?: string;
+      accessKey?: string;
+      secretKey?: string;
+      supabaseUrl?: string;
+      supabaseServiceKey?: string;
+    }>();
+
+    const update: Record<string, unknown> = {
+      storageBackend: body.backend,
+      storageEndpoint: body.endpoint || null,
+      storageRegion: body.region || null,
+      storageBucket: body.bucket || null,
+      storageAccessKey: body.accessKey || null
+    };
+
+    if (body.secretKey) update.storageSecretKeyEnc = encryptSecret(body.secretKey);
+    if (body.supabaseUrl) update.supabaseUrl = body.supabaseUrl;
+    if (body.supabaseServiceKey) update.supabaseServiceKeyEnc = encryptSecret(body.supabaseServiceKey);
+
+    await upsertSystemConfig(update as Partial<typeof systemConfig.$inferInsert>);
+    return c.json({ ok: true });
+  })
+
+  .post('/test-storage', async (c) => {
+    try {
+      const { getStorageProvider } = await import('~/services/storage/provider');
+      const storage = getStorageProvider();
+      const testPath = `_setup_test_${Date.now()}.txt`;
+
+      if (storage.putObject) {
+        await storage.putObject(testPath, new TextEncoder().encode('test'));
+      } else {
+        const { signedUrl } = await storage.createSignedUploadUrl(testPath, 60);
+        if (!signedUrl) throw new Error('Failed to create signed URL');
+      }
+      return c.json({ ok: true });
+    } catch (e) {
+      return c.json({ ok: false, error: e instanceof Error ? e.message : 'Storage test failed' }, 400);
+    }
+  })
+
+  .post('/admin', async (c) => {
+    const { email, password } = await c.req.json<{ email: string; password: string }>();
+    if (!email || !password) return c.json({ error: 'Email and password are required' }, 400);
+    if (password.length < 8) return c.json({ error: 'Password must be at least 8 characters' }, 400);
+
+    try {
+      const ctx = await auth.api.signUpEmail({ body: { email, password, name: 'Admin' } });
+      if (!ctx?.user?.id) return c.json({ error: 'User creation failed' }, 500);
+
+      const { eq } = await import('drizzle-orm');
+      await db.update(user).set({ role: 'admin', emailVerified: true }).where(eq(user.id, ctx.user.id));
+      return c.json({ ok: true, userId: ctx.user.id });
+    } catch (e) {
+      return c.json({ ok: false, error: e instanceof Error ? e.message : 'Admin creation failed' }, 500);
+    }
+  })
+
+  .post('/auth-providers', async (c) => {
+    const body = await c.req.json<{
+      githubEnabled?: boolean;
+      githubClientId?: string;
+      githubClientSecret?: string;
+      oidcEnabled?: boolean;
+      oidcDiscoveryUrl?: string;
+      oidcClientId?: string;
+      oidcClientSecret?: string;
+      oidcProviderId?: string;
+    }>();
+
+    const update: Record<string, unknown> = {};
+
+    if (body.githubEnabled !== undefined) {
+      update.githubEnabled = body.githubEnabled;
+      if (body.githubClientId) update.githubClientId = body.githubClientId;
+      if (body.githubClientSecret) update.githubClientSecretEnc = encryptSecret(body.githubClientSecret);
+    }
+
+    if (body.oidcEnabled !== undefined) {
+      update.oidcEnabled = body.oidcEnabled;
+      if (body.oidcDiscoveryUrl) update.oidcDiscoveryUrl = body.oidcDiscoveryUrl;
+      if (body.oidcClientId) update.oidcClientId = body.oidcClientId;
+      if (body.oidcClientSecret) update.oidcClientSecretEnc = encryptSecret(body.oidcClientSecret);
+      if (body.oidcProviderId) update.oidcProviderId = body.oidcProviderId;
+    }
+
+    await upsertSystemConfig(update as Partial<typeof systemConfig.$inferInsert>);
+    return c.json({ ok: true, restartRequired: body.githubEnabled || body.oidcEnabled });
+  })
+
+  .post('/scanner-llm', async (c) => {
+    const body = await c.req.json<{
+      provider: string;
+      apiKey?: string;
+      baseUrl?: string;
+      model?: string;
+      litellmUrl?: string;
+    }>();
+
+    const update: Record<string, unknown> = {
+      scannerProvider: body.provider
+    };
+
+    if (body.apiKey) update.scannerApiKeyEnc = encryptSecret(body.apiKey);
+    if (body.baseUrl) update.scannerBaseUrl = body.baseUrl;
+    if (body.model) update.scannerModel = body.model;
+    if (body.litellmUrl) update.scannerLitellmUrl = body.litellmUrl;
+
+    await upsertSystemConfig(update as Partial<typeof systemConfig.$inferInsert>);
+    return c.json({ ok: true });
+  })
+
+  .post('/test-llm', async (c) => {
+    const { provider, apiKey, litellmUrl } = await c.req.json<{
+      provider: string;
+      apiKey?: string;
+      baseUrl?: string;
+      model?: string;
+      litellmUrl?: string;
+    }>();
+
+    try {
+      if (provider !== 'disabled' && !apiKey && !litellmUrl) {
+        return c.json({ ok: false, error: 'API key or LiteLLM URL required' }, 400);
+      }
+      return c.json({ ok: true });
+    } catch (e) {
+      return c.json({ ok: false, error: e instanceof Error ? e.message : 'LLM test failed' }, 400);
+    }
+  })
+
+  .post('/complete', async (c) => {
+    await upsertSystemConfig({ setupCompleted: true });
+    return c.json({ ok: true, redirect: '/' });
+  });
+
+async function detectCurrentStep(): Promise<string> {
+  try {
+    const config = await getSystemConfig();
+    if (!config) return 'database';
+    if (!config.instanceUrl) return 'instance-url';
+    return 'storage';
+  } catch {
+    return 'database';
+  }
+}

--- a/apps/registry/src/api/routes/storage.ts
+++ b/apps/registry/src/api/routes/storage.ts
@@ -1,0 +1,43 @@
+import * as fs from 'node:fs';
+import { Hono } from 'hono';
+
+import { getFilesystemProvider } from '~/services/storage/provider';
+
+export const storageRoutes = new Hono()
+  .get('/download', async (c) => {
+    const fsProvider = getFilesystemProvider();
+    if (!fsProvider) return c.json({ error: 'Filesystem storage not configured' }, 404);
+
+    const path = c.req.query('path');
+    const expires = c.req.query('expires');
+    const token = c.req.query('token');
+
+    if (!path || !expires || !token) return c.json({ error: 'Missing parameters' }, 400);
+    if (!fsProvider.verifyToken(path, expires, token)) return c.json({ error: 'Invalid or expired token' }, 403);
+
+    const filePath = fsProvider.getFilePath(path);
+    if (!fs.existsSync(filePath)) return c.json({ error: 'File not found' }, 404);
+
+    const data = fs.readFileSync(filePath);
+    const ext = path.split('.').pop() || '';
+    const contentType = ext === 'tgz' ? 'application/gzip' : 'application/octet-stream';
+
+    return new Response(data, { headers: { 'Content-Type': contentType, 'Content-Length': data.length.toString() } });
+  })
+
+  .put('/upload', async (c) => {
+    const fsProvider = getFilesystemProvider();
+    if (!fsProvider) return c.json({ error: 'Filesystem storage not configured' }, 404);
+
+    const path = c.req.query('path');
+    const expires = c.req.query('expires');
+    const token = c.req.query('token');
+
+    if (!path || !expires || !token) return c.json({ error: 'Missing parameters' }, 400);
+    if (!fsProvider.verifyToken(path, expires, token)) return c.json({ error: 'Invalid or expired token' }, 403);
+
+    const body = await c.req.arrayBuffer();
+    await fsProvider.putObject(path, new Uint8Array(body));
+
+    return c.json({ ok: true });
+  });

--- a/apps/registry/src/consts/env.ts
+++ b/apps/registry/src/consts/env.ts
@@ -9,6 +9,7 @@ export const zEnv = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   APP_URL: zUrl.default('http://localhost:5555'),
   APP_NAME: zStr.default('Tank'),
+  TANK_MODE: z.enum(['cloud', 'selfhosted']).default('cloud'),
 
   // ── Database ──
   DATABASE_URL: zStr,
@@ -32,7 +33,8 @@ export const zEnv = z.object({
   OIDC_USER_INFO_URL: zOptStr,
 
   // ── Storage ──
-  STORAGE_BACKEND: z.enum(['s3', 'supabase']).default('supabase'),
+  STORAGE_BACKEND: z.enum(['s3', 'supabase', 'filesystem']).default('supabase'),
+  STORAGE_FS_PATH: zOptStr,
   S3_ENDPOINT: zOptStr,
   S3_PUBLIC_ENDPOINT: zOptStr,
   S3_ACCESS_KEY: zOptStr,
@@ -87,3 +89,5 @@ export const oidcEnabled =
   !!env.OIDC_CLIENT_ID &&
   !!env.OIDC_CLIENT_SECRET &&
   !!(env.OIDC_DISCOVERY_URL || (env.OIDC_AUTHORIZATION_URL && env.OIDC_TOKEN_URL && env.OIDC_USER_INFO_URL));
+
+export const isSelfHosted = env.TANK_MODE === 'selfhosted';

--- a/apps/registry/src/lib/crypto.ts
+++ b/apps/registry/src/lib/crypto.ts
@@ -1,0 +1,30 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+
+function deriveKey(secret: string): Buffer {
+  return Buffer.from(secret.padEnd(KEY_LENGTH, '\0').slice(0, KEY_LENGTH), 'utf-8');
+}
+
+export function encrypt(plaintext: string, masterKey: string): string {
+  const key = deriveKey(masterKey);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString('base64');
+}
+
+export function decrypt(ciphertext: string, masterKey: string): string {
+  const key = deriveKey(masterKey);
+  const data = Buffer.from(ciphertext, 'base64');
+  const iv = data.subarray(0, IV_LENGTH);
+  const authTag = data.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const encrypted = data.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+  return decipher.update(encrypted) + decipher.final('utf-8');
+}

--- a/apps/registry/src/lib/db/schema.ts
+++ b/apps/registry/src/lib/db/schema.ts
@@ -430,3 +430,41 @@ export const userStatusRelations = relations(userStatus, ({ one }) => ({
     references: [user.id]
   })
 }));
+
+// ---------------------------------------------------------------------------
+// System Config (singleton — on-prem setup wizard state + instance config)
+// ---------------------------------------------------------------------------
+
+export const systemConfig = pgTable('system_config', {
+  id: integer('id').primaryKey().default(1),
+  setupCompleted: boolean('setup_completed').notNull().default(false),
+
+  instanceUrl: text('instance_url'),
+
+  storageBackend: text('storage_backend').default('s3'),
+  storageEndpoint: text('storage_endpoint'),
+  storageRegion: text('storage_region'),
+  storageBucket: text('storage_bucket'),
+  storageAccessKey: text('storage_access_key'),
+  storageSecretKeyEnc: text('storage_secret_key_enc'),
+  supabaseUrl: text('supabase_url'),
+  supabaseServiceKeyEnc: text('supabase_service_key_enc'),
+
+  scannerProvider: text('scanner_provider').default('disabled'),
+  scannerApiKeyEnc: text('scanner_api_key_enc'),
+  scannerBaseUrl: text('scanner_base_url'),
+  scannerModel: text('scanner_model'),
+  scannerLitellmUrl: text('scanner_litellm_url'),
+
+  githubEnabled: boolean('github_enabled').notNull().default(false),
+  githubClientId: text('github_client_id'),
+  githubClientSecretEnc: text('github_client_secret_enc'),
+
+  oidcEnabled: boolean('oidc_enabled').notNull().default(false),
+  oidcDiscoveryUrl: text('oidc_discovery_url'),
+  oidcClientId: text('oidc_client_id'),
+  oidcClientSecretEnc: text('oidc_client_secret_enc'),
+  oidcProviderId: text('oidc_provider_id').default('enterprise-oidc'),
+
+  ...timestamps
+});

--- a/apps/registry/src/lib/setup.ts
+++ b/apps/registry/src/lib/setup.ts
@@ -1,0 +1,55 @@
+import { eq } from 'drizzle-orm';
+import { decrypt, encrypt } from '~/lib/crypto';
+import { db } from '~/lib/db';
+import { systemConfig } from '~/lib/db/schema';
+
+let cachedSetupCompleted: boolean | null = null;
+
+export async function isSetupCompleted(): Promise<boolean> {
+  if (cachedSetupCompleted === true) return true;
+
+  try {
+    const [row] = await db
+      .select({ completed: systemConfig.setupCompleted })
+      .from(systemConfig)
+      .where(eq(systemConfig.id, 1))
+      .limit(1);
+    cachedSetupCompleted = row?.completed ?? false;
+    return cachedSetupCompleted;
+  } catch {
+    return false;
+  }
+}
+
+export function resetSetupCache() {
+  cachedSetupCompleted = null;
+}
+
+export async function getSystemConfig() {
+  const [row] = await db.select().from(systemConfig).where(eq(systemConfig.id, 1)).limit(1);
+  return row ?? null;
+}
+
+export async function upsertSystemConfig(values: Partial<typeof systemConfig.$inferInsert>) {
+  const existing = await getSystemConfig();
+  if (existing) {
+    await db.update(systemConfig).set(values).where(eq(systemConfig.id, 1));
+  } else {
+    await db.insert(systemConfig).values({ id: 1, ...values });
+  }
+  resetSetupCache();
+}
+
+function getMasterKey(): string {
+  const key = process.env.BETTER_AUTH_SECRET;
+  if (!key) throw new Error('BETTER_AUTH_SECRET is required for encryption');
+  return key;
+}
+
+export function encryptSecret(plaintext: string): string {
+  return encrypt(plaintext, getMasterKey());
+}
+
+export function decryptSecret(ciphertext: string): string {
+  return decrypt(ciphertext, getMasterKey());
+}

--- a/apps/registry/src/routes/setup.tsx
+++ b/apps/registry/src/routes/setup.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+
+import { SetupWizardScreen } from '~/screens/setup-wizard-screen';
+
+const checkSelfHosted = createServerFn({ method: 'GET' }).handler(async () => {
+  const { isSelfHosted } = await import('~/consts/env');
+  return isSelfHosted;
+});
+
+export const Route = createFileRoute('/setup')({
+  beforeLoad: async () => {
+    const selfHosted = await checkSelfHosted();
+    if (!selfHosted) throw redirect({ to: '/' });
+  },
+  component: SetupWizardScreen
+});

--- a/apps/registry/src/screens/setup-wizard-screen.tsx
+++ b/apps/registry/src/screens/setup-wizard-screen.tsx
@@ -1,0 +1,1092 @@
+import { useEffect, useState } from 'react';
+
+import { Button } from '~/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
+import { Input } from '~/components/ui/input';
+import { Label } from '~/components/ui/label';
+
+const STEPS = [
+  { title: 'Database', description: 'Connect and initialize your database' },
+  { title: 'Instance URL', description: 'Set the public URL for this instance' },
+  { title: 'Storage', description: 'Verify MinIO object storage connectivity' },
+  { title: 'Admin Account', description: 'Create the initial administrator account' },
+  { title: 'Auth Providers', description: 'Configure optional OAuth and SSO providers' },
+  { title: 'Scanner LLM', description: 'Configure the AI model for skill scanning' },
+  { title: 'Complete', description: 'Review and finalize your setup' }
+];
+
+type LLMProvider = 'groq' | 'openrouter' | 'litellm' | 'custom' | 'disabled';
+
+interface StepState {
+  db: {
+    url: string;
+    tested: boolean;
+    initialized: boolean;
+    checked: boolean;
+    tableCount: number;
+    hasTankTables: boolean;
+    hasSystemConfig: boolean;
+    confirmed: boolean;
+    tables: string[];
+  };
+  instanceUrl: { url: string };
+  storage: {
+    backend: 'minio' | 's3' | 'supabase' | 's3-compatible' | 'filesystem';
+    endpoint: string;
+    region: string;
+    bucket: string;
+    accessKey: string;
+    secretKey: string;
+    supabaseUrl: string;
+    supabaseServiceKey: string;
+    tested: boolean;
+    saved: boolean;
+  };
+  admin: { email: string; password: string; confirmPassword: string };
+  auth: {
+    githubEnabled: boolean;
+    githubClientId: string;
+    githubClientSecret: string;
+    oidcEnabled: boolean;
+    oidcDiscoveryUrl: string;
+    oidcClientId: string;
+    oidcClientSecret: string;
+  };
+  llm: { provider: LLMProvider; apiKey: string; baseUrl: string; tested: boolean };
+}
+
+function ProgressIndicator({ current, total }: { current: number; total: number }) {
+  return (
+    <div className="flex items-center justify-center gap-0 mb-8">
+      {Array.from({ length: total }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static step indicators never reorder
+        <div key={i} className="flex items-center">
+          <div
+            className={[
+              'flex size-8 items-center justify-center rounded-full text-xs font-semibold transition-colors',
+              i < current
+                ? 'bg-primary text-primary-foreground'
+                : i === current
+                  ? 'bg-primary text-primary-foreground ring-2 ring-primary/30 ring-offset-2 ring-offset-background'
+                  : 'bg-muted text-muted-foreground'
+            ].join(' ')}>
+            {i < current ? (
+              <svg className="size-4" viewBox="0 0 16 16" fill="none" role="img" aria-label="completed">
+                <path
+                  d="M3 8l3.5 3.5L13 4.5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            ) : (
+              i + 1
+            )}
+          </div>
+          {i < total - 1 && (
+            <div className={['h-px w-8 transition-colors', i < current ? 'bg-primary' : 'bg-border'].join(' ')} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SuccessBadge({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-emerald-500">
+      <svg className="size-4" viewBox="0 0 16 16" fill="none" role="img" aria-label="success">
+        <path
+          d="M3 8l3.5 3.5L13 4.5"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      {label}
+    </div>
+  );
+}
+
+function DbTableList({ tables }: { tables: string[] }) {
+  const [open, setOpen] = useState(false);
+  if (tables.length === 0) return null;
+  return (
+    <div>
+      <button
+        type="button"
+        className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        onClick={() => setOpen((o) => !o)}>
+        {open ? 'Hide' : 'Show'} {tables.length} tables
+      </button>
+      {open && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {tables.map((t) => (
+            <span key={t} className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground">
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ErrorMessage({ message }: { message: string }) {
+  return (
+    <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+      <p>{message}</p>
+    </div>
+  );
+}
+
+function InstanceUrlStep({
+  state,
+  setState,
+  loading
+}: {
+  state: StepState;
+  setState: React.Dispatch<React.SetStateAction<StepState>>;
+  loading: boolean;
+}) {
+  const [addresses, setAddresses] = useState<{ label: string; url: string }[]>([]);
+  const [fetched, setFetched] = useState(false);
+
+  useEffect(() => {
+    if (fetched) return;
+    fetch('/api/setup/detect-network')
+      .then((r) => r.json())
+      .then((data) => {
+        setAddresses(data.addresses || []);
+        setFetched(true);
+      })
+      .catch(() => setFetched(true));
+  }, [fetched]);
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label htmlFor="instance-url">Public URL</Label>
+        <Input
+          id="instance-url"
+          placeholder="https://tank.company.com"
+          value={state.instanceUrl.url}
+          onChange={(e) => setState((s) => ({ ...s, instanceUrl: { url: e.target.value } }))}
+          disabled={loading}
+        />
+        <p className="text-xs text-muted-foreground">
+          This is how users and the CLI will access Tank. Pre-filled with your current browser URL.
+        </p>
+      </div>
+      {addresses.length > 0 && (
+        <div className="space-y-2">
+          <Label>Detected addresses</Label>
+          <div className="flex flex-wrap gap-1.5">
+            {addresses.map((addr) => (
+              <button
+                key={addr.url}
+                type="button"
+                className={[
+                  'rounded-md border px-2.5 py-1 text-xs transition-colors',
+                  state.instanceUrl.url === addr.url
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border text-muted-foreground hover:border-primary/50 hover:text-foreground'
+                ].join(' ')}
+                onClick={() => setState((s) => ({ ...s, instanceUrl: { url: addr.url } }))}>
+                {addr.label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Click an address, or type a custom URL above if using a reverse proxy or custom domain.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SetupWizardScreen() {
+  const [step, setStep] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [envDbDetected, setEnvDbDetected] = useState(false);
+
+  const [state, setState] = useState<StepState>({
+    db: {
+      url: '',
+      tested: false,
+      initialized: false,
+      checked: false,
+      tableCount: 0,
+      hasTankTables: false,
+      hasSystemConfig: false,
+      confirmed: false,
+      tables: []
+    },
+    instanceUrl: { url: typeof window !== 'undefined' ? window.location.origin : '' },
+    storage: {
+      backend: 'minio',
+      endpoint: '',
+      region: 'us-east-1',
+      bucket: 'packages',
+      accessKey: '',
+      secretKey: '',
+      supabaseUrl: '',
+      supabaseServiceKey: '',
+      tested: false,
+      saved: false
+    },
+    admin: { email: '', password: '', confirmPassword: '' },
+    auth: {
+      githubEnabled: false,
+      githubClientId: '',
+      githubClientSecret: '',
+      oidcEnabled: false,
+      oidcDiscoveryUrl: '',
+      oidcClientId: '',
+      oidcClientSecret: ''
+    },
+    llm: { provider: 'disabled', apiKey: '', baseUrl: '', tested: false }
+  });
+
+  useEffect(() => {
+    fetch('/api/setup/status')
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.defaults?.hasDatabaseUrl && data.defaults.databaseUrl) {
+          setState((s) => ({
+            ...s,
+            db: { ...s.db, url: data.defaults.databaseUrl }
+          }));
+          setEnvDbDetected(true);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const post = async (path: string, body?: unknown) => {
+    const res = await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || data.message || `Request failed (${res.status})`);
+    return data;
+  };
+
+  const run = async (fn: () => Promise<void>) => {
+    setError(null);
+    setLoading(true);
+    try {
+      await fn();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleContinue = async () => {
+    setError(null);
+
+    if (step === 0) {
+      if (!state.db.initialized && !state.db.hasSystemConfig) {
+        setError('Please test and initialize the database before continuing.');
+        return;
+      }
+    }
+
+    if (step === 1) {
+      await run(async () => {
+        await post('/api/setup/instance-url', { instanceUrl: state.instanceUrl.url });
+        setStep(2);
+      });
+      return;
+    }
+
+    if (step === 2) {
+      if (!state.storage.tested) {
+        setError('Please test storage connectivity before continuing.');
+        return;
+      }
+      if (!state.storage.saved) {
+        await run(async () => {
+          const s = state.storage;
+          await post('/api/setup/storage', {
+            backend: s.backend === 'minio' ? 's3' : s.backend,
+            endpoint: s.endpoint || undefined,
+            region: s.region || undefined,
+            bucket: s.bucket || undefined,
+            accessKey: s.accessKey || undefined,
+            secretKey: s.secretKey || undefined,
+            supabaseUrl: s.supabaseUrl || undefined,
+            supabaseServiceKey: s.supabaseServiceKey || undefined
+          });
+          setState((prev) => ({ ...prev, storage: { ...prev.storage, saved: true } }));
+          setStep(3);
+        });
+        return;
+      }
+    }
+
+    if (step === 3) {
+      if (!state.admin.email) {
+        setError('Email is required.');
+        return;
+      }
+      if (state.admin.password.length < 8) {
+        setError('Password must be at least 8 characters.');
+        return;
+      }
+      if (state.admin.password !== state.admin.confirmPassword) {
+        setError('Passwords do not match.');
+        return;
+      }
+      await run(async () => {
+        await post('/api/setup/admin', { email: state.admin.email, password: state.admin.password });
+        setStep(4);
+      });
+      return;
+    }
+
+    if (step === 4) {
+      if (!state.auth.githubEnabled && !state.auth.oidcEnabled) {
+        setStep(5);
+        return;
+      }
+      await run(async () => {
+        await post('/api/setup/auth-providers', {
+          githubEnabled: state.auth.githubEnabled,
+          githubClientId: state.auth.githubClientId || undefined,
+          githubClientSecret: state.auth.githubClientSecret || undefined,
+          oidcEnabled: state.auth.oidcEnabled,
+          oidcDiscoveryUrl: state.auth.oidcDiscoveryUrl || undefined,
+          oidcClientId: state.auth.oidcClientId || undefined,
+          oidcClientSecret: state.auth.oidcClientSecret || undefined
+        });
+        setStep(5);
+      });
+      return;
+    }
+
+    if (step === 5) {
+      await run(async () => {
+        await post('/api/setup/scanner-llm', {
+          provider: state.llm.provider,
+          apiKey: state.llm.apiKey || undefined,
+          baseUrl: state.llm.baseUrl || undefined
+        });
+        setStep(6);
+      });
+      return;
+    }
+
+    if (step === 6) {
+      await run(async () => {
+        await post('/api/setup/complete');
+        window.location.href = '/';
+      });
+      return;
+    }
+
+    setStep((s) => s + 1);
+  };
+
+  const db = state.db;
+  const auth = state.auth;
+  const llm = state.llm;
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-6">
+      <div className="w-full max-w-lg">
+        <div className="text-center mb-6">
+          <h1 className="text-2xl font-bold text-foreground">Tank Setup</h1>
+          <p className="text-sm text-muted-foreground mt-1">Configure your on-premises instance</p>
+        </div>
+
+        <ProgressIndicator current={step} total={STEPS.length} />
+
+        <Card className="w-full">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex size-8 items-center justify-center rounded-full bg-primary/10 text-primary text-sm font-semibold">
+                {step + 1}
+              </div>
+              <div>
+                <CardTitle>{STEPS[step]?.title}</CardTitle>
+                <CardDescription className="mt-0.5">{STEPS[step]?.description}</CardDescription>
+              </div>
+            </div>
+          </CardHeader>
+
+          <CardContent className="space-y-4">
+            {step === 0 && (
+              <>
+                {envDbDetected && (
+                  <div className="rounded-md bg-primary/5 border border-primary/20 p-3 text-sm">
+                    <span className="text-primary font-medium">Database detected from environment.</span>
+                    <span className="text-muted-foreground">
+                      {' '}
+                      You can test and initialize it directly, or change the connection below.
+                    </span>
+                  </div>
+                )}
+                <div className="space-y-2">
+                  <Label htmlFor="db-provider">Provider</Label>
+                  <select
+                    id="db-provider"
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    onChange={(e) => {
+                      const templates: Record<string, string> = {
+                        docker: 'postgresql://tank:change-this-password@postgres:5432/tank',
+                        supabase:
+                          'postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres',
+                        neon: 'postgresql://[user]:[password]@[endpoint].neon.tech/[database]?sslmode=require',
+                        rds: 'postgresql://[user]:[password]@[instance].[region].rds.amazonaws.com:5432/[database]',
+                        azure:
+                          'postgresql://[user]:[password]@[server].postgres.database.azure.com:5432/[database]?sslmode=require',
+                        railway: 'postgresql://postgres:[password]@[host].railway.internal:5432/railway',
+                        render: 'postgresql://[user]:[password]@[host].render.com:5432/[database]',
+                        custom: ''
+                      };
+                      const val = templates[e.target.value] ?? '';
+                      setState((s) => ({
+                        ...s,
+                        db: { ...s.db, url: val, tested: false, initialized: false, checked: false, confirmed: false }
+                      }));
+                    }}
+                    disabled={loading}>
+                    <option value="docker">Docker Compose (default)</option>
+                    <option value="supabase">Supabase</option>
+                    <option value="neon">Neon</option>
+                    <option value="rds">AWS RDS</option>
+                    <option value="azure">Azure Database</option>
+                    <option value="railway">Railway</option>
+                    <option value="render">Render</option>
+                    <option value="custom">Custom</option>
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="db-url">Connection String</Label>
+                  <Input
+                    id="db-url"
+                    placeholder="postgresql://user:pass@host:5432/tank"
+                    value={db.url}
+                    onChange={(e) =>
+                      setState((s) => ({
+                        ...s,
+                        db: {
+                          ...s.db,
+                          url: e.target.value,
+                          tested: false,
+                          initialized: false,
+                          checked: false,
+                          confirmed: false
+                        }
+                      }))
+                    }
+                    disabled={loading}
+                  />
+                  <p className="text-xs text-muted-foreground font-mono break-all">
+                    {db.url
+                      ? db.url.replace(/:[^:@/]+@/, ':***@')
+                      : 'Select a provider above or type a connection string'}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={loading || (!db.url && !envDbDetected)}
+                    onClick={() =>
+                      run(async () => {
+                        const connPayload = envDbDetected ? { useEnv: true } : { databaseUrl: db.url };
+                        await post('/api/setup/test-db', connPayload);
+                        setState((s) => ({ ...s, db: { ...s.db, tested: true } }));
+                        const checkResult = await post('/api/setup/check-db', connPayload);
+                        setState((s) => ({
+                          ...s,
+                          db: {
+                            ...s.db,
+                            checked: true,
+                            tableCount: checkResult.tableCount ?? 0,
+                            tables: checkResult.tables ?? [],
+                            hasTankTables: checkResult.hasTankTables ?? false,
+                            hasSystemConfig: checkResult.hasSystemConfig ?? false
+                          }
+                        }));
+                      })
+                    }>
+                    {loading ? 'Testing…' : 'Test Connection'}
+                  </Button>
+                  {db.tested && db.checked && (db.tableCount === 0 || db.confirmed) && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={loading}
+                      onClick={() =>
+                        run(async () => {
+                          await post('/api/setup/init-db');
+                          setState((s) => ({ ...s, db: { ...s.db, initialized: true } }));
+                        })
+                      }>
+                      {loading ? 'Initializing…' : 'Initialize Schema'}
+                    </Button>
+                  )}
+                </div>
+                {db.tested && !db.checked && <SuccessBadge label="Connection successful, checking database…" />}
+
+                {db.tested && db.checked && db.tableCount === 0 && !db.initialized && (
+                  <SuccessBadge label="Connection successful — database is empty, ready to initialize" />
+                )}
+
+                {db.tested && db.checked && db.hasSystemConfig && !db.initialized && (
+                  <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm space-y-2">
+                    <p className="font-medium text-emerald-500">Database already configured</p>
+                    <p className="text-muted-foreground">
+                      Found an existing Tank database with {db.tableCount} tables. You can continue to the next step or
+                      re-initialize to update the schema.
+                    </p>
+                    <DbTableList tables={db.tables} />
+                  </div>
+                )}
+
+                {db.tested && db.checked && db.tableCount > 0 && !db.hasSystemConfig && !db.confirmed && (
+                  <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm space-y-2">
+                    <p className="font-medium text-amber-500">
+                      This database has {db.tableCount} existing table{db.tableCount !== 1 ? 's' : ''}
+                    </p>
+                    {db.hasTankTables ? (
+                      <p className="text-muted-foreground">
+                        Tank tables detected but setup hasn't completed. Initialize to update the schema (existing data
+                        is preserved).
+                      </p>
+                    ) : (
+                      <p className="text-muted-foreground">
+                        These don't look like Tank tables. Initializing will add Tank tables alongside the existing
+                        ones. Make sure this is the right database.
+                      </p>
+                    )}
+                    <DbTableList tables={db.tables} />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setState((s) => ({ ...s, db: { ...s.db, confirmed: true } }))}>
+                      {db.hasTankTables ? 'Continue with this database' : 'Yes, use this database'}
+                    </Button>
+                  </div>
+                )}
+
+                {db.tested &&
+                  db.checked &&
+                  db.tableCount > 0 &&
+                  !db.hasSystemConfig &&
+                  db.confirmed &&
+                  !db.initialized && <SuccessBadge label="Database confirmed — ready to initialize" />}
+
+                {db.initialized && <SuccessBadge label="Database initialized" />}
+              </>
+            )}
+
+            {step === 1 && <InstanceUrlStep state={state} setState={setState} loading={loading} />}
+
+            {step === 2 && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="storage-backend">Provider</Label>
+                  <select
+                    id="storage-backend"
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    value={state.storage.backend}
+                    onChange={(e) => {
+                      const backend = e.target.value as StepState['storage']['backend'];
+                      const defaults: Record<string, Partial<StepState['storage']>> = {
+                        minio: {
+                          endpoint: 'http://minio:9000',
+                          region: 'us-east-1',
+                          bucket: 'packages',
+                          accessKey: '',
+                          secretKey: ''
+                        },
+                        s3: { endpoint: '', region: 'us-east-1', bucket: '', accessKey: '', secretKey: '' },
+                        's3-compatible': {
+                          endpoint: '',
+                          region: 'us-east-1',
+                          bucket: '',
+                          accessKey: '',
+                          secretKey: ''
+                        },
+                        supabase: { supabaseUrl: '', supabaseServiceKey: '' },
+                        filesystem: {}
+                      };
+                      setState((s) => ({
+                        ...s,
+                        storage: { ...s.storage, ...defaults[backend], backend, tested: false, saved: false }
+                      }));
+                    }}
+                    disabled={loading}>
+                    <option value="minio">MinIO (Docker Compose)</option>
+                    <option value="s3">AWS S3</option>
+                    <option value="s3-compatible">S3-Compatible (R2, DigitalOcean, Backblaze)</option>
+                    <option value="supabase">Supabase Storage</option>
+                    <option value="filesystem">Local Filesystem</option>
+                  </select>
+                </div>
+
+                {(['minio', 's3', 's3-compatible'] as string[]).includes(state.storage.backend) && (
+                  <>
+                    {state.storage.backend !== 's3' && (
+                      <div className="space-y-2">
+                        <Label htmlFor="storage-endpoint">Endpoint URL</Label>
+                        <Input
+                          id="storage-endpoint"
+                          placeholder={
+                            state.storage.backend === 'minio'
+                              ? 'http://minio:9000'
+                              : 'https://s3.us-east-1.amazonaws.com'
+                          }
+                          value={state.storage.endpoint}
+                          onChange={(e) =>
+                            setState((s) => ({
+                              ...s,
+                              storage: { ...s.storage, endpoint: e.target.value, tested: false, saved: false }
+                            }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                    )}
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-2">
+                        <Label htmlFor="storage-region">Region</Label>
+                        <Input
+                          id="storage-region"
+                          placeholder="us-east-1"
+                          value={state.storage.region}
+                          onChange={(e) =>
+                            setState((s) => ({
+                              ...s,
+                              storage: { ...s.storage, region: e.target.value, tested: false, saved: false }
+                            }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="storage-bucket">Bucket</Label>
+                        <Input
+                          id="storage-bucket"
+                          placeholder="packages"
+                          value={state.storage.bucket}
+                          onChange={(e) =>
+                            setState((s) => ({
+                              ...s,
+                              storage: { ...s.storage, bucket: e.target.value, tested: false, saved: false }
+                            }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-2">
+                        <Label htmlFor="storage-access-key">Access Key</Label>
+                        <Input
+                          id="storage-access-key"
+                          placeholder="Access key ID"
+                          value={state.storage.accessKey}
+                          onChange={(e) =>
+                            setState((s) => ({
+                              ...s,
+                              storage: { ...s.storage, accessKey: e.target.value, tested: false, saved: false }
+                            }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="storage-secret-key">Secret Key</Label>
+                        <Input
+                          id="storage-secret-key"
+                          type="password"
+                          placeholder="Secret access key"
+                          value={state.storage.secretKey}
+                          onChange={(e) =>
+                            setState((s) => ({
+                              ...s,
+                              storage: { ...s.storage, secretKey: e.target.value, tested: false, saved: false }
+                            }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {state.storage.backend === 'supabase' && (
+                  <>
+                    <div className="space-y-2">
+                      <Label htmlFor="supabase-url">Supabase URL</Label>
+                      <Input
+                        id="supabase-url"
+                        placeholder="https://your-project.supabase.co"
+                        value={state.storage.supabaseUrl}
+                        onChange={(e) =>
+                          setState((s) => ({
+                            ...s,
+                            storage: { ...s.storage, supabaseUrl: e.target.value, tested: false, saved: false }
+                          }))
+                        }
+                        disabled={loading}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="supabase-key">Service Role Key</Label>
+                      <Input
+                        id="supabase-key"
+                        type="password"
+                        placeholder="eyJhbGci..."
+                        value={state.storage.supabaseServiceKey}
+                        onChange={(e) =>
+                          setState((s) => ({
+                            ...s,
+                            storage: { ...s.storage, supabaseServiceKey: e.target.value, tested: false, saved: false }
+                          }))
+                        }
+                        disabled={loading}
+                      />
+                    </div>
+                  </>
+                )}
+
+                {state.storage.backend === 'filesystem' && (
+                  <div className="rounded-md bg-primary/5 border border-primary/20 p-3 text-sm">
+                    <p className="text-muted-foreground">
+                      Files will be stored at <code className="font-mono text-foreground">/app/data/packages</code>{' '}
+                      inside the container. Mount a Docker volume to persist data. No additional configuration needed.
+                    </p>
+                  </div>
+                )}
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={loading}
+                  onClick={() =>
+                    run(async () => {
+                      await post('/api/setup/test-storage');
+                      setState((s) => ({ ...s, storage: { ...s.storage, tested: true } }));
+                    })
+                  }>
+                  {loading ? 'Testing…' : 'Test Storage'}
+                </Button>
+                {state.storage.tested && <SuccessBadge label="Storage reachable" />}
+              </>
+            )}
+
+            {step === 3 && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="admin-email">Email</Label>
+                  <Input
+                    id="admin-email"
+                    type="email"
+                    placeholder="admin@company.com"
+                    value={state.admin.email}
+                    onChange={(e) => setState((s) => ({ ...s, admin: { ...s.admin, email: e.target.value } }))}
+                    disabled={loading}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="admin-password">Password</Label>
+                  <Input
+                    id="admin-password"
+                    type="password"
+                    placeholder="Minimum 8 characters"
+                    value={state.admin.password}
+                    onChange={(e) => setState((s) => ({ ...s, admin: { ...s.admin, password: e.target.value } }))}
+                    disabled={loading}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="admin-confirm">Confirm Password</Label>
+                  <Input
+                    id="admin-confirm"
+                    type="password"
+                    placeholder="Repeat password"
+                    value={state.admin.confirmPassword}
+                    onChange={(e) =>
+                      setState((s) => ({ ...s, admin: { ...s.admin, confirmPassword: e.target.value } }))
+                    }
+                    disabled={loading}
+                  />
+                </div>
+              </>
+            )}
+
+            {step === 4 && (
+              <>
+                <p className="text-sm text-muted-foreground">
+                  Email/password login is always enabled. Optionally add OAuth or SSO below, or click Continue to skip.
+                </p>
+                <div className="rounded-md border p-4 space-y-3">
+                  <div className="flex items-center gap-2">
+                    <input
+                      id="github-toggle"
+                      type="checkbox"
+                      className="size-4 rounded border-input accent-primary"
+                      checked={auth.githubEnabled}
+                      onChange={(e) =>
+                        setState((s) => ({ ...s, auth: { ...s.auth, githubEnabled: e.target.checked } }))
+                      }
+                    />
+                    <Label htmlFor="github-toggle" className="font-semibold">
+                      GitHub OAuth
+                    </Label>
+                  </div>
+                  {auth.githubEnabled && (
+                    <div className="space-y-3 pl-6">
+                      <div className="space-y-2">
+                        <Label htmlFor="gh-client-id">Client ID</Label>
+                        <Input
+                          id="gh-client-id"
+                          placeholder="Ov23li..."
+                          value={auth.githubClientId}
+                          onChange={(e) =>
+                            setState((s) => ({ ...s, auth: { ...s.auth, githubClientId: e.target.value } }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="gh-client-secret">Client Secret</Label>
+                        <Input
+                          id="gh-client-secret"
+                          type="password"
+                          placeholder="••••••••"
+                          value={auth.githubClientSecret}
+                          onChange={(e) =>
+                            setState((s) => ({ ...s, auth: { ...s.auth, githubClientSecret: e.target.value } }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <div className="rounded-md border p-4 space-y-3">
+                  <div className="flex items-center gap-2">
+                    <input
+                      id="oidc-toggle"
+                      type="checkbox"
+                      className="size-4 rounded border-input accent-primary"
+                      checked={auth.oidcEnabled}
+                      onChange={(e) => setState((s) => ({ ...s, auth: { ...s.auth, oidcEnabled: e.target.checked } }))}
+                    />
+                    <Label htmlFor="oidc-toggle" className="font-semibold">
+                      OIDC / SSO
+                    </Label>
+                  </div>
+                  {auth.oidcEnabled && (
+                    <div className="space-y-3 pl-6">
+                      <div className="space-y-2">
+                        <Label htmlFor="oidc-discovery">Discovery URL</Label>
+                        <Input
+                          id="oidc-discovery"
+                          placeholder="https://accounts.google.com/.well-known/openid-configuration"
+                          value={auth.oidcDiscoveryUrl}
+                          onChange={(e) =>
+                            setState((s) => ({ ...s, auth: { ...s.auth, oidcDiscoveryUrl: e.target.value } }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="oidc-client-id">Client ID</Label>
+                        <Input
+                          id="oidc-client-id"
+                          placeholder="client_id"
+                          value={auth.oidcClientId}
+                          onChange={(e) =>
+                            setState((s) => ({ ...s, auth: { ...s.auth, oidcClientId: e.target.value } }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="oidc-client-secret">Client Secret</Label>
+                        <Input
+                          id="oidc-client-secret"
+                          type="password"
+                          placeholder="••••••••"
+                          value={auth.oidcClientSecret}
+                          onChange={(e) =>
+                            setState((s) => ({ ...s, auth: { ...s.auth, oidcClientSecret: e.target.value } }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+
+            {step === 5 && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="llm-provider">Provider</Label>
+                  <select
+                    id="llm-provider"
+                    className="border-input dark:bg-input/30 h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] transition-[color,box-shadow]"
+                    value={llm.provider}
+                    onChange={(e) =>
+                      setState((s) => ({
+                        ...s,
+                        llm: { ...s.llm, provider: e.target.value as LLMProvider, tested: false }
+                      }))
+                    }
+                    disabled={loading}>
+                    <option value="disabled">Disabled</option>
+                    <option value="groq">Groq</option>
+                    <option value="openrouter">OpenRouter</option>
+                    <option value="litellm">LiteLLM</option>
+                    <option value="custom">Custom (OpenAI-compatible)</option>
+                  </select>
+                </div>
+
+                {llm.provider !== 'disabled' && (
+                  <>
+                    {(llm.provider === 'groq' || llm.provider === 'openrouter') && (
+                      <div className="space-y-2">
+                        <Label htmlFor="llm-api-key">API Key</Label>
+                        <Input
+                          id="llm-api-key"
+                          type="password"
+                          placeholder="sk-..."
+                          value={llm.apiKey}
+                          onChange={(e) =>
+                            setState((s) => ({ ...s, llm: { ...s.llm, apiKey: e.target.value, tested: false } }))
+                          }
+                          disabled={loading}
+                        />
+                      </div>
+                    )}
+                    {(llm.provider === 'litellm' || llm.provider === 'custom') && (
+                      <>
+                        <div className="space-y-2">
+                          <Label htmlFor="llm-base-url">Base URL</Label>
+                          <Input
+                            id="llm-base-url"
+                            placeholder="http://litellm:4000/v1"
+                            value={llm.baseUrl}
+                            onChange={(e) =>
+                              setState((s) => ({ ...s, llm: { ...s.llm, baseUrl: e.target.value, tested: false } }))
+                            }
+                            disabled={loading}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="llm-api-key-2">API Key (optional)</Label>
+                          <Input
+                            id="llm-api-key-2"
+                            type="password"
+                            placeholder="sk-..."
+                            value={llm.apiKey}
+                            onChange={(e) =>
+                              setState((s) => ({ ...s, llm: { ...s.llm, apiKey: e.target.value, tested: false } }))
+                            }
+                            disabled={loading}
+                          />
+                        </div>
+                      </>
+                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={loading}
+                      onClick={() =>
+                        run(async () => {
+                          await post('/api/setup/test-llm', {
+                            provider: llm.provider,
+                            apiKey: llm.apiKey || undefined,
+                            baseUrl: llm.baseUrl || undefined
+                          });
+                          setState((s) => ({ ...s, llm: { ...s.llm, tested: true } }));
+                        })
+                      }>
+                      {loading ? 'Testing…' : 'Test Connection'}
+                    </Button>
+                    {llm.tested && <SuccessBadge label="LLM reachable" />}
+                  </>
+                )}
+              </>
+            )}
+
+            {step === 6 && (
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  Your instance is ready to be finalized. Review the configuration below.
+                </p>
+                <div className="rounded-md border divide-y divide-border text-sm">
+                  <div className="flex justify-between px-3 py-2">
+                    <span className="text-muted-foreground">Database</span>
+                    <SuccessBadge label="Initialized" />
+                  </div>
+                  <div className="flex justify-between px-3 py-2">
+                    <span className="text-muted-foreground">Instance URL</span>
+                    <span className="font-mono text-xs truncate max-w-[200px]">{state.instanceUrl.url}</span>
+                  </div>
+                  <div className="flex justify-between px-3 py-2">
+                    <span className="text-muted-foreground">Storage</span>
+                    <SuccessBadge label="Verified" />
+                  </div>
+                  <div className="flex justify-between px-3 py-2">
+                    <span className="text-muted-foreground">Admin</span>
+                    <span className="truncate max-w-[200px]">{state.admin.email}</span>
+                  </div>
+                  <div className="flex justify-between px-3 py-2">
+                    <span className="text-muted-foreground">GitHub OAuth</span>
+                    <span>{auth.githubEnabled ? 'Enabled' : 'Disabled'}</span>
+                  </div>
+                  <div className="flex justify-between px-3 py-2">
+                    <span className="text-muted-foreground">OIDC / SSO</span>
+                    <span>{auth.oidcEnabled ? 'Enabled' : 'Disabled'}</span>
+                  </div>
+                  <div className="flex justify-between px-3 py-2">
+                    <span className="text-muted-foreground">Scanner LLM</span>
+                    <span className="capitalize">{llm.provider}</span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {error && <ErrorMessage message={error} />}
+
+            <div className="flex justify-between pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={step === 0 || loading}
+                onClick={() => {
+                  setError(null);
+                  setStep((s) => s - 1);
+                }}>
+                Back
+              </Button>
+              <Button size="sm" disabled={loading} onClick={handleContinue}>
+                {loading ? 'Please wait…' : step === 6 ? 'Complete Setup' : 'Continue'}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/src/server.ts
+++ b/apps/registry/src/server.ts
@@ -1,3 +1,53 @@
-import handler from '@tanstack/react-start/server-entry';
+import handler, { createServerEntry } from '@tanstack/react-start/server-entry';
 
-export default handler;
+import { serveDocMarkdown } from '~/lib/docs-fs';
+
+const DOCS_RAW_PATTERN = /^\/docs\/([a-z0-9_-]+)\.(md|txt)$/;
+const SETUP_PASSTHROUGH = /^\/(setup|api\/health|api\/setup|api\/auth)/;
+
+export default createServerEntry({
+  fetch: async (request, opts) => {
+    const url = new URL(request.url);
+
+    if (process.env.TANK_MODE === 'selfhosted') {
+      const { isSetupCompleted } = await import('~/lib/setup');
+
+      if (!SETUP_PASSTHROUGH.test(url.pathname)) {
+        const completed = await isSetupCompleted();
+        if (!completed) {
+          return new Response(null, {
+            status: 302,
+            headers: { Location: '/setup' }
+          });
+        }
+      }
+
+      if (url.pathname === '/setup') {
+        const completed = await isSetupCompleted();
+        if (completed) {
+          return new Response(null, {
+            status: 302,
+            headers: { Location: '/' }
+          });
+        }
+      }
+    }
+
+    const match = url.pathname.match(DOCS_RAW_PATTERN);
+    if (match) {
+      const { content, found } = serveDocMarkdown(match[1]);
+      const contentType = match[2] === 'txt' ? 'text/plain' : 'text/markdown';
+
+      return new Response(content, {
+        status: found ? 200 : 404,
+        headers: {
+          'Content-Type': `${contentType}; charset=utf-8`,
+          'X-Robots-Tag': 'noindex',
+          'Cache-Control': 'public, max-age=300, s-maxage=300'
+        }
+      });
+    }
+
+    return handler.fetch(request, opts);
+  }
+});

--- a/apps/registry/src/services/storage/provider.ts
+++ b/apps/registry/src/services/storage/provider.ts
@@ -1,3 +1,6 @@
+import { createHmac } from 'node:crypto';
+import * as fs from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import {
   CreateBucketCommand,
   GetObjectCommand,
@@ -189,6 +192,74 @@ class S3StorageProvider implements StorageProvider {
   }
 }
 
+class FilesystemStorageProvider implements StorageProvider {
+  private readonly baseDir: string;
+  private readonly publicUrl: string;
+
+  constructor(baseDir: string, publicUrl: string) {
+    this.baseDir = baseDir;
+    this.publicUrl = publicUrl.replace(/\/$/, '');
+  }
+
+  private resolvePath(path: string): string {
+    const resolved = resolve(join(this.baseDir, path));
+    if (!resolved.startsWith(resolve(this.baseDir))) {
+      throw new Error('Path traversal detected');
+    }
+    return resolved;
+  }
+
+  private generateToken(path: string, expiresAt: number): string {
+    const secret = process.env.BETTER_AUTH_SECRET || 'tank-fs-secret';
+    return createHmac('sha256', secret).update(`${path}:${expiresAt}`).digest('hex');
+  }
+
+  async createSignedUploadUrl(path: string, expiresInSeconds = 3600): Promise<SignedUrlResult> {
+    const expiresAt = Math.floor(Date.now() / 1000) + expiresInSeconds;
+    const token = this.generateToken(path, expiresAt);
+    return {
+      signedUrl: `${this.publicUrl}/api/storage/upload?path=${encodeURIComponent(path)}&expires=${expiresAt}&token=${token}`
+    };
+  }
+
+  async createSignedUrl(path: string, expiresInSeconds = 3600): Promise<SignedUrlResult> {
+    const expiresAt = Math.floor(Date.now() / 1000) + expiresInSeconds;
+    const token = this.generateToken(path, expiresAt);
+    return {
+      signedUrl: `${this.publicUrl}/api/storage/download?path=${encodeURIComponent(path)}&expires=${expiresAt}&token=${token}`
+    };
+  }
+
+  async putObject(path: string, body: Uint8Array): Promise<void> {
+    const fullPath = this.resolvePath(path);
+    fs.mkdirSync(dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, body);
+  }
+
+  async listObjects(_bucket: string, prefix: string, limit: number): Promise<unknown> {
+    const dir = this.resolvePath(prefix || '');
+    if (!fs.existsSync(dir)) return { Contents: [] };
+    const files = fs
+      .readdirSync(dir)
+      .slice(0, limit)
+      .map((name: string) => ({
+        Key: join(prefix || '', name),
+        Size: fs.statSync(join(dir, name)).size
+      }));
+    return { Contents: files };
+  }
+
+  verifyToken(path: string, expires: string, token: string): boolean {
+    const expiresAt = Number.parseInt(expires, 10);
+    if (isNaN(expiresAt) || Date.now() / 1000 > expiresAt) return false;
+    return this.generateToken(path, expiresAt) === token;
+  }
+
+  getFilePath(path: string): string {
+    return this.resolvePath(path);
+  }
+}
+
 let providerInstance: StorageProvider | null = null;
 
 export function getStorageProvider(): StorageProvider {
@@ -197,6 +268,13 @@ export function getStorageProvider(): StorageProvider {
   const backend = env.STORAGE_BACKEND;
   const bucket = env.STORAGE_BUCKET || env.S3_BUCKET;
 
+  if (backend === 'filesystem') {
+    const baseDir = env.STORAGE_FS_PATH || '/app/data/packages';
+    const publicUrl = env.BETTER_AUTH_URL || env.APP_URL || 'http://localhost:3000';
+    providerInstance = new FilesystemStorageProvider(baseDir, publicUrl);
+    return providerInstance;
+  }
+
   if (backend === 's3') {
     providerInstance = new S3StorageProvider(bucket);
     return providerInstance;
@@ -204,4 +282,9 @@ export function getStorageProvider(): StorageProvider {
 
   providerInstance = new SupabaseStorageProvider(bucket);
   return providerInstance;
+}
+
+export function getFilesystemProvider(): FilesystemStorageProvider | null {
+  const provider = getStorageProvider();
+  return provider instanceof FilesystemStorageProvider ? provider : null;
 }

--- a/e2e/onprem-e2e.sh
+++ b/e2e/onprem-e2e.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Tank On-Prem E2E Test Suite
+# Runs against a live Docker stack. Expects fresh volumes.
+# Usage: BASE=http://localhost:4444 bash e2e/onprem-e2e.sh
+
+set -euo pipefail
+
+BASE="${BASE:-http://localhost:4444}"
+PASS=0; FAIL=0; SKIP=0
+COOKIE_JAR=$(mktemp)
+trap 'rm -f $COOKIE_JAR' EXIT
+
+assert() { local n="$1" e="$2" a="$3"; if [ "$e" = "$a" ]; then echo "  ✅ $n"; PASS=$((PASS+1)); else echo "  ❌ $n — expected: $e, got: $a"; FAIL=$((FAIL+1)); fi; }
+assert_contains() { local n="$1" e="$2" a="$3"; if echo "$a" | grep -q "$e"; then echo "  ✅ $n"; PASS=$((PASS+1)); else echo "  ❌ $n — expected to contain: $e"; FAIL=$((FAIL+1)); fi; }
+post() { curl -s -X POST "$BASE$1" -H 'Content-Type: application/json' -H "Origin: $BASE" -d "$2" -b $COOKIE_JAR -c $COOKIE_JAR; }
+get() { curl -s "$BASE$1" -b $COOKIE_JAR -c $COOKIE_JAR; }
+status() { curl -s -o /dev/null -w '%{http_code}' "$BASE$1" -b $COOKIE_JAR -c $COOKIE_JAR; }
+
+echo "═══════════════════════════════════════"
+echo "  Tank On-Prem E2E Test Suite"
+echo "  Target: $BASE"
+echo "═══════════════════════════════════════"
+
+# ─── SETUP WIZARD ───
+echo ""
+echo "▸ Setup Wizard"
+assert "/ redirects to /setup" "302" "$(curl -sI -o /dev/null -w '%{http_code}' $BASE/)"
+assert_contains "Not completed" '"completed":false' "$(get /api/setup/status)"
+assert_contains "Test DB" '"ok":true' "$(post /api/setup/test-db '{"useEnv":true}')"
+assert_contains "Init DB" '"ok":true' "$(post /api/setup/init-db '')"
+assert_contains "System config exists" '"hasSystemConfig":true' "$(post /api/setup/check-db '{"useEnv":true}')"
+assert_contains "Instance URL" '"ok":true' "$(post /api/setup/instance-url "{\"instanceUrl\":\"$BASE\"}")"
+assert_contains "Test storage" '"ok":true' "$(post /api/setup/test-storage '')"
+assert_contains "Save storage" '"ok":true' "$(post /api/setup/storage '{"backend":"s3"}')"
+assert_contains "Create admin" '"ok":true' "$(post /api/setup/admin '{"email":"admin@e2e.test","password":"e2epass12345"}')"
+assert_contains "Weak pw rejected" '"error"' "$(post /api/setup/admin '{"email":"x@x.com","password":"short"}')"
+assert_contains "Scanner disabled" '"ok":true' "$(post /api/setup/scanner-llm '{"provider":"disabled"}')"
+assert_contains "Complete" '"ok":true' "$(post /api/setup/complete '')"
+assert "/ serves app" "200" "$(curl -sI -o /dev/null -w '%{http_code}' $BASE/)"
+assert "/setup blocked" "302" "$(curl -sI -o /dev/null -w '%{http_code}' $BASE/setup)"
+assert_contains "Completed" '"completed":true' "$(get /api/setup/status)"
+
+# ─── AUTH: Login ───
+echo ""
+echo "▸ Auth: Login"
+R=$(post /api/auth/sign-in/email '{"email":"admin@e2e.test","password":"e2epass12345"}')
+assert_contains "Admin login" '"user"' "$R"
+
+# verify cookie works
+assert "Dashboard accessible" "200" "$(status /dashboard)"
+assert "Admin accessible" "200" "$(status /admin)"
+
+# ─── TOKENS: CRUD ───
+echo ""
+echo "▸ Tokens: CRUD"
+R=$(post /api/auth/api-key/create '{"name":"e2e-token","expiresIn":86400}')
+TOKEN_ID=""
+if echo "$R" | grep -q '"id"'; then
+  assert_contains "Create token returns id" '"id"' "$R"
+  assert_contains "Create token returns key" '"key"' "$R"
+  TOKEN_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || echo "")
+else
+  echo "  ⚠️  Create token response: $(echo $R | head -c 120)"
+  SKIP=$((SKIP+1))
+fi
+
+R=$(get /api/auth/api-key/list)
+if echo "$R" | grep -q '\['; then
+  assert_contains "List tokens returns array" '\[' "$R"
+else
+  echo "  ⚠️  List tokens response: $(echo $R | head -c 120)"
+  SKIP=$((SKIP+1))
+fi
+
+if [ -n "$TOKEN_ID" ]; then
+  R=$(post /api/auth/api-key/delete "{\"keyId\":\"$TOKEN_ID\"}")
+  assert_contains "Revoke token" '"success"\|"ok"' "$R"
+else
+  echo "  ⚠️  Skipping revoke (no token ID)"
+  SKIP=$((SKIP+1))
+fi
+
+# ─── CLI AUTH FLOW ───
+echo ""
+echo "▸ CLI Auth Flow"
+STATE=$(python3 -c "import uuid; print(uuid.uuid4())")
+R=$(post /api/v1/cli-auth/start "{\"state\":\"$STATE\"}")
+assert_contains "CLI start returns authUrl" '"authUrl"' "$R"
+assert_contains "CLI start returns sessionCode" '"sessionCode"' "$R"
+SESSION_CODE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sessionCode',''))" 2>/dev/null || echo "")
+
+if [ -n "$SESSION_CODE" ]; then
+  # Authorize (with browser cookies)
+  R=$(post /api/v1/cli-auth/authorize "{\"sessionCode\":\"$SESSION_CODE\"}")
+  assert_contains "CLI authorize" '"success":true' "$R"
+
+  # Exchange
+  R=$(post /api/v1/cli-auth/exchange "{\"sessionCode\":\"$SESSION_CODE\",\"state\":\"$STATE\"}")
+  assert_contains "CLI exchange returns token" '"token"' "$R"
+  assert_contains "CLI exchange returns user" '"user"' "$R"
+else
+  echo "  ❌ No session code — cannot test authorize/exchange"
+  FAIL=$((FAIL+2))
+fi
+
+# ─── ADMIN APIs ───
+echo ""
+echo "▸ Admin: Users API"
+R=$(get /api/admin/users)
+assert_contains "List users" '"users"' "$R"
+assert_contains "Has total" '"total"' "$R"
+assert_contains "Has pagination" '"totalPages"' "$R"
+
+R=$(get "/api/admin/users?search=admin")
+assert_contains "Search users" '"users"' "$R"
+
+echo ""
+echo "▸ Admin: Packages API"
+R=$(get /api/admin/packages)
+assert_contains "List packages" '"packages"' "$R"
+assert_contains "Has total" '"total"' "$R"
+
+R=$(get "/api/admin/packages?status=invalid")
+assert "Invalid status returns 400" "400" "$(status '/api/admin/packages?status=invalid')"
+
+echo ""
+echo "▸ Admin: Audit Logs API"
+R=$(get /api/admin/audit-logs)
+assert_contains "List audit logs" '"events"' "$R"
+assert_contains "Has total" '"total"' "$R"
+
+R=$(get "/api/admin/audit-logs?startDate=invalid")
+assert "Invalid date returns 400" "400" "$(status '/api/admin/audit-logs?startDate=invalid')"
+
+# ─── ADMIN: CRUD Operations ───
+echo ""
+echo "▸ Admin: CRUD Operations"
+post /api/setup/admin '{"email":"testuser@e2e.test","password":"testpass12345"}' > /dev/null 2>&1
+sleep 1
+
+R=$(get "/api/admin/users?search=testuser")
+TEST_USER_ID=$(echo "$R" | python3 -c "import sys,json; users=json.load(sys.stdin).get('users',[]); print(users[0]['id'] if users else '')" 2>/dev/null || echo "")
+
+if [ -n "$TEST_USER_ID" ]; then
+  # Suspend
+  R=$(curl -s -X PATCH "$BASE/api/admin/users/$TEST_USER_ID/status" -H 'Content-Type: application/json' -H "Origin: $BASE" -b $COOKIE_JAR -d '{"status":"suspended","reason":"E2E test"}')
+  assert_contains "Suspend user" '"ok":true' "$R"
+
+  # Verify suspended
+  R=$(get "/api/admin/users/$TEST_USER_ID")
+  assert_contains "User has suspended status" '"suspended"' "$R"
+
+  # Reactivate
+  R=$(curl -s -X PATCH "$BASE/api/admin/users/$TEST_USER_ID/status" -H 'Content-Type: application/json' -H "Origin: $BASE" -b $COOKIE_JAR -d '{"status":"active"}')
+  assert_contains "Activate user" '"ok":true' "$R"
+else
+  echo "  ⚠️  Could not find test user — skipping CRUD"
+  SKIP=$((SKIP+3))
+fi
+
+# ─── NON-ADMIN ACCESS (should fail) ───
+echo ""
+echo "▸ Access Control"
+# Clear cookies to test as unauthenticated
+EMPTY_JAR=$(mktemp)
+assert "Admin users 401 without auth" "401" "$(curl -s -o /dev/null -w '%{http_code}' $BASE/api/admin/users -b $EMPTY_JAR)"
+assert "Admin packages 401 without auth" "401" "$(curl -s -o /dev/null -w '%{http_code}' $BASE/api/admin/packages -b $EMPTY_JAR)"
+assert "Admin audit-logs 401 without auth" "401" "$(curl -s -o /dev/null -w '%{http_code}' $BASE/api/admin/audit-logs -b $EMPTY_JAR)"
+rm -f $EMPTY_JAR
+
+# ─── RESULTS ───
+echo ""
+echo "═══════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "═══════════════════════════════════════"
+
+if [ $FAIL -gt 0 ]; then exit 1; fi

--- a/infra/docker-compose.production.yml
+++ b/infra/docker-compose.production.yml
@@ -110,6 +110,7 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       EMAIL_FROM: ${EMAIL_FROM:-no-reply@tank.local}
       FIRST_ADMIN_EMAIL: ${FIRST_ADMIN_EMAIL:-}
+      TANK_MODE: selfhosted
     depends_on:
       postgres:
         condition: service_healthy

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       EMAIL_FROM: ${EMAIL_FROM:-no-reply@tank.local}
       FIRST_ADMIN_EMAIL: ${FIRST_ADMIN_EMAIL:-}
+      TANK_MODE: selfhosted
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Adds on-prem/self-hosted support to Tank, safely gated behind `TANK_MODE` env var so the public Vercel deployment is never affected.

### How it works
- `TANK_MODE=cloud` (default, Vercel) → all on-prem features disabled, setup routes return 404
- `TANK_MODE=selfhosted` (Docker) → setup wizard enabled, DB migrations in entrypoint, filesystem storage

### Security hardening (per Oracle review)
- `/api/setup/*` returns 404 in cloud mode (middleware gate in app.ts)
- All setup POST endpoints return 403 once setup is completed (one-time only)
- Removed shell `eval` injection vector in entrypoint — uses file-based env loading with sanitization
- All DB-sourced values sanitized before env export (strips shell metacharacters)
- AES-256-GCM encryption for secrets stored in `system_config` table

### Features
- 7-step setup wizard UI (DB, URL, storage, admin account, auth providers, scanner LLM, complete)
- Setup guard in `server.ts` redirects to `/setup` until first setup completes (selfhosted only)
- `FilesystemStorageProvider` with HMAC-signed URLs for air-gapped deployments
- Docker entrypoint with `AUTO_MIGRATE` for headless setup
- `systemConfig` Drizzle table for persistent instance configuration

### Bug fixes
- Fixed `SUPABASE_SERVICE_ROLE_KEY` variable name mismatch in DB loader
- Fixed `AUTH_PROVIDERS` overwrite when both GitHub + OIDC enabled