### PR TITLE
fix(docker): add missing e2e workspace to Dockerfile

### DIFF
--- a/apps/registry/Dockerfile
+++ b/apps/registry/Dockerfile
@@ -12,6 +12,7 @@ COPY apps/registry/package.json ./apps/registry/
 COPY packages/cli/package.json ./packages/cli/
 COPY packages/mcp-server/package.json ./packages/mcp-server/
 COPY bdd/package.json ./bdd/
+COPY e2e/package.json ./e2e/
 
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
Fixes Docker build failure: 'Workspace not found e2e'. The root package.json lists e2e as a workspace but the Dockerfile didn't COPY its package.json.