### PR TITLE
fix: mobile filter bar for skills browse page

### DIFF
--- a/apps/registry/src/components/skills/mobile-skills-filters.tsx
+++ b/apps/registry/src/components/skills/mobile-skills-filters.tsx
@@ -1,0 +1,120 @@
+import { useNavigate } from '@tanstack/react-router';
+import { FileText } from 'lucide-react';
+
+import { Button } from '~/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select';
+import type { FreshnessBucket, PopularityBucket, ScoreBucket, VisibilityFilter } from '~/lib/skills/data';
+
+import { FRESHNESS_OPTIONS, POPULARITY_OPTIONS, SCORE_OPTIONS, VISIBILITY_OPTIONS } from './skills-filters';
+
+interface MobileSkillsFiltersProps {
+  currentVisibility: VisibilityFilter;
+  currentScoreBucket: ScoreBucket;
+  currentFreshness: FreshnessBucket;
+  currentPopularity: PopularityBucket;
+  currentHasReadme: boolean;
+  isLoggedIn: boolean;
+}
+
+function useFilterNavigate() {
+  const navigate = useNavigate();
+  return (paramKey: string, value: string, defaultValue: string) => {
+    navigate({
+      to: '/skills',
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        [paramKey]: value === defaultValue ? undefined : value,
+        page: 1
+      })
+    } as never);
+  };
+}
+
+export function MobileSkillsFilters({
+  currentVisibility,
+  currentScoreBucket,
+  currentFreshness,
+  currentPopularity,
+  currentHasReadme,
+  isLoggedIn
+}: MobileSkillsFiltersProps) {
+  const filterNav = useFilterNavigate();
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-1 lg:hidden" data-testid="mobile-filter-bar">
+      {isLoggedIn && (
+        <Select value={currentVisibility} onValueChange={(v) => filterNav('visibility', v, 'all')}>
+          <SelectTrigger className="h-8 min-w-[100px] shrink-0 text-xs" data-testid="mobile-filter-visibility">
+            <SelectValue placeholder="Visibility" />
+          </SelectTrigger>
+          <SelectContent>
+            {VISIBILITY_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      <Select value={currentScoreBucket} onValueChange={(v) => filterNav('score', v, 'all')}>
+        <SelectTrigger className="h-8 min-w-[110px] shrink-0 text-xs" data-testid="mobile-filter-score">
+          <SelectValue placeholder="Score" />
+        </SelectTrigger>
+        <SelectContent>
+          {SCORE_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={currentFreshness} onValueChange={(v) => filterNav('freshness', v, 'all')}>
+        <SelectTrigger className="h-8 min-w-[100px] shrink-0 text-xs" data-testid="mobile-filter-freshness">
+          <SelectValue placeholder="Freshness" />
+        </SelectTrigger>
+        <SelectContent>
+          {FRESHNESS_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={currentPopularity} onValueChange={(v) => filterNav('popularity', v, 'all')}>
+        <SelectTrigger className="h-8 min-w-[100px] shrink-0 text-xs" data-testid="mobile-filter-popularity">
+          <SelectValue placeholder="Popularity" />
+        </SelectTrigger>
+        <SelectContent>
+          {POPULARITY_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Button
+        variant={currentHasReadme ? 'default' : 'outline'}
+        size="sm"
+        className="h-8 shrink-0 gap-1 text-xs"
+        onClick={() => {
+          navigate({
+            to: '/skills',
+            search: (prev: Record<string, unknown>) => ({
+              ...prev,
+              docs: !currentHasReadme,
+              page: 1
+            })
+          } as never);
+        }}
+        data-testid="mobile-filter-docs">
+        <FileText className="size-3" />
+        Docs
+      </Button>
+    </div>
+  );
+}

--- a/apps/registry/src/components/skills/skills-filters.tsx
+++ b/apps/registry/src/components/skills/skills-filters.tsx
@@ -56,27 +56,27 @@ function FilterGroup<T extends string>({ label, options, current, paramKey, defa
   );
 }
 
-const VISIBILITY_OPTIONS = [
+export const VISIBILITY_OPTIONS = [
   { value: 'all' as const, label: 'All' },
   { value: 'public' as const, label: 'Public' },
   { value: 'private' as const, label: 'Private' }
 ] as const;
 
-const SCORE_OPTIONS = [
+export const SCORE_OPTIONS = [
   { value: 'all' as const, label: 'All scores' },
   { value: 'high' as const, label: 'High (7+)' },
   { value: 'medium' as const, label: 'Medium (4-6)' },
   { value: 'low' as const, label: 'Low (<4)' }
 ] as const;
 
-const FRESHNESS_OPTIONS = [
+export const FRESHNESS_OPTIONS = [
   { value: 'all' as const, label: 'Any time' },
   { value: 'week' as const, label: 'Past week' },
   { value: 'month' as const, label: 'Past month' },
   { value: 'year' as const, label: 'Past year' }
 ] as const;
 
-const POPULARITY_OPTIONS = [
+export const POPULARITY_OPTIONS = [
   { value: 'all' as const, label: 'All' },
   { value: 'popular' as const, label: 'Popular' },
   { value: 'growing' as const, label: 'Growing' },
@@ -105,7 +105,7 @@ export function SkillsFilters({
   }
 
   return (
-    <aside>
+    <aside data-testid="desktop-filter-sidebar">
       <div className="rounded-lg border border-border/60 bg-card/50 p-4 space-y-5">
         {isLoggedIn && (
           <FilterGroup

--- a/apps/registry/src/components/ui/select.tsx
+++ b/apps/registry/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+import * as React from "react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "~/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
+        className={cn("relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          data-position={position}
+          className={cn(
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && ""
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/apps/registry/src/screens/skills-list-screen.tsx
+++ b/apps/registry/src/screens/skills-list-screen.tsx
@@ -2,6 +2,7 @@ import { encodeSkillName } from '@internals/helpers';
 import { Link } from '@tanstack/react-router';
 import { Download, Lock, Star } from 'lucide-react';
 
+import { MobileSkillsFilters } from '~/components/skills/mobile-skills-filters';
 import { SearchBar } from '~/components/skills/search-bar';
 import { SkillsFilters } from '~/components/skills/skills-filters';
 import { SkillsSort } from '~/components/skills/skills-sort';
@@ -60,15 +61,26 @@ export function SkillsListScreen({
 
       <SearchBar defaultValue={query} />
 
+      <MobileSkillsFilters
+        currentVisibility={visibility}
+        currentScoreBucket={scoreBucket}
+        currentFreshness={freshness}
+        currentPopularity={popularity}
+        currentHasReadme={hasReadme}
+        isLoggedIn={isLoggedIn}
+      />
+
       <div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)]">
-        <SkillsFilters
-          currentVisibility={visibility}
-          currentScoreBucket={scoreBucket}
-          currentFreshness={freshness}
-          currentPopularity={popularity}
-          currentHasReadme={hasReadme}
-          isLoggedIn={isLoggedIn}
-        />
+        <div className="hidden lg:block">
+          <SkillsFilters
+            currentVisibility={visibility}
+            currentScoreBucket={scoreBucket}
+            currentFreshness={freshness}
+            currentPopularity={popularity}
+            currentHasReadme={hasReadme}
+            isLoggedIn={isLoggedIn}
+          />
+        </div>
 
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-3 flex-wrap">

--- a/bdd/features/browser/tanstack/search/skills-browse-mobile-filters.feature
+++ b/bdd/features/browser/tanstack/search/skills-browse-mobile-filters.feature
@@ -1,0 +1,44 @@
+# Intent: idd/modules/skills-browse-mobile/INTENT.md
+
+@tanstack
+@search
+@responsive
+Feature: Skills browse page — mobile filter bar
+  As a developer browsing skills on a phone
+  I need compact inline filters instead of a full sidebar
+  So that skill cards are immediately visible without scrolling past filter groups
+
+  Scenario: Mobile shows horizontal filter bar instead of sidebar
+    When I open the skills browse page on a mobile viewport
+    Then the mobile filter bar should be visible
+    And the desktop filter sidebar should be hidden
+    And the skills grid should be visible
+
+  Scenario: Desktop shows sidebar instead of mobile filter bar
+    When I open the skills browse page on a desktop viewport
+    Then the desktop filter sidebar should be visible
+    And the mobile filter bar should be hidden
+
+  Scenario: Mobile filter bar contains select dropdowns for each filter
+    When I open the skills browse page on a mobile viewport
+    Then the mobile filter bar should contain a "Score" filter
+    And the mobile filter bar should contain a "Freshness" filter
+    And the mobile filter bar should contain a "Popularity" filter
+
+  Scenario: Selecting a mobile filter navigates with URL params
+    When I open the skills browse page on a mobile viewport
+    And I select "High (7+)" from the "Score" mobile filter
+    Then the URL should contain "score=high"
+    And the skills grid should be visible
+
+  Scenario: Active mobile filter shows current value
+    When I open the skills browse page on a mobile viewport with score=high
+    Then the "Score" mobile filter should show "High (7+)"
+
+  Scenario: Mobile filter bar is horizontally scrollable
+    When I open the skills browse page on a mobile viewport
+    Then the mobile filter bar should have horizontal scroll
+
+  Scenario: No horizontal page overflow on mobile browse
+    When I open the skills browse page on a mobile viewport
+    Then the page should not have horizontal overflow

--- a/bdd/steps/browser/skills-browse-mobile.steps.ts
+++ b/bdd/steps/browser/skills-browse-mobile.steps.ts
@@ -1,0 +1,77 @@
+import { expect } from '@playwright/test';
+
+import { Then, When } from './fixtures';
+
+const MOBILE = { width: 375, height: 812 };
+const DESKTOP = { width: 1280, height: 800 };
+
+When('I open the skills browse page on a mobile viewport', async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto('/skills');
+  await page.waitForLoadState('networkidle');
+});
+
+When('I open the skills browse page on a desktop viewport', async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto('/skills');
+  await page.waitForLoadState('networkidle');
+});
+
+When('I open the skills browse page on a mobile viewport with score=high', async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto('/skills?score=high');
+  await page.waitForLoadState('networkidle');
+});
+
+Then('the mobile filter bar should be visible', async ({ page }) => {
+  await expect(page.getByTestId('mobile-filter-bar')).toBeVisible();
+});
+
+Then('the mobile filter bar should be hidden', async ({ page }) => {
+  await expect(page.getByTestId('mobile-filter-bar')).toBeHidden();
+});
+
+Then('the desktop filter sidebar should be visible', async ({ page }) => {
+  await expect(page.getByTestId('desktop-filter-sidebar')).toBeVisible();
+});
+
+Then('the desktop filter sidebar should be hidden', async ({ page }) => {
+  await expect(page.getByTestId('desktop-filter-sidebar')).toBeHidden();
+});
+
+Then('the skills grid should be visible', async ({ page }) => {
+  await expect(page.getByTestId('skills-grid').or(page.getByTestId('skills-count'))).toBeVisible();
+});
+
+Then('the mobile filter bar should contain a {string} filter', async ({ page }, filterName: string) => {
+  const bar = page.getByTestId('mobile-filter-bar');
+  await expect(bar.getByTestId(`mobile-filter-${filterName.toLowerCase()}`)).toBeVisible();
+});
+
+When('I select {string} from the {string} mobile filter', async ({ page }, value: string, filterName: string) => {
+  const trigger = page.getByTestId(`mobile-filter-${filterName.toLowerCase()}`);
+  await trigger.click();
+  await page.getByRole('option', { name: value }).click();
+});
+
+Then('the URL should contain {string}', async ({ page }, param: string) => {
+  expect(page.url()).toContain(param);
+});
+
+Then('the {string} mobile filter should show {string}', async ({ page }, filterName: string, value: string) => {
+  const trigger = page.getByTestId(`mobile-filter-${filterName.toLowerCase()}`);
+  await expect(trigger).toContainText(value);
+});
+
+Then('the mobile filter bar should have horizontal scroll', async ({ page }) => {
+  const bar = page.getByTestId('mobile-filter-bar');
+  const overflow = await bar.evaluate((el) => getComputedStyle(el).overflowX);
+  expect(overflow).toBe('auto');
+});
+
+Then('the page should not have horizontal overflow', async ({ page }) => {
+  const hasOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+  );
+  expect(hasOverflow).toBe(false);
+});

--- a/idd/modules/skills-browse-mobile/INTENT.md
+++ b/idd/modules/skills-browse-mobile/INTENT.md
@@ -1,0 +1,34 @@
+# Skills Browse Page — Mobile Filter Bar
+
+## Layer 1: Purpose
+
+The skills browse page filter sidebar must not dominate the mobile viewport. On narrow screens, filters render as a horizontally scrollable row of compact `<Select>` dropdowns above the results grid. On desktop, the full vertical sidebar stays in its left column. Skill cards must be immediately visible on mobile without scrolling past filters.
+
+Reference: Airbnb mobile search filters, Amazon mobile category filters, GitHub mobile issue filters.
+
+## Layer 2: Constraints
+
+| Constraint              | Value                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| Breakpoint              | `lg` (1024px) — below this is "mobile"                                                          |
+| Desktop                 | 220px left sidebar, vertical filter groups, always visible                                      |
+| Mobile                  | Horizontal scrollable row of `<Select>` dropdowns, always visible                               |
+| Mobile height           | Single row, ~40px. No vertical stacking of filter groups                                        |
+| Overflow                | `overflow-x-auto` — swipe to see more filters if they exceed viewport width                     |
+| Component               | shadcn `<Select>` for each filter group                                                         |
+| Active state            | Non-default filter values should be visually distinct (e.g. primary text color)                 |
+| Navigation              | Selecting a filter value navigates with the same URL param logic as the desktop sidebar         |
+| Documentation filter    | Rendered as a checkbox-style toggle, not a select (binary on/off)                               |
+| No duplication of logic | Both mobile and desktop filters use the same URL param navigation. Extract shared filter config |
+
+## Layer 3: Examples
+
+| Input                              | Expected Output                                                                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------------- |
+| 375px viewport, default filters    | Horizontal row of selects visible: Score, Freshness, Popularity, Docs. Skill cards below |
+| 375px viewport, logged in          | Visibility select also appears in the row                                                |
+| 375px viewport, tap Score select   | Dropdown opens with: All scores, High (7+), Medium (4-6), Low (<4)                       |
+| 375px viewport, select "High (7+)" | Page navigates with `?score=high&page=1`, select shows "High (7+)"                       |
+| 375px viewport, active filter      | Select trigger text shows current value, visually distinct from default                  |
+| 1280px viewport                    | Full vertical sidebar visible, no horizontal select row                                  |
+| 1280px viewport                    | Mobile filter bar hidden                                                                 |


### PR DESCRIPTION
## Summary

- Replace full vertical filter sidebar with horizontal scrollable Select dropdown row on mobile
- Desktop sidebar unchanged — hidden on mobile via `hidden lg:block`
- Each filter group (Score, Freshness, Popularity, Visibility) renders as a compact `<Select>` dropdown
- Documentation filter renders as a toggle button (binary on/off)
- Shared filter option constants exported from `skills-filters.tsx` — no logic duplication

## Bulletproof Artifacts

- `idd/modules/skills-browse-mobile/INTENT.md` — constraints + examples
- `bdd/features/browser/tanstack/search/skills-browse-mobile-filters.feature` — 7 Gherkin scenarios
- `bdd/steps/browser/skills-browse-mobile.steps.ts` — Playwright BDD step definitions