### PR TITLE
fix(onprem): resolve CLI login opening localhost instead of instance URL

### DIFF
--- a/apps/registry/src/api/app.ts
+++ b/apps/registry/src/api/app.ts
@@ -22,6 +22,19 @@ const storageReady = (async () => {
       process.env.APP_URL = config.instanceUrl;
       process.env.BETTER_AUTH_URL = config.instanceUrl;
     }
+
+    if (process.env.TANK_MODE === 'selfhosted') {
+      const url = process.env.APP_URL || '';
+      if (!url || url.includes('localhost') || url.includes('127.0.0.1')) {
+        // biome-ignore lint/suspicious/noConsole: intentional — startup diagnostic for on-prem admins
+        console.warn(
+          '[tank] WARNING: APP_URL is localhost in selfhosted mode. ' +
+            'CLI auth and email links will point to localhost. ' +
+            'Complete the setup wizard or set APP_URL in your .env file.'
+        );
+      }
+    }
+
     if (!config?.storageBackend) return;
 
     const { setStorageOverride } = await import('~/services/storage/provider');

--- a/apps/registry/src/api/routes/cli.ts
+++ b/apps/registry/src/api/routes/cli.ts
@@ -1,6 +1,7 @@
 import { createReadStream, existsSync, statSync } from 'node:fs';
 import { Hono } from 'hono';
 import { stream } from 'hono/streaming';
+import { getAppUrl } from '~/lib/app-url';
 
 const cliRoutes = new Hono();
 
@@ -68,7 +69,7 @@ cliRoutes.get('/install.sh', async (c) => {
     return c.json({ error: 'Not found' }, 404);
   }
 
-  const appUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL || 'http://localhost:3000';
+  const appUrl = getAppUrl(c);
 
   const script = `#!/usr/bin/env bash
 # Tank CLI Installer
@@ -128,7 +129,7 @@ cliRoutes.get('/platforms', async (c) => {
     return c.json({ error: 'Not found' }, 404);
   }
 
-  const appUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL || 'http://localhost:3000';
+  const appUrl = getAppUrl(c);
   const available = Object.entries(PLATFORMS)
     .filter(([_, filename]) => existsSync(`${BINARY_DIR}/${filename}`))
     .map(([platform, filename]) => ({

--- a/apps/registry/src/api/routes/v1/cli-auth.ts
+++ b/apps/registry/src/api/routes/v1/cli-auth.ts
@@ -1,7 +1,7 @@
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { env } from '~/consts/env';
+import { getAppUrl } from '~/lib/app-url';
 import { isUserBlocked } from '~/lib/auth/authz';
 import { authorizeSession, consumeSession, createSession, getSession } from '~/lib/auth/cli-store';
 import { auth } from '~/lib/auth/core';
@@ -28,7 +28,7 @@ export const cliAuthRoutes = new Hono()
 
       const sessionCode = await createSession(state);
 
-      const baseUrl = env.APP_URL;
+      const baseUrl = getAppUrl(c);
       const authUrl = `${baseUrl}/cli-login?session=${sessionCode}`;
 
       authLog.info(

--- a/apps/registry/src/lib/__tests__/app-url.test.ts
+++ b/apps/registry/src/lib/__tests__/app-url.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('~/consts/env', () => ({
+  env: { APP_URL: 'http://localhost:5555' }
+}));
+
+import { getAppUrl } from '../app-url';
+
+function fakeContext(headers: Record<string, string>) {
+  return {
+    req: {
+      header(name: string) {
+        return headers[name.toLowerCase()];
+      }
+    }
+  } as Parameters<typeof getAppUrl>[0];
+}
+
+describe('getAppUrl', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.APP_URL;
+    delete process.env.BETTER_AUTH_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns live process.env.APP_URL when set to non-localhost', () => {
+    process.env.APP_URL = 'https://tank.acme.corp';
+    expect(getAppUrl()).toBe('https://tank.acme.corp');
+  });
+
+  it('prefers BETTER_AUTH_URL over APP_URL', () => {
+    process.env.BETTER_AUTH_URL = 'https://auth.acme.corp';
+    process.env.APP_URL = 'https://tank.acme.corp';
+    expect(getAppUrl()).toBe('https://auth.acme.corp');
+  });
+
+  it('derives URL from request Host header when process.env is localhost', () => {
+    process.env.APP_URL = 'http://localhost:5555';
+    const c = fakeContext({
+      host: 'tank.acme.corp',
+      'x-forwarded-proto': 'https'
+    });
+    expect(getAppUrl(c)).toBe('https://tank.acme.corp');
+  });
+
+  it('derives URL from X-Forwarded-Host when present', () => {
+    process.env.APP_URL = 'http://localhost:5555';
+    const c = fakeContext({
+      'x-forwarded-host': 'tank.acme.corp',
+      'x-forwarded-proto': 'https',
+      host: 'internal-docker:3000'
+    });
+    expect(getAppUrl(c)).toBe('https://tank.acme.corp');
+  });
+
+  it('returns localhost for dev when no context provided', () => {
+    process.env.APP_URL = 'http://localhost:5555';
+    expect(getAppUrl()).toBe('http://localhost:5555');
+  });
+
+  it('falls back to frozen env.APP_URL when process.env is empty', () => {
+    expect(getAppUrl()).toBe('http://localhost:5555');
+  });
+
+  it('strips trailing slash from derived host', () => {
+    process.env.APP_URL = 'http://localhost:5555';
+    const c = fakeContext({
+      host: 'tank.acme.corp/',
+      'x-forwarded-proto': 'https'
+    });
+    expect(getAppUrl(c)).toBe('https://tank.acme.corp');
+  });
+
+  it('skips request-header fallback when host is also localhost', () => {
+    process.env.APP_URL = 'http://localhost:5555';
+    const c = fakeContext({
+      host: 'localhost:3000',
+      'x-forwarded-proto': 'http'
+    });
+    expect(getAppUrl(c)).toBe('http://localhost:5555');
+  });
+
+  it('defaults X-Forwarded-Proto to https when header missing', () => {
+    process.env.APP_URL = 'http://localhost:5555';
+    const c = fakeContext({ host: 'tank.acme.corp' });
+    expect(getAppUrl(c)).toBe('https://tank.acme.corp');
+  });
+});

--- a/apps/registry/src/lib/app-url.ts
+++ b/apps/registry/src/lib/app-url.ts
@@ -1,0 +1,36 @@
+import type { Context } from 'hono';
+import { env } from '~/consts/env';
+
+/**
+ * Returns the live APP_URL, reading from process.env (hydrated by
+ * bootstrap/setup wizard) instead of the frozen `env` object.
+ *
+ * For Hono handlers, pass the Context to derive the URL from request
+ * headers as a fallback — resilient even when env is misconfigured
+ * (common in on-prem deployments behind a reverse proxy).
+ *
+ * Fallback chain:
+ *   1. process.env.BETTER_AUTH_URL / process.env.APP_URL (live, non-localhost)
+ *   2. Request headers: X-Forwarded-Proto + X-Forwarded-Host / Host (if Context provided)
+ *   3. process.env values even if localhost (dev environment)
+ *   4. Frozen env.APP_URL (last resort)
+ */
+export function getAppUrl(c?: Context): string {
+  const live = process.env.BETTER_AUTH_URL || process.env.APP_URL;
+
+  if (live && !isLocalhost(live)) return live;
+
+  if (c) {
+    const proto = c.req.header('x-forwarded-proto') || 'https';
+    const host = c.req.header('x-forwarded-host') || c.req.header('host');
+    if (host && !isLocalhost(host)) return `${proto}://${host.replace(/\/$/, '')}`;
+  }
+
+  if (live) return live;
+
+  return env.APP_URL;
+}
+
+function isLocalhost(value: string): boolean {
+  return value.includes('localhost') || value.includes('127.0.0.1');
+}

--- a/apps/registry/src/lib/auth/core.ts
+++ b/apps/registry/src/lib/auth/core.ts
@@ -2,8 +2,8 @@ import { apiKey } from '@better-auth/api-key';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { genericOAuth, organization } from 'better-auth/plugins';
-
 import { enabledProviders, env, githubEnabled, oidcEnabled } from '~/consts/env';
+import { getAppUrl } from '~/lib/app-url';
 import { db } from '~/lib/db';
 import { checkEmailRateLimit, checkVerificationRateLimit } from '~/services/email/rate-limiter';
 import { getFromAddress, getProvider, sendEmail } from '~/services/email/service';
@@ -13,7 +13,7 @@ function createAuth() {
     database: drizzleAdapter(db, {
       provider: 'pg'
     }),
-    baseURL: process.env.BETTER_AUTH_URL || process.env.APP_URL || env.APP_URL,
+    baseURL: getAppUrl(),
     basePath: '/api/auth',
     secret: process.env.BETTER_AUTH_SECRET || env.BETTER_AUTH_SECRET,
     emailAndPassword: {
@@ -67,7 +67,7 @@ function createAuth() {
             throw new Error(`Too many emails sent. Please wait ${Math.ceil(rateLimit.resetIn / 60000)} minutes.`);
           }
 
-          const acceptUrl = `${env.APP_URL}/orgs/accept-invitation?id=${data.id}`;
+          const acceptUrl = `${getAppUrl()}/orgs/accept-invitation?id=${data.id}`;
           const result = await sendEmail({
             from: getFromAddress(),
             to: data.email,

--- a/apps/registry/src/routes/index.tsx
+++ b/apps/registry/src/routes/index.tsx
@@ -14,9 +14,9 @@ const data = routeHead({
 });
 
 export const Route = createFileRoute('/')({
-  loader: ({ context }) => {
-    const selfhostedAppUrl =
-      process.env.TANK_MODE === 'selfhosted' ? process.env.APP_URL || process.env.BETTER_AUTH_URL || '' : '';
+  loader: async ({ context }) => {
+    const { getAppUrl } = await import('~/lib/app-url');
+    const selfhostedAppUrl = process.env.TANK_MODE === 'selfhosted' ? getAppUrl() : '';
     return Promise.all([
       context.queryClient.ensureQueryData(homepageStatsQueryOptions()),
       context.queryClient.ensureQueryData(githubStarsQueryOptions)

--- a/apps/registry/src/routes/install-cli.tsx
+++ b/apps/registry/src/routes/install-cli.tsx
@@ -2,8 +2,9 @@ import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 
 const getCliInfo = createServerFn({ method: 'GET' }).handler(async () => {
+  const { getAppUrl } = await import('~/lib/app-url');
   const isSelfHosted = process.env.TANK_MODE === 'selfhosted';
-  const appUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL || 'http://localhost:3000';
+  const appUrl = getAppUrl();
   return { isSelfHosted, appUrl };
 });
 

--- a/apps/registry/src/services/storage/provider.ts
+++ b/apps/registry/src/services/storage/provider.ts
@@ -12,8 +12,8 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 import { createClient as createSupabaseClient, type SupabaseClient } from '@supabase/supabase-js';
-
 import { env } from '~/consts/env';
+import { getAppUrl } from '~/lib/app-url';
 
 export interface SignedUrlResult {
   signedUrl: string;
@@ -308,7 +308,7 @@ export function getStorageProvider(): StorageProvider {
 
   if (backend === 'filesystem') {
     const baseDir = storageOverride?.fsPath || env.STORAGE_FS_PATH || '/app/data/packages';
-    const publicUrl = env.BETTER_AUTH_URL || env.APP_URL || 'http://localhost:3000';
+    const publicUrl = getAppUrl();
     providerInstance = new FilesystemStorageProvider(baseDir, publicUrl);
     return providerInstance;
   }

--- a/bdd/features/system/login/login.feature
+++ b/bdd/features/system/login/login.feature
@@ -44,3 +44,23 @@ Feature: CLI OAuth login flow via browser handshake
     Given a pending login session exists
     When I exchange the session code with a mismatched state
     Then the response is 400 or 404
+
+  # ── On-prem authUrl resolution (C9, C10) ─────────────────────────────
+  @high @selfhosted
+  Scenario: authUrl uses configured instance URL, not frozen default (E10)
+    Given APP_URL is configured as "https://tank.acme.corp" in the database
+    And process.env.APP_URL has been hydrated from the database
+    When I initiate a CLI login session
+    Then the response is 200
+    And the "authUrl" starts with "https://tank.acme.corp"
+    And the "authUrl" does not contain "localhost"
+
+  @high @selfhosted
+  Scenario: authUrl derived from request headers when APP_URL is localhost (E11)
+    Given APP_URL defaults to "http://localhost:5555"
+    And the request includes header "Host" with value "tank.acme.corp"
+    And the request includes header "X-Forwarded-Proto" with value "https"
+    When I initiate a CLI login session
+    Then the response is 200
+    And the "authUrl" starts with "https://tank.acme.corp"
+    And the "authUrl" does not contain "localhost"

--- a/idd/modules/login/INTENT.md
+++ b/idd/modules/login/INTENT.md
@@ -23,32 +23,36 @@ packages/cli/src/lib/config.ts                 # Reads/writes ~/.tank/config.jso
 
 ## Layer 2: Constraints
 
-| #           | Rule                                                                                       | Rationale                                                       | Verified by  |
-| ----------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------- | ------------ |
-| C1          | `POST /cli-auth/start` requires a non-empty `state` string                                 | CSRF protection — state binds CLI to browser session            | BDD scenario |
-| C2          | `POST /cli-auth/start` returns `authUrl` (browser URL) and `sessionCode` (CLI polling key) | These are the two halves of the auth handshake                  | BDD scenario |
-| C3          | `POST /cli-auth/exchange` returns 400 while session is pending (not yet authorized)        | CLI must poll until authorized or timed out                     | BDD scenario |
-| C4          | `POST /cli-auth/exchange` returns 200 with `token` + `user` once authorized                | Token is written to config by CLI after this step               | BDD scenario |
-| C5          | Session expires after 5 minutes; `loginCommand` throws "Login timed out"                   | Prevents stale sessions accumulating in Redis                   | BDD scenario |
-| C6          | Token is written to `~/.tank/config.json` (configurable via `--config-dir`)                | Token must persist across CLI invocations                       | BDD scenario |
-| C7          | Exchange validates `state` matches what was passed to start                                | Prevents session fixation attacks                               | BDD scenario |
-| C8          | Network errors during polling are swallowed; only non-transient errors throw               | Flaky networks during auth flow must not abort the CLI          | Code review  |
-| C_browser_1 | Login page must render email/password form and social auth options                         | Users need visible, accessible auth entry points in the browser | BDD scenario |
-| C_browser_2 | Unauthenticated users must be redirected to `/login` when accessing protected routes       | Enforces auth boundary at the browser level                     | BDD scenario |
-| C_browser_3 | Successful login must redirect to dashboard                                                | Post-auth landing page; user expects to land somewhere useful   | BDD scenario |
+| #           | Rule                                                                                                                   | Rationale                                                                                                                                                            | Verified by  |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| C1          | `POST /cli-auth/start` requires a non-empty `state` string                                                             | CSRF protection — state binds CLI to browser session                                                                                                                 | BDD scenario |
+| C2          | `POST /cli-auth/start` returns `authUrl` (browser URL) and `sessionCode` (CLI polling key)                             | These are the two halves of the auth handshake                                                                                                                       | BDD scenario |
+| C3          | `POST /cli-auth/exchange` returns 400 while session is pending (not yet authorized)                                    | CLI must poll until authorized or timed out                                                                                                                          | BDD scenario |
+| C4          | `POST /cli-auth/exchange` returns 200 with `token` + `user` once authorized                                            | Token is written to config by CLI after this step                                                                                                                    | BDD scenario |
+| C5          | Session expires after 5 minutes; `loginCommand` throws "Login timed out"                                               | Prevents stale sessions accumulating in Redis                                                                                                                        | BDD scenario |
+| C6          | Token is written to `~/.tank/config.json` (configurable via `--config-dir`)                                            | Token must persist across CLI invocations                                                                                                                            | BDD scenario |
+| C7          | Exchange validates `state` matches what was passed to start                                                            | Prevents session fixation attacks                                                                                                                                    | BDD scenario |
+| C8          | Network errors during polling are swallowed; only non-transient errors throw                                           | Flaky networks during auth flow must not abort the CLI                                                                                                               | Code review  |
+| C9          | `authUrl` returned by `/cli-auth/start` must use the live instance URL, not the frozen env default                     | On-prem: `env.APP_URL` is frozen at module-load time (before DB bootstrap sets `process.env.APP_URL`). Using the frozen value returns `localhost:5555` to CLI users. | BDD scenario |
+| C10         | When `APP_URL` is localhost on a selfhosted deployment, derive base URL from request `Host`/`X-Forwarded-Host` headers | On-prem instances behind reverse proxies must self-heal even if `APP_URL` was never configured                                                                       | BDD scenario |
+| C_browser_1 | Login page must render email/password form and social auth options                                                     | Users need visible, accessible auth entry points in the browser                                                                                                      | BDD scenario |
+| C_browser_2 | Unauthenticated users must be redirected to `/login` when accessing protected routes                                   | Enforces auth boundary at the browser level                                                                                                                          | BDD scenario |
+| C_browser_3 | Successful login must redirect to dashboard                                                                            | Post-auth landing page; user expects to land somewhere useful                                                                                                        | BDD scenario |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                                   | Expected Output                                   |
-| --- | ------------------------------------------------------- | ------------------------------------------------- |
-| E1  | `POST /cli-auth/start` with valid state                 | 200: `{ authUrl, sessionCode }`                   |
-| E2  | `POST /cli-auth/start` with missing state               | 400: `{ error: "Missing required field: state" }` |
-| E3  | `POST /cli-auth/exchange` before authorization          | 400: session still pending                        |
-| E4  | `POST /cli-auth/exchange` after simulated authorization | 200: `{ token, user }`                            |
-| E5  | Exchange with mismatched state                          | 400 or 404: state validation failure              |
-| E6  | Poll loop times out (deadline exceeded)                 | Error: "Login timed out. Please try again."       |
-| E7  | Unauthenticated user navigates to `/dashboard`          | Redirected to `/login`                            |
-| E8  | User visits `/login`                                    | Sees email/password form and social auth options  |
-| E9  | User submits valid credentials on `/login`              | Redirected to `/dashboard`                        |
+| #   | Input                                                                                                   | Expected Output                                                               |
+| --- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| E1  | `POST /cli-auth/start` with valid state                                                                 | 200: `{ authUrl, sessionCode }`                                               |
+| E2  | `POST /cli-auth/start` with missing state                                                               | 400: `{ error: "Missing required field: state" }`                             |
+| E3  | `POST /cli-auth/exchange` before authorization                                                          | 400: session still pending                                                    |
+| E4  | `POST /cli-auth/exchange` after simulated authorization                                                 | 200: `{ token, user }`                                                        |
+| E5  | Exchange with mismatched state                                                                          | 400 or 404: state validation failure                                          |
+| E6  | Poll loop times out (deadline exceeded)                                                                 | Error: "Login timed out. Please try again."                                   |
+| E7  | Unauthenticated user navigates to `/dashboard`                                                          | Redirected to `/login`                                                        |
+| E8  | User visits `/login`                                                                                    | Sees email/password form and social auth options                              |
+| E9  | User submits valid credentials on `/login`                                                              | Redirected to `/dashboard`                                                    |
+| E10 | `POST /cli-auth/start` on selfhosted with `APP_URL` set in DB                                           | `authUrl` starts with configured instance URL, not `localhost`                |
+| E11 | `POST /cli-auth/start` on selfhosted with `APP_URL` still defaulted, request via `Host: tank.acme.corp` | `authUrl` starts with `https://tank.acme.corp` (derived from request headers) |


### PR DESCRIPTION
## Summary

- On-prem `tank login` opens `localhost:5555` in browser instead of the configured instance URL
- Root cause: `cli-auth.ts` reads frozen `env.APP_URL` (parsed at module-load) instead of live `process.env.APP_URL` (hydrated by DB bootstrap)

## Changes

- **New `getAppUrl(c?)` helper** (`src/lib/app-url.ts`) with 4-step fallback: live `process.env` → request headers (`X-Forwarded-Host`/`Host`) → localhost (dev) → frozen env
- **Replaced all 8 callsites** using inconsistent `APP_URL` resolution patterns with the unified helper
- **Startup warning** when `TANK_MODE=selfhosted` and `APP_URL` is still localhost
- **9 unit tests** covering all fallback paths
- **IDD**: Added constraints C9/C10 and examples E10/E11 to `idd/modules/login/INTENT.md`
- **BDD**: Added 2 Gherkin scenarios to `bdd/features/system/login/login.feature`

## Affected files

| File | Before | After |
|------|--------|-------|
| `cli-auth.ts:31` | `env.APP_URL` (frozen) | `getAppUrl(c)` (live + request headers) |
| `auth/core.ts:16` | 3-way `\|\|` chain | `getAppUrl()` |
| `auth/core.ts:70` | `env.APP_URL` (frozen) | `getAppUrl()` |
| `storage/provider.ts:311` | 3-way `\|\|` chain | `getAppUrl()` |
| `cli.ts:71,131` | `process.env` chain | `getAppUrl(c)` |
| `install-cli.tsx:6` | `process.env` chain | `getAppUrl()` |
| `index.tsx:19` | `process.env` chain | `getAppUrl()` |

## Testing

- 9/9 unit tests pass
- 0 LSP errors across all changed files
- `tsc --noEmit` clean

Note: pre-existing lint error in `findings-table.test.tsx` (unused import) is unrelated.