### PR TITLE
fix: skip email verification for self-hosted auth

### DIFF
--- a/apps/registry/src/lib/auth/core.ts
+++ b/apps/registry/src/lib/auth/core.ts
@@ -9,6 +9,8 @@ import { checkEmailRateLimit, checkVerificationRateLimit } from '~/services/emai
 import { getFromAddress, getProvider, sendEmail } from '~/services/email/service';
 
 function createAuth() {
+  const isSelfHosted = process.env.TANK_MODE === 'selfhosted';
+
   return betterAuth({
     database: drizzleAdapter(db, {
       provider: 'pg'
@@ -18,10 +20,10 @@ function createAuth() {
     secret: process.env.BETTER_AUTH_SECRET || env.BETTER_AUTH_SECRET,
     emailAndPassword: {
       enabled: enabledProviders.has('credentials'),
-      requireEmailVerification: enabledProviders.has('credentials')
+      requireEmailVerification: enabledProviders.has('credentials') && !isSelfHosted
     },
     emailVerification: {
-      sendOnSignUp: enabledProviders.has('credentials'),
+      sendOnSignUp: enabledProviders.has('credentials') && !isSelfHosted,
       autoSignInAfterVerification: true,
       sendVerificationEmail: async ({ user, url }) => {
         const rateLimit = await checkVerificationRateLimit(user.email);

--- a/apps/registry/src/lib/auth/session.ts
+++ b/apps/registry/src/lib/auth/session.ts
@@ -20,5 +20,9 @@ export const getAdminSession = createServerFn({ method: 'GET' }).handler(async (
 });
 
 export const getAuthProviders = createServerFn({ method: 'GET' }).handler(async () => {
-  return { providers: [...enabledProviders], oidcProviderId: env.OIDC_PROVIDER_ID };
+  return {
+    providers: [...enabledProviders],
+    oidcProviderId: env.OIDC_PROVIDER_ID,
+    selfHosted: process.env.TANK_MODE === 'selfhosted'
+  };
 });

--- a/apps/registry/src/routes/_auth/login.tsx
+++ b/apps/registry/src/routes/_auth/login.tsx
@@ -14,15 +14,15 @@ export const Route = createFileRoute('/_auth/login')({
     redirect: (search.redirect as string) || ''
   }),
   loader: async () => {
-    const { providers, oidcProviderId } = await getAuthProviders();
-    return { providers, oidcProviderId };
+    const { providers, oidcProviderId, selfHosted } = await getAuthProviders();
+    return { providers, oidcProviderId, selfHosted };
   },
   head: () => settings,
   component: LoginPage
 });
 
 function LoginPage() {
-  const { providers, oidcProviderId } = Route.useLoaderData();
+  const { providers, oidcProviderId, selfHosted } = Route.useLoaderData();
   const { redirect } = Route.useSearch();
 
   return (
@@ -31,6 +31,7 @@ function LoginPage() {
         enabledProviders={new Set(providers)}
         oidcProviderId={oidcProviderId}
         redirect={redirect || undefined}
+        selfHosted={selfHosted}
       />
     </div>
   );

--- a/apps/registry/src/screens/login-screen.tsx
+++ b/apps/registry/src/screens/login-screen.tsx
@@ -11,9 +11,10 @@ interface LoginScreenProps {
   enabledProviders: Set<string>;
   oidcProviderId: string;
   redirect?: string;
+  selfHosted?: boolean;
 }
 
-export function LoginScreen({ enabledProviders, oidcProviderId, redirect }: LoginScreenProps) {
+export function LoginScreen({ enabledProviders, oidcProviderId, redirect, selfHosted }: LoginScreenProps) {
   const githubEnabled = enabledProviders.has('github');
   const oidcEnabled = enabledProviders.has('oidc');
   const [mode, setMode] = useState<'signin' | 'signup'>('signin');
@@ -43,9 +44,10 @@ export function LoginScreen({ enabledProviders, oidcProviderId, redirect }: Logi
         });
         if (result.error) {
           setError(result.error.message || 'Failed to create account');
-        } else {
+        } else if (!selfHosted) {
           setVerificationEmail(value.email);
         }
+        // selfHosted: Better Auth auto-signs in, callbackURL handles redirect
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred. Please try again.');


### PR DESCRIPTION
## Summary

- Self-hosted instances (`TANK_MODE=selfhosted`) no longer require email verification on signup
- Users sign up with email/password and are logged in immediately
- No verification email sent, no verification gate
- Existing unverified users can log in directly
- **Cloud mode behavior is unchanged**

## Changes

| File | Change |
|------|--------|
| `core.ts` | Gate `requireEmailVerification` and `sendOnSignUp` on `!isSelfHosted` |
| `session.ts` | Expose `selfHosted` from `getAuthProviders` server fn |
| `login.tsx` | Pass `selfHosted` through route loader to component |
| `login-screen.tsx` | Skip verification notice on signup when selfHosted |

## Verification

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 25/25 tests pass
- [x] `vite build` — production build succeeds
- [x] LSP diagnostics clean on all 4 files