### PR TITLE
ci(docker): push nightly images to DockerHub

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -24,13 +24,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/registry/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/tankpkg/tank-web:nightly,ghcr.io/tankpkg/tank-web:sha-${{ github.sha }}
+          tags: |
+            ghcr.io/tankpkg/tank-web:nightly
+            ghcr.io/tankpkg/tank-web:sha-${{ github.sha }}
+            tankpkg/tank-web:nightly
+            tankpkg/tank-web:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -45,12 +53,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/python-api/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/tankpkg/tank-scanner:nightly,ghcr.io/tankpkg/tank-scanner:sha-${{ github.sha }}
+          tags: |
+            ghcr.io/tankpkg/tank-scanner:nightly
+            ghcr.io/tankpkg/tank-scanner:sha-${{ github.sha }}
+            tankpkg/tank-scanner:nightly
+            tankpkg/tank-scanner:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds DockerHub login + push to nightly workflow. Images now available at both ghcr.io/tankpkg/* and docker.io/tankpkg/*.