### PR TITLE
fix(registry): detect backend-truncated descriptions ending with '...'

### DIFF
--- a/apps/registry/src/components/skills/findings-table.tsx
+++ b/apps/registry/src/components/skills/findings-table.tsx
@@ -16,8 +16,10 @@ const TRUNCATE_LENGTH = 100;
 
 function ExpandableDescription({ description, evidence }: { description: string; evidence: string | null }) {
   const [expanded, setExpanded] = useState(false);
-  const fullText = evidence && evidence.length > description.length ? evidence : description;
-  const hasMore = fullText.length > description.length || description.length > TRUNCATE_LENGTH;
+  const hasEvidence = !!evidence && evidence !== description;
+  const descriptionTruncated = description.endsWith('...');
+  const hasMore = hasEvidence || descriptionTruncated || description.length > TRUNCATE_LENGTH;
+  const fullText = hasEvidence ? evidence : description;
 
   if (!hasMore) {
     return <span>{description}</span>;


### PR DESCRIPTION
## Summary

Follow-up to #265 and #266 — the "Show more" button wasn't appearing for short descriptions that were already truncated by the scanner backend (e.g., `Matched injection pattern: act as a...` is only 44 chars, well under the 100-char threshold).

- Detect trailing `...` as a backend truncation signal
- Always show "Show more" when description ends with `...`, regardless of length
- Expanding reveals the full `evidence` field (which the scanner always populates with the untruncated matched text)

Closes #253