### PR TITLE
fix(ci): install just in release/nightly/create-release workflows

### DIFF
--- a/.github/workflows/cli-nightly.yml
+++ b/.github/workflows/cli-nightly.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+      - uses: extractions/setup-just@v2
       - run: bun install --frozen-lockfile
       - run: just ci-publish-npm-nightly
         env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,6 +26,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@v2
+      - uses: extractions/setup-just@v2
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
+      - uses: extractions/setup-just@v2
 
       - run: bun install --frozen-lockfile
 
@@ -105,6 +106,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+      - uses: extractions/setup-just@v2
       - run: bun install --frozen-lockfile
       - run: just ci-publish-npm "${GITHUB_REF_NAME#v}"
         env:


### PR DESCRIPTION
## Summary

All 3 workflows that call `just` recipes never installed it — every CI run fails with `just: command not found`.

- `release.yml` — build job (5 platforms) + publish-npm job
- `cli-nightly.yml` — publish job  
- `create-release.yml` — release job

Added `extractions/setup-just@v2` to each job.

This blocked the v0.10.1 release (CLI binaries + npm publish).