### PR TITLE
fix: match tarball entries with or without path prefix

### DIFF
--- a/apps/registry/src/api/routes/v1/skills-read.ts
+++ b/apps/registry/src/api/routes/v1/skills-read.ts
@@ -17,8 +17,9 @@ function extractFileFromTarball(tarball: Uint8Array, targetPath: string): Promis
     let found = false;
 
     extractor.on('entry', (header, stream, next) => {
-      const entryPath = header.name.replace(/^[^/]+\//, '');
-      if (entryPath === targetPath) {
+      const raw = header.name;
+      const stripped = raw.replace(/^[^/]+\//, '');
+      if (raw === targetPath || stripped === targetPath) {
         const chunks: Buffer[] = [];
         stream.on('data', (chunk: Buffer) => chunks.push(chunk));
         stream.on('end', () => {


### PR DESCRIPTION
Tank tarballs store files without a prefix (`references/foo.md`), while npm-style tarballs use `package/` prefix. The extractor now matches both formats.