### PR TITLE
fix: correct file path extraction in file content API

### DIFF
--- a/apps/registry/scripts/seed-tarballs.ts
+++ b/apps/registry/scripts/seed-tarballs.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { CreateBucketCommand, HeadBucketCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import postgres from 'postgres';
+import { pack } from 'tar-stream';
+
+const SKILLS_DIR = '/tmp/tank-skills/skills';
+
+function collectFiles(dir: string, base: string): { path: string; content: Buffer }[] {
+  const files: { path: string; content: Buffer }[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...collectFiles(full, base));
+    else files.push({ path: relative(base, full), content: readFileSync(full) });
+  }
+  return files;
+}
+
+function createTarball(files: { path: string; content: Buffer }[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const p = pack();
+    const chunks: Buffer[] = [];
+
+    p.on('data', (chunk: Buffer) => chunks.push(chunk));
+    p.on('end', () => resolve(Buffer.concat(chunks)));
+    p.on('error', reject);
+
+    for (const file of files) {
+      p.entry({ name: `package/${file.path}` }, file.content);
+    }
+    p.finalize();
+  });
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('DATABASE_URL required');
+    process.exit(1);
+  }
+
+  const sql = postgres(databaseUrl);
+  const s3 = new S3Client({
+    region: process.env.S3_REGION || 'us-east-1',
+    endpoint: process.env.S3_ENDPOINT || 'http://localhost:9000',
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY || 'minioadmin',
+      secretAccessKey: process.env.S3_SECRET_KEY || 'minioadmin'
+    }
+  });
+
+  const bucket = process.env.S3_BUCKET || 'tank-skills';
+
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+  } catch {
+    await s3.send(new CreateBucketCommand({ Bucket: bucket }));
+    console.log(`Created bucket: ${bucket}`);
+  }
+
+  const skillDirs = readdirSync(SKILLS_DIR).filter((name) => {
+    try {
+      return statSync(join(SKILLS_DIR, name)).isDirectory() && statSync(join(SKILLS_DIR, name, 'skills.json')).isFile();
+    } catch {
+      return false;
+    }
+  });
+
+  console.log(`Uploading tarballs for ${skillDirs.length} skills...`);
+
+  for (const dirName of skillDirs) {
+    const skillDir = join(SKILLS_DIR, dirName);
+    const manifest = JSON.parse(readFileSync(join(skillDir, 'skills.json'), 'utf-8'));
+    const name: string = manifest.name;
+
+    const rows = await sql`
+      SELECT sv.tarball_path FROM skill_versions sv
+      INNER JOIN skills s ON s.id = sv.skill_id
+      WHERE s.name = ${name}
+    `;
+
+    if (rows.length === 0) {
+      console.log(`  ⚠ ${name}: no version in DB, skipping`);
+      continue;
+    }
+
+    const tarballPath = rows[0].tarball_path as string;
+    const files = collectFiles(skillDir, skillDir);
+    const tarData = await createTarball(files);
+    const gzipped = gzipSync(tarData);
+
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: tarballPath,
+        Body: gzipped,
+        ContentType: 'application/gzip'
+      })
+    );
+
+    console.log(`  ✓ ${name} → ${tarballPath} (${(gzipped.length / 1024).toFixed(1)} KB)`);
+  }
+
+  console.log(`\n✅ All tarballs uploaded to ${bucket}`);
+  await sql.end();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/registry/src/api/routes/v1/skills-read.ts
+++ b/apps/registry/src/api/routes/v1/skills-read.ts
@@ -264,7 +264,9 @@ export const skillsReadRoutes = new Hono()
     try {
       const name = decodeURIComponent(c.req.param('name'));
       const version = c.req.param('version');
-      const filePath = c.req.path.replace(`/api/v1/skills/${c.req.param('name')}/${version}/files/`, '');
+      const rawUrl = new URL(c.req.url);
+      const pathParts = rawUrl.pathname.split('/files/');
+      const filePath = pathParts.length > 1 ? decodeURIComponent(pathParts[pathParts.length - 1]) : '';
 
       if (!filePath || filePath.includes('..')) {
         return c.json({ error: 'Invalid file path' }, 400);

--- a/scripts/seed-tarballs.ts
+++ b/scripts/seed-tarballs.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { CreateBucketCommand, HeadBucketCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import postgres from 'postgres';
+import { pack } from 'tar-stream';
+
+const SKILLS_DIR = '/tmp/tank-skills/skills';
+
+function collectFiles(dir: string, base: string): { path: string; content: Buffer }[] {
+  const files: { path: string; content: Buffer }[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...collectFiles(full, base));
+    else files.push({ path: relative(base, full), content: readFileSync(full) });
+  }
+  return files;
+}
+
+function createTarball(files: { path: string; content: Buffer }[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const p = pack();
+    const chunks: Buffer[] = [];
+
+    p.on('data', (chunk: Buffer) => chunks.push(chunk));
+    p.on('end', () => resolve(Buffer.concat(chunks)));
+    p.on('error', reject);
+
+    for (const file of files) {
+      p.entry({ name: `package/${file.path}` }, file.content);
+    }
+    p.finalize();
+  });
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('DATABASE_URL required');
+    process.exit(1);
+  }
+
+  const sql = postgres(databaseUrl);
+  const s3 = new S3Client({
+    region: process.env.S3_REGION || 'us-east-1',
+    endpoint: process.env.S3_ENDPOINT || 'http://localhost:9000',
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY || 'minioadmin',
+      secretAccessKey: process.env.S3_SECRET_KEY || 'minioadmin'
+    }
+  });
+
+  const bucket = process.env.S3_BUCKET || 'tank-skills';
+
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+  } catch {
+    await s3.send(new CreateBucketCommand({ Bucket: bucket }));
+    console.log(`Created bucket: ${bucket}`);
+  }
+
+  const skillDirs = readdirSync(SKILLS_DIR).filter((name) => {
+    try {
+      return statSync(join(SKILLS_DIR, name)).isDirectory() && statSync(join(SKILLS_DIR, name, 'skills.json')).isFile();
+    } catch {
+      return false;
+    }
+  });
+
+  console.log(`Uploading tarballs for ${skillDirs.length} skills...`);
+
+  for (const dirName of skillDirs) {
+    const skillDir = join(SKILLS_DIR, dirName);
+    const manifest = JSON.parse(readFileSync(join(skillDir, 'skills.json'), 'utf-8'));
+    const name: string = manifest.name;
+
+    const rows = await sql`
+      SELECT sv.tarball_path FROM skill_versions sv
+      INNER JOIN skills s ON s.id = sv.skill_id
+      WHERE s.name = ${name}
+    `;
+
+    if (rows.length === 0) {
+      console.log(`  ⚠ ${name}: no version in DB, skipping`);
+      continue;
+    }
+
+    const tarballPath = rows[0].tarball_path as string;
+    const files = collectFiles(skillDir, skillDir);
+    const tarData = await createTarball(files);
+    const gzipped = gzipSync(tarData);
+
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: tarballPath,
+        Body: gzipped,
+        ContentType: 'application/gzip'
+      })
+    );
+
+    console.log(`  ✓ ${name} → ${tarballPath} (${(gzipped.length / 1024).toFixed(1)} KB)`);
+  }
+
+  console.log(`\n✅ All tarballs uploaded to ${bucket}`);
+  await sql.end();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

The file content API endpoint (`GET /skills/:name/:version/files/*`) returned "File not found in package" for all files because the wildcard path was extracted using `c.req.path` string replacement, which broke with Hono's sub-router mounting.

## Fix

Parse the full URL and split on `/files/` to reliably extract the file path regardless of how the route is mounted.

## Also includes

- `STORAGE_BACKEND=s3` in `.env` for local dev (MinIO)
- `scripts/seed-tarballs.ts` utility that creates real `.tgz` files from `/tmp/tank-skills/` and uploads them to MinIO, so file browsing works locally

## Tested

```bash
curl /api/v1/skills/%40tank%2Fsecurity-review/1.0.0/files/references/code-review-workflow.md
# → Returns actual markdown content ✓

curl /api/v1/skills/%40tank%2Fsecurity-review/1.0.0/files/references/threat-modeling.md  
# → Returns actual markdown content ✓

curl /api/v1/skills/%40tank%2Fsecurity-review/1.0.0/files/SKILL.md
# → Returns SKILL.md content ✓
```