### PR TITLE
feat: make service URLs configurable via TANK_REGISTRY_URL

### DIFF
--- a/.github/workflows/cli-nightly.yml
+++ b/.github/workflows/cli-nightly.yml
@@ -59,7 +59,9 @@ jobs:
             }
           "
 
-      - name: Build packages
+      - name: Build packages (with nightly URLs baked in)
+        env:
+          TANK_REGISTRY_URL: https://nightly.tankpkg.dev
         run: |
           bun --filter @internals/schemas run build
           bun --filter @internals/helpers run build

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -9,7 +9,7 @@ export interface TankConfig {
 }
 
 const DEFAULT_CONFIG: TankConfig = {
-  registry: 'https://www.tankpkg.dev'
+  registry: process.env.TANK_REGISTRY_URL || 'https://www.tankpkg.dev'
 };
 
 /**

--- a/packages/internals-schemas/src/constants/registry.ts
+++ b/packages/internals-schemas/src/constants/registry.ts
@@ -1,4 +1,4 @@
-export const REGISTRY_URL = 'https://tankpkg.dev';
+export const REGISTRY_URL = process.env.TANK_REGISTRY_URL || 'https://www.tankpkg.dev';
 export const REGISTRY_API_VERSION = 'v1';
 export const MAX_PACKAGE_SIZE = 50 * 1024 * 1024; // 50MB
 export const MAX_FILE_COUNT = 1000;


### PR DESCRIPTION
## Problem
All environments (nightly, stable, on-prem) share hardcoded URLs. Nightly web talks to stable scanner, nightly CLI points to stable registry.

## Fix
- `REGISTRY_URL` in schemas and CLI `config.ts` now respects `TANK_REGISTRY_URL` env var
- Falls back to `https://www.tankpkg.dev` if unset (stable default)
- Nightly CLI workflow bakes `TANK_REGISTRY_URL=https://nightly.tankpkg.dev` at build time
- On-prem users can set `TANK_REGISTRY_URL` to their own domain

## Vercel env vars to set (manual)

### safe-skills-directory (web)
| Env var | Production | Preview |
|---------|-----------|---------|
| `PYTHON_API_URL` | `https://scanner.tankpkg.dev` | `https://nightly-scanner.tankpkg.dev` |

### python-api (scanner)
No changes needed — scanner doesn't call the web app.