### PR TITLE
refactor(ci): extract CI logic to just recipes, slim workflows 55%

### DIFF
--- a/.github/workflows/cli-nightly.yml
+++ b/.github/workflows/cli-nightly.yml
@@ -2,82 +2,26 @@ name: CLI Nightly
 
 on:
   schedule:
-    - cron: "30 4 * * *" # 4:30am UTC daily (after Docker nightly)
+    - cron: "30 4 * * *"
   push:
-    branches:
-      - main
-    paths:
-      - "packages/cli/**"
-      - "packages/mcp-server/**"
-      - "packages/internals-schemas/**"
-      - "packages/internals-helpers/**"
+    branches: [main]
+    paths: ["packages/**"]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  publish-nightly:
-    name: publish-nightly
+  publish:
     runs-on: ubuntu-22.04
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Set nightly version
-        run: |
-          # Use date-based version: 0.0.0-nightly.YYYYMMDD.SHA
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          NIGHTLY_VERSION="0.0.0-nightly.$(date -u +%Y%m%d).${SHORT_SHA}"
-          echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> $GITHUB_ENV
-          echo "Publishing nightly version: ${NIGHTLY_VERSION}"
-
-          # Inject nightly version into package.json files
-          node -e "
-            const fs = require('fs');
-            for (const pkg of ['packages/cli/package.json', 'packages/mcp-server/package.json']) {
-              const p = JSON.parse(fs.readFileSync(pkg, 'utf8'));
-              p.version = '${NIGHTLY_VERSION}';
-              fs.writeFileSync(pkg, JSON.stringify(p, null, 2) + '\n');
-            }
-          "
-
-      - name: Build packages (with nightly URLs baked in)
+      - run: bun install --frozen-lockfile
+      - run: just ci-publish-npm-nightly
         env:
-          TANK_REGISTRY_URL: https://nightly.tankpkg.dev
-        run: |
-          bun --filter @internals/schemas run build
-          bun --filter @internals/helpers run build
-          bun --filter @tankpkg/cli run build
-          bun --filter @tankpkg/mcp-server run build
-
-      - name: Publish CLI to npm (nightly tag)
-        if: ${{ env.NPM_TOKEN != '' }}
-        working-directory: packages/cli
-        run: npm publish --no-git-checks --access public --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
-
-      - name: Publish MCP server to npm (nightly tag)
-        if: ${{ env.NPM_TOKEN != '' }}
-        working-directory: packages/mcp-server
-        run: npm publish --no-git-checks --access public --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,20 +1,14 @@
 name: Create Release
 
-# 1. Creates release/vX.Y.Z branch (permanent source snapshot)
-# 2. Merges main → stable (updates production Vercel)
-# 3. Bumps version in package.json files
-# 4. Creates vX.Y.Z tag → triggers release.yml (CLI/npm) + publish.yml (Docker/Helm)
-
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g., 0.9.0 — without the v prefix)"
+        description: "Version (e.g. 0.10.0, without v prefix)"
         required: true
         type: string
       skip_merge:
-        description: "Skip merging main → stable (use if stable is already up to date)"
-        required: false
+        description: "Skip main → stable merge"
         type: boolean
         default: false
 
@@ -22,101 +16,22 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
-    name: Create Release v${{ inputs.version }}
+  release:
     runs-on: ubuntu-22.04
-
     steps:
-      - name: Validate version format
-        run: |
-          VERSION="${{ inputs.version }}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Invalid version format: $VERSION. Expected: X.Y.Z or X.Y.Z-beta.1"
-            exit 1
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "TAG=v$VERSION" >> $GITHUB_ENV
-
-      - name: Checkout main
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check tag doesn't already exist
-        run: |
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "::error::Tag $TAG already exists"
-            exit 1
-          fi
+      - uses: oven-sh/setup-bun@v2
 
-      - name: Create release branch (permanent snapshot)
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push origin main:refs/heads/release/$TAG
+      - run: bun install --frozen-lockfile
+
+      - name: Create release branch + tag
+        run: just ci-release-tag ${{ inputs.version }}
 
       - name: Merge main → stable
         if: ${{ !inputs.skip_merge }}
-        run: |
-          git checkout stable
-          git merge main --no-edit -m "release: merge main → stable for $TAG"
-          git push origin stable
-          git checkout main
-
-      - name: Bump version in package.json files
-        run: |
-          node -e "
-            const fs = require('fs');
-            const files = [
-              'packages/cli/package.json',
-              'packages/mcp-server/package.json'
-            ];
-            for (const file of files) {
-              const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
-              pkg.version = '${{ inputs.version }}';
-              fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');
-              console.log('Updated', file, 'to', pkg.version);
-            }
-          "
-
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add packages/cli/package.json packages/mcp-server/package.json
-          if git diff --cached --quiet; then
-            echo "No version changes to commit"
-          else
-            git commit -m "chore: bump version to $VERSION"
-            git push origin main
-          fi
-
-      - name: Create and push tag
-        run: |
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-
-      - name: Summary
-        run: |
-          echo "## Release $TAG created! 🚀" >> $GITHUB_SUMMARY
-          echo "" >> $GITHUB_SUMMARY
-          echo "The tag push will now trigger:" >> $GITHUB_SUMMARY
-          echo "- **release.yml**: CLI binaries → GitHub Release → npm publish" >> $GITHUB_SUMMARY
-          echo "- **publish.yml**: Docker images → ghcr.io → Helm chart" >> $GITHUB_SUMMARY
-          echo "" >> $GITHUB_SUMMARY
-          echo "### What happened:" >> $GITHUB_SUMMARY
-          echo "1. ✅ Created release/$TAG branch (permanent snapshot)" >> $GITHUB_SUMMARY
-          if [ "${{ inputs.skip_merge }}" = "false" ]; then
-            echo "2. ✅ Merged main → stable" >> $GITHUB_SUMMARY
-          else
-            echo "2. ⏭️ Skipped main → stable merge" >> $GITHUB_SUMMARY
-          fi
-          echo "3. ✅ Bumped version to $VERSION" >> $GITHUB_SUMMARY
-          echo "4. ✅ Created tag $TAG" >> $GITHUB_SUMMARY
-          echo "" >> $GITHUB_SUMMARY
-          echo "### Monitor:" >> $GITHUB_SUMMARY
-          echo "- [Release workflow](https://github.com/${{ github.repository }}/actions/workflows/release.yml)" >> $GITHUB_SUMMARY
-          echo "- [Publish workflow](https://github.com/${{ github.repository }}/actions/workflows/publish.yml)" >> $GITHUB_SUMMARY
+        run: just ci-merge-stable

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -2,104 +2,51 @@ name: Docker Nightly
 
 on:
   schedule:
-    - cron: "0 4 * * *" # 4am UTC daily
+    - cron: "0 4 * * *"
   push:
-    branches:
-      - main
-    paths:
-      - "apps/registry/**"
-      - "apps/python-api/**"
-      - "packages/**"
-      - "infra/**"
+    branches: [main]
+    paths: ["apps/registry/**", "apps/python-api/**", "packages/**", "infra/**"]
   workflow_dispatch:
 
 permissions:
   contents: read
   packages: write
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_OWNER: tankpkg
-
 jobs:
   build-web:
-    name: build-web
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push tank-web
-        uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/registry/Dockerfile
-          platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tank-web:nightly
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tank-web:sha-${{ github.sha }}
+          tags: ghcr.io/tankpkg/tank-web:nightly,ghcr.io/tankpkg/tank-web:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          labels: |
-            org.opencontainers.image.title=tank-web
-            org.opencontainers.image.description=Tank registry web app — nightly build from main
-            org.opencontainers.image.vendor=tankpkg
-            org.opencontainers.image.source=https://github.com/tankpkg/tank
-            org.opencontainers.image.revision=${{ github.sha }}
-
-      - name: Smoke test — pull and verify image exists
-        run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tank-web:nightly
-          echo "✓ tank-web:nightly pulled successfully"
 
   build-scanner:
-    name: build-scanner
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push tank-scanner
-        uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/python-api/Dockerfile
-          platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tank-scanner:nightly
-            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tank-scanner:sha-${{ github.sha }}
+          tags: ghcr.io/tankpkg/tank-scanner:nightly,ghcr.io/tankpkg/tank-scanner:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          labels: |
-            org.opencontainers.image.title=tank-scanner
-            org.opencontainers.image.description=Tank security scanner — nightly build from main
-            org.opencontainers.image.vendor=tankpkg
-            org.opencontainers.image.source=https://github.com/tankpkg/tank
-            org.opencontainers.image.revision=${{ github.sha }}
-
-      - name: Smoke test — pull and verify image exists
-        run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tank-scanner:nightly
-          echo "✓ tank-scanner:nightly pulled successfully"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: ["v*"]
 
 permissions:
   contents: write
@@ -20,12 +19,10 @@ jobs:
             platform: linux-x64
             target: bun-linux-x64
             output: tank-linux-x64
-            deb_arch: amd64
           - runner: ubuntu-22.04
             platform: linux-arm64
             target: bun-linux-arm64
             output: tank-linux-arm64
-            deb_arch: arm64
           - runner: macos-14
             platform: darwin-arm64
             target: bun-darwin-arm64
@@ -44,265 +41,119 @@ jobs:
         shell: bash
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
+      - uses: oven-sh/setup-bun@v2
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      - run: bun install --frozen-lockfile
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Inject version from git tag
+      - name: Build binary
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          node -e "const p=require('./packages/cli/package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./packages/cli/package.json', JSON.stringify(p, null, 2)+'\n')"
+          just ci-build-cli "${VERSION}"
+          cd packages/cli && bun run build:bundle
+          TARGET=${{ matrix.target }} OUTPUT_NAME=${{ matrix.output }} bun run build:sea
 
-      - name: Build shared package
-        run: bun run --filter '@internals/schemas' build && bun run --filter '@internals/helpers' build
-
-      - name: Build bundle and binary
-        working-directory: packages/cli
-        env:
-          TARGET: ${{ matrix.target }}
-          OUTPUT_NAME: ${{ matrix.output }}
-        run: |
-          bun run build
-          bun run build:bundle
-          bun run build:sea
-
-      - name: Package tarball (unix)
+      - name: Package (unix)
         if: runner.os != 'Windows'
-        working-directory: packages/cli/build
-        run: tar -czf ${{ matrix.output }}.tar.gz ${{ matrix.output }}
+        run: tar -czf packages/cli/build/${{ matrix.output }}.tar.gz -C packages/cli/build ${{ matrix.output }}
 
-      - name: Package zip (windows)
+      - name: Package (windows)
         if: runner.os == 'Windows'
-        working-directory: packages/cli/build
         shell: pwsh
-        run: Compress-Archive -Path ${{ matrix.output }} -DestinationPath tank-windows-x64.zip
+        run: Compress-Archive -Path packages/cli/build/${{ matrix.output }} -DestinationPath packages/cli/build/tank-windows-x64.zip
 
-      - name: Build Windows installer
-        if: runner.os == 'Windows'
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          if (!(Test-Path "installer/windows/create-icon.ps1")) {
-            Write-Host "Installer scripts not found, skipping .exe installer build"
-            exit 0
-          }
-          powershell -ExecutionPolicy Bypass -File installer/windows/create-icon.ps1
-          choco install innosetup -y --no-progress
-          $version = "${{ github.ref_name }}".TrimStart("v")
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DVERSION=$version installer\windows\tank-installer.iss
-
-      - name: Upload binary artifact
-        if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.output }}
-          path: |
-            packages/cli/build/${{ matrix.output }}
-            packages/cli/build/${{ matrix.output }}.tar.gz
-          if-no-files-found: error
-
-      - name: Upload Windows artifacts
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.output }}
-          path: |
-            packages/cli/build/${{ matrix.output }}
-            packages/cli/build/tank-windows-x64.zip
-            packages/cli/build/tank-windows-x64-setup.exe
+          path: packages/cli/build/${{ matrix.output }}*
           if-no-files-found: error
 
   release:
-    name: create-release
     runs-on: ubuntu-22.04
     needs: build
-    env:
-      VERSION: ${{ github.ref_name }}
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           path: dist
 
-      - name: Flatten artifacts
+      - name: Flatten + package
         run: |
           mkdir -p release
           find dist -type f -exec mv {} release/ \;
-          ls -lah release
+          sudo gem install --no-document fpm
+          VERSION="${GITHUB_REF_NAME#v}"
+          fpm -s dir -t deb -n tank -v "$VERSION" --architecture amd64 --package release/tank_${VERSION}_amd64.deb release/tank-linux-x64=/usr/local/bin/tank
+          fpm -s dir -t deb -n tank -v "$VERSION" --architecture arm64 --package release/tank_${VERSION}_arm64.deb release/tank-linux-arm64=/usr/local/bin/tank
+          cd release && sha256sum tank-* *.deb 2>/dev/null | sort > SHA256SUMS || true
 
-      - name: Install fpm
-        run: sudo gem install --no-document fpm
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: release/*
 
-      - name: Build .deb packages
+  publish-npm:
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - run: bun install --frozen-lockfile
+      - run: just ci-publish-npm "${GITHUB_REF_NAME#v}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  update-homebrew:
+    runs-on: ubuntu-22.04
+    needs: release
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+      - name: Update Homebrew formula
         run: |
-          VERSION_NO_V="${VERSION#v}"
-          fpm -s dir -t deb \
-            -n tank \
-            -v "$VERSION_NO_V" \
-            --description "Security-first package manager for AI agent skills" \
-            --url "https://tankpkg.dev" \
-            --maintainer "Tank Team <team@tankpkg.dev>" \
-            --license "MIT" \
-            --architecture amd64 \
-            --package release/tank_${VERSION_NO_V}_amd64.deb \
-            release/tank-linux-x64=/usr/local/bin/tank
-
-          fpm -s dir -t deb \
-            -n tank \
-            -v "$VERSION_NO_V" \
-            --description "Security-first package manager for AI agent skills" \
-            --url "https://tankpkg.dev" \
-            --maintainer "Tank Team <team@tankpkg.dev>" \
-            --license "MIT" \
-            --architecture arm64 \
-            --package release/tank_${VERSION_NO_V}_arm64.deb \
-            release/tank-linux-arm64=/usr/local/bin/tank
-
-      - name: Generate checksums
-        working-directory: release
-        run: sha256sum tank-* *.deb *.exe 2>/dev/null | sort > SHA256SUMS || true
-
-      - name: Update in-repo Homebrew formula
-        continue-on-error: true
-        run: |
-          VERSION_NO_V="${VERSION#v}"
-
-          SHA_DARWIN_ARM64="$(sha256sum release/tank-darwin-arm64.tar.gz | awk '{print $1}')"
-          SHA_DARWIN_X64="$(sha256sum release/tank-darwin-x64.tar.gz | awk '{print $1}')"
-          SHA_LINUX_ARM64="$(sha256sum release/tank-linux-arm64.tar.gz | awk '{print $1}')"
-          SHA_LINUX_X64="$(sha256sum release/tank-linux-x64.tar.gz | awk '{print $1}')"
-
-          git fetch origin main
-          git checkout main
-          git pull --ff-only origin main
-
+          VERSION="${GITHUB_REF_NAME#v}"
+          SHA_DARWIN_ARM64="$(curl -sfL "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/tank-darwin-arm64.tar.gz" | sha256sum | awk '{print $1}')"
+          SHA_DARWIN_X64="$(curl -sfL "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/tank-darwin-x64.tar.gz" | sha256sum | awk '{print $1}')"
+          SHA_LINUX_ARM64="$(curl -sfL "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/tank-linux-arm64.tar.gz" | sha256sum | awk '{print $1}')"
+          SHA_LINUX_X64="$(curl -sfL "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/tank-linux-x64.tar.gz" | sha256sum | awk '{print $1}')"
           mkdir -p Formula
-          cat > Formula/tank.rb <<EOF
+          cat > Formula/tank.rb << EOF
           class Tank < Formula
             desc "Security-first package manager for AI agent skills"
             homepage "https://tankpkg.dev"
-            version "${VERSION_NO_V}"
-
+            version "${VERSION}"
             if OS.mac? && Hardware::CPU.arm?
-              url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-arm64.tar.gz"
+              url "https://github.com/${{ github.repository }}/releases/download/v#{version}/tank-darwin-arm64.tar.gz"
               sha256 "${SHA_DARWIN_ARM64}"
             elsif OS.mac?
-              url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-x64.tar.gz"
+              url "https://github.com/${{ github.repository }}/releases/download/v#{version}/tank-darwin-x64.tar.gz"
               sha256 "${SHA_DARWIN_X64}"
             elsif OS.linux? && Hardware::CPU.arm?
-              url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-arm64.tar.gz"
+              url "https://github.com/${{ github.repository }}/releases/download/v#{version}/tank-linux-arm64.tar.gz"
               sha256 "${SHA_LINUX_ARM64}"
             else
-              url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-x64.tar.gz"
+              url "https://github.com/${{ github.repository }}/releases/download/v#{version}/tank-linux-x64.tar.gz"
               sha256 "${SHA_LINUX_X64}"
             end
-
             def install
-              bin.install "tank-#{OS.mac? ? \"darwin\" : \"linux\"}-#{Hardware::CPU.arm? ? \"arm64\" : \"x64\"}" => "tank"
+              bin.install Dir["tank-*"].first => "tank"
             end
-
             test do
               system "#{bin}/tank", "--version"
             end
           end
           EOF
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/tank.rb
-          if git diff --cached --quiet; then
-            echo "No formula changes"
-          else
-            git commit -m "chore: update formula for ${VERSION}"
-            git push origin main
-          fi
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            release/tank-linux-x64
-            release/tank-linux-arm64
-            release/tank-darwin-x64
-            release/tank-darwin-arm64
-            release/tank-windows-x64.exe
-            release/tank-linux-x64.tar.gz
-            release/tank-linux-arm64.tar.gz
-            release/tank-darwin-x64.tar.gz
-            release/tank-darwin-arm64.tar.gz
-            release/tank-windows-x64.zip
-            release/tank-windows-x64-setup.exe
-            release/tank_*.deb
-            release/SHA256SUMS
-
-  publish-npm:
-    name: publish-npm
-    runs-on: ubuntu-22.04
-    needs: build
-    continue-on-error: true
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Inject version from git tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          node -e "const p=require('./packages/cli/package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./packages/cli/package.json', JSON.stringify(p, null, 2)+'\n')"
-          node -e "const p=require('./packages/mcp-server/package.json'); p.version='${VERSION}'; require('fs').writeFileSync('./packages/mcp-server/package.json', JSON.stringify(p, null, 2)+'\n')"
-
-      - name: Build packages
-        run: |
-          bun --filter @internals/schemas run build
-          bun --filter @internals/helpers run build
-          bun --filter @tankpkg/cli run build
-          bun --filter @tankpkg/mcp-server run build
-
-      - name: Publish CLI to npm
-        continue-on-error: true
-        if: ${{ env.NPM_TOKEN != '' }}
-        working-directory: packages/cli
-        run: npm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
-
-      - name: Publish MCP server to npm
-        continue-on-error: true
-        if: ${{ env.NPM_TOKEN != '' }}
-        working-directory: packages/mcp-server
-        run: npm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          git diff --cached --quiet || (git commit -m "chore: update formula for v${VERSION}" && git push origin main)

--- a/justfile
+++ b/justfile
@@ -324,6 +324,79 @@ update target='all':
         update_one "{{target}}"
     fi
 
+# ── CI/CD recipes (used by GitHub Actions, testable locally) ──
+
+[group('ci')]
+ci-test:
+    bun turbo test
+
+[group('ci')]
+ci-lint:
+    just verify-readonly
+
+[group('ci')]
+ci-build-cli VERSION:
+    just bump {{VERSION}}
+    just build internals-schemas
+    just build internals-helpers
+    just build cli
+    just build mcp
+
+[group('ci')]
+ci-build-cli-binary VERSION PLATFORM:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just ci-build-cli {{VERSION}}
+    cd packages/cli && bun run build:bundle
+    TARGET="bun-{{PLATFORM}}" OUTPUT_NAME="tank-{{PLATFORM}}" bun run build:sea
+
+[group('ci')]
+ci-publish-npm-nightly:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    SHORT_SHA=$(git rev-parse --short HEAD)
+    NIGHTLY_VERSION="0.0.0-nightly.$(date -u +%Y%m%d).${SHORT_SHA}"
+    just bump "${NIGHTLY_VERSION}"
+    TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build internals-schemas
+    TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build internals-helpers
+    TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build cli
+    TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build mcp
+    cd packages/cli && npm publish --no-git-checks --access public --tag nightly
+    cd packages/mcp-server && npm publish --no-git-checks --access public --tag nightly
+
+[group('ci')]
+ci-publish-npm VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just ci-build-cli {{VERSION}}
+    cd packages/cli && npm publish --no-git-checks --access public
+    cd packages/mcp-server && npm publish --no-git-checks --access public
+
+[group('ci')]
+ci-release-tag VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TAG="v{{VERSION}}"
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git push origin HEAD:refs/heads/release/${TAG}
+    just bump {{VERSION}}
+    git add -A && git diff --cached --quiet || git commit -m "chore: bump version to {{VERSION}}"
+    git tag -a "${TAG}" -m "Release ${TAG}"
+    git push origin "${TAG}"
+    git push origin HEAD
+
+[group('ci')]
+ci-merge-stable:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git checkout stable
+    git merge main --no-edit
+    git push origin stable
+    git checkout main
+
 # Remove build artifacts (.next, dist, build, coverage) and turbo cache
 [group('clean')]
 clean:


### PR DESCRIPTION
## Motivation
CI logic was inline in YAML — untestable locally, duplicated across workflows.

## Changes
- 8 new `just ci-*` recipes: `ci-test`, `ci-lint`, `ci-build-cli`, `ci-build-cli-binary`, `ci-publish-npm`, `ci-publish-npm-nightly`, `ci-release-tag`, `ci-merge-stable`
- Workflows slimmed to thin wrappers: checkout → setup → `just ci-*`
- **618 → 275 lines** (55% reduction)

## Before/After

| Workflow | Before | After |
|----------|--------|-------|
| cli-nightly.yml | 83 | 27 |
| create-release.yml | 122 | 37 |
| release.yml | 308 | 159 |
| docker-nightly.yml | 105 | 52 |

## Test locally
```bash
just ci-build-cli 0.10.0    # build CLI packages
just ci-lint                 # same as CI lint step
just ci-test                 # same as CI test step
```