### PR TITLE
fix(scanner): stop truncating finding descriptions at 50 chars

### DIFF
--- a/apps/python-api/lib/scan/stage3_injection.py
+++ b/apps/python-api/lib/scan/stage3_injection.py
@@ -178,7 +178,7 @@ def detect_hidden_content(content: str, file_path: str) -> list[Finding]:
                             location=f"{file_path}:{line_num}",
                             confidence=0.85,
                             tool="stage3_hidden",
-                            evidence=comment_text[:100] + "..." if len(comment_text) > 100 else comment_text,
+                            evidence=comment_text[:500] + "..." if len(comment_text) > 500 else comment_text,
                         )
                     )
                     break
@@ -202,7 +202,7 @@ def detect_hidden_content(content: str, file_path: str) -> list[Finding]:
                         location=f"{file_path}:{line_num}",
                         confidence=0.7,
                         tool="stage3_hidden",
-                        evidence=comment_text[:100] + "..." if len(comment_text) > 100 else comment_text,
+                        evidence=comment_text[:500] + "..." if len(comment_text) > 500 else comment_text,
                     )
                 )
 
@@ -283,7 +283,7 @@ def analyze_markdown_file(temp_dir: str, file_path: str) -> list[Finding]:
                         stage="stage3",
                         severity=severity,
                         type="prompt_injection_pattern",
-                        description=f"Matched injection pattern: {matched_text[:50]}...",
+                        description=f"Matched injection pattern: {matched_text}",
                         location=f"{file_path}:{line_num}",
                         confidence=weight,
                         tool="stage3_regex",

--- a/apps/python-api/lib/scan/test_llm_analyzer.py
+++ b/apps/python-api/lib/scan/test_llm_analyzer.py
@@ -26,7 +26,7 @@ def sample_finding():
         stage="stage3",
         severity="high",
         type="prompt_injection_pattern",
-        description="Matched injection pattern: you are now a...",
+        description="Matched injection pattern: you are now a helpful assistant",
         location="skill.md:10",
         confidence=0.9,
         tool="stage3_regex",


### PR DESCRIPTION
## Summary

**Root cause of #253** — the Python scanner (`stage3_injection.py` line 286) was unconditionally truncating matched text to 50 characters:

```python
# Before
description=f"Matched injection pattern: {matched_text[:50]}..."

# After
description=f"Matched injection pattern: {matched_text}"
```

This produced descriptions like `"Matched injection pattern: act as a..."` where the `...` was baked into the stored data. The frontend had no way to recover the full text since evidence was often shorter than the (already truncated) description.

### Changes
- **`stage3_injection.py`**: Remove 50-char truncation from `description` field — now stores full matched text
- **`stage3_injection.py`**: Bump evidence cap for HTML/markdown comment findings from 100 → 500 chars
- **`test_llm_analyzer.py`**: Update test fixture to match new untruncated format

### Test Results
```
47 passed in 0.48s
```

**Note**: Existing scans will still show truncated descriptions (data already stored). Only new scans will have full descriptions. A rescan of affected packages will fix historical data.

Closes #253