### PR TITLE
chore: bump version to 0.10.3

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/infra/helm/tank/Chart.yaml
+++ b/infra/helm/tank/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   PostgreSQL, Redis, and MinIO for on-premises installations.
 type: application
 version: 0.1.0
-appVersion: "0.10.2"
+appVersion: "0.10.3"
 home: https://github.com/tankpkg/tank
 sources:
   - https://github.com/tankpkg/tank

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/packages/internals-helpers/package.json
+++ b/packages/internals-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internals/helpers",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/internals-schemas/package.json
+++ b/packages/internals-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internals/schemas",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/mcp-server",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "MCP server for Tank - scan and publish AI agent skills from your editor",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release v0.10.3 — fixes truncated scan finding descriptions (#253).

### Included fixes
- #265 — Frontend expand/collapse for findings
- #266 — Show evidence field on expand
- #267 — Detect backend `...` truncation  
- #268 — Fix expand logic + 16 component tests
- #269 — **Root cause**: remove 50-char truncation in Python scanner