### PR TITLE
ci(docker): build nightly images for linux/amd64 + linux/arm64

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -28,6 +29,7 @@ jobs:
           context: .
           file: apps/registry/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/tankpkg/tank-web:nightly,ghcr.io/tankpkg/tank-web:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -36,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -47,6 +50,7 @@ jobs:
           context: .
           file: apps/python-api/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/tankpkg/tank-scanner:nightly,ghcr.io/tankpkg/tank-scanner:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds QEMU + multi-platform build (`linux/amd64,linux/arm64`) to Docker Nightly workflow. 
Fixes nightly image not running on Apple Silicon Macs.