### PR TITLE
fix: remove ignoreCommand blocking production deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,5 @@
   "framework": null,
   "buildCommand": "NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
   "installCommand": "bun install",
-  "devCommand": "bun --filter registry run dev",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; exit 0"
+  "devCommand": "bun --filter registry run dev"
 }


### PR DESCRIPTION
The ignoreCommand was skipping main builds, but Vercel production branch IS main. Production never deployed. This is why www.tankpkg.dev was stuck on old frontend code.