### PR TITLE
fix(ci): add PR permissions for Homebrew formula update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: release
     continue-on-error: true
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GITHUB_TOKEN needs `pull-requests: write` to call `gh pr create`. Added at job level.