### PR TITLE
perf(docs): pre-render markdown to HTML at build time

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 5555",
-    "build": "vite build",
+    "build": "bun run scripts/build-docs.ts && vite build",
+    "build:docs": "bun run scripts/build-docs.ts",
     "start": "node .output/server/index.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/apps/registry/scripts/build-docs.ts
+++ b/apps/registry/scripts/build-docs.ts
@@ -1,0 +1,135 @@
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import rehypeShiki from '@shikijs/rehype';
+import type { Element, Root, RootContent } from 'hast';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeRaw from 'rehype-raw';
+import rehypeSlug from 'rehype-slug';
+import rehypeStringify from 'rehype-stringify';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
+import { visit } from 'unist-util-visit';
+
+const calloutStyles: Record<string, string> = {
+  info: 'border-l-4 border-blue-500 bg-blue-500/10 p-4 rounded-r-lg my-4',
+  warn: 'border-l-4 border-amber-500 bg-amber-500/10 p-4 rounded-r-lg my-4',
+  error: 'border-l-4 border-red-500 bg-red-500/10 p-4 rounded-r-lg my-4'
+};
+
+type Heading = { id: string; text: string; level: number };
+type HeadingFile = { data?: Record<string, unknown> & { headings?: Heading[] } };
+
+function rehypeCallout() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node) => {
+      if (node.tagName !== 'callout') return;
+      const type = (node.properties?.type as string) || 'info';
+      node.tagName = 'blockquote';
+      node.properties = { className: calloutStyles[type] || calloutStyles.info };
+    });
+  };
+}
+
+function extractText(node: RootContent | Element): string {
+  if (node.type === 'text') return node.value || '';
+  if ('children' in node) return node.children.map(extractText).join('');
+  return '';
+}
+
+function rehypeCollectHeadings() {
+  return (tree: Root, file: HeadingFile) => {
+    const headings: Heading[] = [];
+    visit(tree, 'element', (node) => {
+      if (/^h[2-4]$/.test(node.tagName) && node.properties?.id) {
+        headings.push({
+          id: node.properties.id as string,
+          text: extractText(node),
+          level: Number.parseInt(node.tagName[1], 10)
+        });
+      }
+    });
+    file.data = file.data || {};
+    file.data.headings = headings;
+  };
+}
+
+function parseFrontmatter(content: string): { data: Record<string, string>; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { data: {}, body: content };
+  const data: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const sep = line.indexOf(':');
+    if (sep > 0) {
+      const key = line.slice(0, sep).trim();
+      const val = line
+        .slice(sep + 1)
+        .trim()
+        .replace(/^['"]|['"]$/g, '');
+      data[key] = val;
+    }
+  }
+  return { data, body: match[2] };
+}
+
+async function main() {
+  const docsDir = join(import.meta.dir, '..', 'public', 'docs');
+  const outDir = join(import.meta.dir, '..', 'src', 'generated');
+
+  const files = readdirSync(docsDir)
+    .filter((f) => f.endsWith('.md'))
+    .sort();
+  console.log(`[build-docs] Processing ${files.length} markdown files...`);
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeCallout)
+    .use(rehypeSlug)
+    .use(rehypeAutolinkHeadings, { behavior: 'wrap', properties: { className: ['anchor-heading'] } })
+    .use(rehypeCollectHeadings)
+    .use(rehypeShiki, {
+      themes: { light: 'github-light', dark: 'github-dark' },
+      defaultColor: false
+    })
+    .use(rehypeStringify);
+
+  const entries: Array<{
+    title: string;
+    description?: string;
+    slug: string;
+    html: string;
+    headings: Heading[];
+  }> = [];
+
+  for (const file of files) {
+    const raw = readFileSync(join(docsDir, file), 'utf-8');
+    const { data, body } = parseFrontmatter(raw);
+    const result = await processor.process(body);
+    const headings = (result.data?.headings as Heading[]) || [];
+    const slug = file.replace(/\.md$/, '');
+    entries.push({
+      title: data.title || slug,
+      description: data.description,
+      slug: slug === 'index' ? '' : slug,
+      html: String(result),
+      headings
+    });
+    console.log(`  \u2713 ${file} (${headings.length} headings)`);
+  }
+
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'docs.json'), JSON.stringify(entries));
+  console.log(
+    `[build-docs] Wrote ${entries.length} docs to src/generated/docs.json (${(JSON.stringify(entries).length / 1024).toFixed(0)}KB)`
+  );
+}
+
+main().catch((e) => {
+  console.error('[build-docs] FAILED:', e);
+  process.exit(1);
+});

--- a/apps/registry/src/query/docs.ts
+++ b/apps/registry/src/query/docs.ts
@@ -1,120 +1,25 @@
-import rehypeShiki from '@shikijs/rehype';
 import { createServerFn } from '@tanstack/react-start';
-import type { Element, Root, RootContent } from 'hast';
-import rehypeAutolinkHeadings from 'rehype-autolink-headings';
-import rehypeRaw from 'rehype-raw';
-import rehypeSlug from 'rehype-slug';
-import rehypeStringify from 'rehype-stringify';
-import remarkGfm from 'remark-gfm';
-import remarkParse from 'remark-parse';
-import remarkRehype from 'remark-rehype';
-import { unified } from 'unified';
-import { visit } from 'unist-util-visit';
 
-import { parseFrontmatter, readDocFile, readDocFiles } from '~/lib/docs-fs';
-
-const calloutStyles: Record<string, string> = {
-  info: 'border-l-4 border-blue-500 bg-blue-500/10 p-4 rounded-r-lg my-4',
-  warn: 'border-l-4 border-amber-500 bg-amber-500/10 p-4 rounded-r-lg my-4',
-  error: 'border-l-4 border-red-500 bg-red-500/10 p-4 rounded-r-lg my-4'
-};
-
-type Heading = { id: string; text: string; level: number };
-type HeadingFile = {
-  data?: Record<string, unknown> & {
-    headings?: Heading[];
-  };
-};
-
-function rehypeCallout() {
-  return (tree: Root) => {
-    visit(tree, 'element', (node, index, parent) => {
-      if (node.tagName !== 'callout' || index == null || !parent) return;
-      const type = (node.properties?.type as string) || 'info';
-      node.tagName = 'blockquote';
-      node.properties = { className: calloutStyles[type] || calloutStyles.info };
-    });
-  };
-}
-
-function extractText(node: RootContent | Element): string {
-  if (node.type === 'text') return node.value || '';
-  if ('children' in node) return node.children.map(extractText).join('');
-  return '';
-}
-
-function rehypeCollectHeadings() {
-  return (tree: Root, file: HeadingFile) => {
-    const headings: Heading[] = [];
-    visit(tree, 'element', (node) => {
-      if (/^h[2-4]$/.test(node.tagName) && node.properties?.id) {
-        headings.push({
-          id: node.properties.id as string,
-          text: extractText(node),
-          level: Number.parseInt(node.tagName[1], 10)
-        });
-      }
-    });
-    file.data = file.data || {};
-    file.data.headings = headings;
-  };
-}
+import docsData from '~/generated/docs.json';
 
 export interface DocEntry {
   title: string;
   description?: string;
   slug: string;
   html: string;
-  headings: Heading[];
+  headings: { id: string; text: string; level: number }[];
 }
 
-let docsCache: DocEntry[] | null = null;
-
-async function loadDocs(): Promise<DocEntry[]> {
-  if (docsCache) return docsCache;
-
-  const files = readDocFiles();
-  if (files.length === 0) return [];
-
-  const processor = unified()
-    .use(remarkParse)
-    .use(remarkGfm)
-    .use(remarkRehype, { allowDangerousHtml: true })
-    .use(rehypeRaw)
-    .use(rehypeCallout)
-    .use(rehypeSlug)
-    .use(rehypeAutolinkHeadings, { behavior: 'wrap', properties: { className: ['anchor-heading'] } })
-    .use(rehypeCollectHeadings)
-    .use(rehypeShiki, {
-      themes: { light: 'github-light', dark: 'github-dark' },
-      defaultColor: false
-    })
-    .use(rehypeStringify);
-
-  const entries: DocEntry[] = [];
-  for (const file of files) {
-    const { data, body } = parseFrontmatter(readDocFile(file));
-    const result = await processor.process(body);
-    const headings = (result.data?.headings as Heading[]) || [];
-    const slug = file.replace(/\.md$/, '');
-    entries.push({
-      title: data.title || slug,
-      description: data.description,
-      slug: slug === 'index' ? '' : slug,
-      html: String(result),
-      headings
-    });
-  }
-
-  docsCache = entries;
-  return entries;
-}
+const docs: DocEntry[] = docsData as DocEntry[];
 
 export const getDocBySlug = createServerFn({ method: 'GET' })
   .inputValidator((slug: string) => slug)
   .handler(async ({ data: slug }) => {
-    const docs = await loadDocs();
     const normalized = slug === '' || slug === 'index' ? '' : slug;
     const doc = docs.find((d) => d.slug === normalized);
     return doc ?? null;
   });
+
+export const getAllDocs = createServerFn({ method: 'GET' }).handler(async () => {
+  return docs.map(({ title, description, slug }) => ({ title, description, slug }));
+});


### PR DESCRIPTION
## Problem
Docs pages take 2-5 seconds to load on first visit. Every Vercel serverless cold start processes all 18 markdown files through unified + Shiki syntax highlighting at runtime.

## Fix
Pre-render all markdown → HTML at build time. Runtime is now a JSON array lookup (instant).

| Before | After |
|--------|-------|
| 18 files × unified pipeline × Shiki WASM | JSON import + `.find()` |
| ~2-5s cold start | ~0ms |
| Repeated on every function cold start | Once at build time |

## Files
- `scripts/build-docs.ts` — build-time processor
- `query/docs.ts` — rewritten to import static JSON
- `package.json` — build script prepends `build-docs.ts`
- `src/generated/docs.json` — gitignored, built in CI