### PR TITLE
fix(registry): curl install command 404 — pointed to nonexistent route

### DIFF
--- a/apps/registry/src/consts/brand.ts
+++ b/apps/registry/src/consts/brand.ts
@@ -2,7 +2,11 @@ export const GITHUB_REPO = 'tankpkg/tank';
 export const SITE_URL = 'https://tankpkg.dev';
 export const INSTALL_COMMAND = 'curl -fsSL https://raw.githubusercontent.com/tankpkg/tank/main/install.sh | sh';
 export const INSTALL_METHODS = [
-  { id: 'curl', label: 'curl', command: 'curl -fsSL https://tankpkg.dev/install | sh' },
+  {
+    id: 'curl',
+    label: 'curl',
+    command: 'curl -fsSL https://raw.githubusercontent.com/tankpkg/tank/main/install.sh | sh'
+  },
   { id: 'brew', label: 'Homebrew', command: 'brew install tankpkg/tap/tank' },
   { id: 'npm', label: 'npm', command: 'npm install -g @tankpkg/cli' },
   { id: 'bun', label: 'Bun', command: 'bun install -g @tankpkg/cli' }


### PR DESCRIPTION
## Summary

- The curl install method on the homepage (`INSTALL_METHODS`) used `https://tankpkg.dev/install` which returns 404
- No route exists at `/install` — neither in TanStack Router nor in the Hono API
- The `/api/cli/install.sh` endpoint only works in selfhosted mode (`TANK_MODE=selfhosted`)
- Fixed: aligned curl command with the existing `INSTALL_COMMAND` constant that points to the GitHub raw URL (`raw.githubusercontent.com/tankpkg/tank/main/install.sh`)

## Verified

- `curl -fsSL https://raw.githubusercontent.com/tankpkg/tank/main/install.sh` returns 200
- `bun run typecheck` passes (9/9 tasks)