### PR TITLE
chore: bump version to 0.10.4

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/infra/helm/tank/Chart.yaml
+++ b/infra/helm/tank/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   PostgreSQL, Redis, and MinIO for on-premises installations.
 type: application
 version: 0.1.0
-appVersion: "0.10.3"
+appVersion: "0.10.4"
 home: https://github.com/tankpkg/tank
 sources:
   - https://github.com/tankpkg/tank

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/packages/internals-helpers/package.json
+++ b/packages/internals-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internals/helpers",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/internals-schemas/package.json
+++ b/packages/internals-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internals/schemas",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/mcp-server",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "MCP server for Tank - scan and publish AI agent skills from your editor",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release v0.10.4

### Fixes since v0.10.3
- **#271** — Scanner evidence now captures full source line (not just regex match)
- **#272** — Rescan endpoint uses public signed URLs
- **#274** — Rescan returns scan result details for debugging  
- **#275** — Rescan stores results via Drizzle (scanner Vercel project can't write to DB)

### Testing
- 51 scanner tests passing (4 new regression tests for description truncation)
- 16 frontend component tests passing