### PR TITLE
fix(scanner): remove empty installCommand that blocked dependency install

### DIFF
--- a/apps/python-api/vercel.json
+++ b/apps/python-api/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "",
   "buildCommand": "",
   "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
 }


### PR DESCRIPTION
Scanner on Vercel crashes with `ModuleNotFoundError: No module named fastapi` because `"installCommand": ""` in vercel.json overrides Vercel auto-detection of `requirements.txt`. Removing it lets Vercel install deps normally.