### PR TITLE
fix(cli-auth): use database KV store on serverless — memory store loses sessions

### DIFF
--- a/apps/registry/src/services/kv/index.ts
+++ b/apps/registry/src/services/kv/index.ts
@@ -1,6 +1,7 @@
 import { env } from '~/consts/env';
 
 import { createMemoryStore } from './memory';
+import { createPostgresStore } from './postgres';
 import { createRedisStore } from './redis';
 import type { KVStore } from './store';
 
@@ -10,7 +11,13 @@ let instance: KVStore | null = null;
 
 export function getKVStore(): KVStore {
   if (!instance) {
-    instance = env.REDIS_URL ? createRedisStore(env.REDIS_URL) : createMemoryStore();
+    if (env.REDIS_URL) {
+      instance = createRedisStore(env.REDIS_URL);
+    } else if (env.DATABASE_URL) {
+      instance = createPostgresStore(env.DATABASE_URL);
+    } else {
+      instance = createMemoryStore();
+    }
   }
   return instance;
 }

--- a/apps/registry/src/services/kv/postgres.ts
+++ b/apps/registry/src/services/kv/postgres.ts
@@ -1,0 +1,58 @@
+import postgres from 'postgres';
+
+import type { KVStore } from './store';
+
+export function createPostgresStore(connectionString: string): KVStore {
+  const sql = postgres(connectionString);
+  let initialized = false;
+
+  async function ensureTable() {
+    if (initialized) return;
+    await sql`
+      CREATE TABLE IF NOT EXISTS kv_store (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        expires_at TIMESTAMPTZ NOT NULL
+      )
+    `;
+    initialized = true;
+  }
+
+  return {
+    async get(key) {
+      await ensureTable();
+      const rows = await sql`
+        SELECT value FROM kv_store WHERE key = ${key} AND expires_at > NOW()
+      `;
+      if (rows.length === 0) return null;
+      return rows[0].value as string;
+    },
+
+    async set(key, value, ttlMs) {
+      await ensureTable();
+      const expiresAt = new Date(Date.now() + ttlMs);
+      await sql`
+        INSERT INTO kv_store (key, value, expires_at) VALUES (${key}, ${value}, ${expiresAt})
+        ON CONFLICT (key) DO UPDATE SET value = ${value}, expires_at = ${expiresAt}
+      `;
+    },
+
+    async del(key) {
+      await ensureTable();
+      await sql`DELETE FROM kv_store WHERE key = ${key}`;
+    },
+
+    async incr(key, ttlMs) {
+      await ensureTable();
+      const expiresAt = new Date(Date.now() + ttlMs);
+      const rows = await sql`
+        INSERT INTO kv_store (key, value, expires_at) VALUES (${key}, '1', ${expiresAt})
+        ON CONFLICT (key) DO UPDATE
+          SET value = (COALESCE(kv_store.value, '0')::int + 1)::text,
+              expires_at = CASE WHEN kv_store.expires_at > NOW() THEN kv_store.expires_at ELSE ${expiresAt} END
+        RETURNING value
+      `;
+      return Number.parseInt(rows[0].value as string, 10);
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- CLI auth exchange (`/api/v1/cli-auth/exchange`) returns 400 "Session invalid, expired, or already used" even after successful authorization — **login is completely broken**.
- Root cause: KV store falls back to in-memory `Map` when `REDIS_URL` is absent. On Vercel serverless, each invocation runs in an isolated container — sessions created by `/start` and authorized by `/authorize` are invisible to `/exchange`.
- Fix: add PostgreSQL-backed KV store (`kv/postgres.ts`) as auto-fallback. `DATABASE_URL` is always available, so sessions persist across invocations without requiring Redis.

## Changes

| File | Change |
|------|--------|
| `apps/registry/src/services/kv/postgres.ts` | New PostgreSQL KV store using `CREATE TABLE IF NOT EXISTS kv_store` — no migration needed |
| `apps/registry/src/services/kv/index.ts` | Auto-detection priority: Redis → PostgreSQL → Memory |

## Store selection priority

```
REDIS_URL set    → Redis (fastest, existing behavior)
DATABASE_URL set → PostgreSQL (new, serverless-safe)
neither          → Memory (local dev only)
```