### PR TITLE
feat: add sub_path support for monorepo scanning

### DIFF
--- a/apps/python-api/api/analyze/scan.py
+++ b/apps/python-api/api/analyze/scan.py
@@ -149,7 +149,7 @@ async def run_scan_pipeline(request: ScanRequest) -> ScanResponse:
 
     # Stage 0: Ingestion & Quarantine (REQUIRED - provides temp dir)
     try:
-        ingest_result = await stage0_ingest(request.tarball_url)
+        ingest_result = await stage0_ingest(request.tarball_url, request.sub_path)
         stage_results.append(ingest_result.stage_result)
         file_hashes = ingest_result.file_hashes
 

--- a/apps/python-api/lib/scan/models.py
+++ b/apps/python-api/lib/scan/models.py
@@ -65,6 +65,12 @@ class ScanRequest(BaseModel):
     version_id: str = Field(..., description="skill_versions.id UUID")
     manifest: dict[str, Any] = Field(..., description="Skill manifest from database")
     permissions: dict[str, Any] = Field(..., description="Declared permissions from database")
+    sub_path: str | None = Field(
+        None,
+        description="Subdirectory within the tarball to scan. "
+        "Useful for monorepos containing multiple skills where only one should be scanned. "
+        "Example: 'my-skill' to scan only the my-skill/ directory.",
+    )
 
 
 class ScanResponse(BaseModel):

--- a/apps/python-api/lib/scan/stage0_ingest.py
+++ b/apps/python-api/lib/scan/stage0_ingest.py
@@ -326,14 +326,122 @@ def compute_file_hashes(base_dir: str, files: list[str]) -> dict[str, str]:
     return hashes
 
 
-async def stage0_ingest(tarball_url: str) -> IngestResult:
+def narrow_to_sub_path(
+    temp_dir: str,
+    sub_path: str,
+    extracted_files: list[str],
+) -> tuple[str, list[str], int, list[Finding]]:
+    """Narrow extracted contents to a specific subdirectory.
+
+    Used for monorepo support where a tarball contains multiple skills
+    but only one should be scanned.
+
+    GitHub tarballs extract with a prefix directory (e.g., "owner-repo-sha/"),
+    so we look for sub_path inside that prefix.
+
+    Args:
+        temp_dir: Path to the full extraction directory
+        sub_path: Subdirectory to narrow to (e.g., "my-skill")
+        extracted_files: List of relative file paths from extraction
+
+    Returns:
+        (new_temp_dir, filtered_files, total_size, findings)
+    """
+    findings: list[Finding] = []
+
+    # Sanitize sub_path to prevent path traversal
+    clean_sub_path = Path(sub_path).as_posix()
+    if ".." in clean_sub_path or clean_sub_path.startswith("/"):
+        findings.append(
+            Finding(
+                stage="stage0",
+                severity="critical",
+                type="invalid_sub_path",
+                description=f"Invalid sub_path contains path traversal: {sub_path}",
+                confidence=1.0,
+                tool="stage0_ingest",
+            )
+        )
+        return temp_dir, extracted_files, 0, findings
+
+    # GitHub tarballs have a single top-level directory (e.g., "owner-repo-sha/")
+    top_entries = [
+        e for e in os.listdir(temp_dir)
+        if os.path.isdir(os.path.join(temp_dir, e))
+    ]
+
+    if len(top_entries) == 1:
+        repo_root = os.path.join(temp_dir, top_entries[0])
+    else:
+        repo_root = temp_dir
+
+    target_dir = os.path.join(repo_root, clean_sub_path)
+
+    # Verify target stays within temp_dir (defense in depth)
+    try:
+        Path(target_dir).resolve().relative_to(Path(temp_dir).resolve())
+    except ValueError:
+        findings.append(
+            Finding(
+                stage="stage0",
+                severity="critical",
+                type="sub_path_escape",
+                description=f"sub_path resolves outside extraction directory: {sub_path}",
+                confidence=1.0,
+                tool="stage0_ingest",
+            )
+        )
+        return temp_dir, extracted_files, 0, findings
+
+    if not os.path.isdir(target_dir):
+        findings.append(
+            Finding(
+                stage="stage0",
+                severity="medium",
+                type="sub_path_not_found",
+                description=f"Requested sub_path '{sub_path}' not found in archive",
+                confidence=1.0,
+                tool="stage0_ingest",
+            )
+        )
+        return temp_dir, extracted_files, 0, findings
+
+    # Create new temp directory with only the sub_path contents
+    new_temp_dir = tempfile.mkdtemp(prefix="tank_scan_sub_")
+    for item in os.listdir(target_dir):
+        src = os.path.join(target_dir, item)
+        dst = os.path.join(new_temp_dir, item)
+        if os.path.isdir(src):
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+
+    # Clean up original temp dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+    # Build new file list and compute total size
+    new_files: list[str] = []
+    total_size = 0
+    for root, _dirs, files in os.walk(new_temp_dir):
+        for f in files:
+            full = os.path.join(root, f)
+            rel = os.path.relpath(full, new_temp_dir)
+            new_files.append(rel)
+            total_size += os.path.getsize(full)
+
+    return new_temp_dir, new_files, total_size, findings
+
+
+async def stage0_ingest(tarball_url: str, sub_path: str | None = None) -> IngestResult:
     """Run Stage 0: Ingestion & Quarantine.
 
     Downloads tarball, safely extracts to temp directory, validates contents,
-    and computes file hashes.
+    and computes file hashes. Optionally narrows to a subdirectory for
+    monorepo support.
 
     Args:
         tarball_url: Signed URL to download the skill tarball
+        sub_path: Optional subdirectory to narrow the scan to
 
     Returns:
         IngestResult with temp directory path, file hashes, and any findings
@@ -421,6 +529,13 @@ async def stage0_ingest(tarball_url: str) -> IngestResult:
 
     # Remove the tarball (we don't need it anymore)
     os.remove(tar_path)
+
+    # Narrow to sub_path if specified (monorepo support)
+    if sub_path:
+        temp_dir, extracted_files, total_size, sub_path_findings = narrow_to_sub_path(
+            temp_dir, sub_path, extracted_files
+        )
+        findings.extend(sub_path_findings)
 
     # Compute file hashes
     file_hashes = compute_file_hashes(temp_dir, extracted_files)

--- a/apps/python-api/lib/scan/test_sub_path.py
+++ b/apps/python-api/lib/scan/test_sub_path.py
@@ -1,0 +1,128 @@
+"""Tests for sub_path narrowing in stage0_ingest."""
+
+import os
+import tempfile
+
+from lib.scan.stage0_ingest import narrow_to_sub_path
+
+
+def _create_mock_extraction(structure: dict[str, str]) -> tuple[str, list[str]]:
+    """Create a mock extracted tarball directory.
+
+    Args:
+        structure: Dict of relative_path -> file_content
+
+    Returns:
+        (temp_dir, file_list)
+    """
+    temp_dir = tempfile.mkdtemp(prefix="tank_test_")
+    file_list = []
+    for rel_path, content in structure.items():
+        full_path = os.path.join(temp_dir, rel_path)
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        file_list.append(rel_path)
+    return temp_dir, file_list
+
+
+class TestNarrowToSubPath:
+    """Tests for the narrow_to_sub_path function."""
+
+    def test_narrows_to_subdirectory_with_github_prefix(self):
+        """Narrows to correct subdirectory inside a GitHub tarball prefix dir."""
+        temp_dir, file_list = _create_mock_extraction({
+            "owner-repo-abc123/skill-a/SKILL.md": "# Skill A",
+            "owner-repo-abc123/skill-a/scripts/helper.py": "print('a')",
+            "owner-repo-abc123/skill-b/SKILL.md": "# Skill B",
+            "owner-repo-abc123/skill-b/scripts/helper.py": "print('b')",
+        })
+
+        new_dir, new_files, total_size, findings = narrow_to_sub_path(
+            temp_dir, "skill-a", file_list
+        )
+
+        assert len(findings) == 0
+        assert new_dir != temp_dir
+        assert not os.path.exists(temp_dir)  # Original cleaned up
+        assert set(new_files) == {"SKILL.md", os.path.join("scripts", "helper.py")}
+        assert os.path.isfile(os.path.join(new_dir, "SKILL.md"))
+        assert total_size > 0
+
+        # Verify skill-b files are NOT present
+        assert not os.path.exists(os.path.join(new_dir, "skill-b"))
+
+        # Cleanup
+        import shutil
+        shutil.rmtree(new_dir, ignore_errors=True)
+
+    def test_narrows_without_prefix_directory(self):
+        """Works when tarball has no single top-level prefix directory."""
+        temp_dir, file_list = _create_mock_extraction({
+            "skill-a/SKILL.md": "# Skill A",
+            "skill-b/SKILL.md": "# Skill B",
+        })
+
+        new_dir, new_files, total_size, findings = narrow_to_sub_path(
+            temp_dir, "skill-a", file_list
+        )
+
+        assert len(findings) == 0
+        assert set(new_files) == {"SKILL.md"}
+        assert os.path.isfile(os.path.join(new_dir, "SKILL.md"))
+
+        import shutil
+        shutil.rmtree(new_dir, ignore_errors=True)
+
+    def test_sub_path_not_found(self):
+        """Returns finding when sub_path directory doesn't exist."""
+        temp_dir, file_list = _create_mock_extraction({
+            "owner-repo-abc123/skill-a/SKILL.md": "# Skill A",
+        })
+
+        result_dir, result_files, total_size, findings = narrow_to_sub_path(
+            temp_dir, "nonexistent-skill", file_list
+        )
+
+        assert len(findings) == 1
+        assert findings[0].type == "sub_path_not_found"
+        assert findings[0].severity == "medium"
+        # Original dir preserved since we couldn't narrow
+        assert result_dir == temp_dir
+
+        import shutil
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_path_traversal_blocked(self):
+        """Rejects sub_path with path traversal attempts."""
+        temp_dir, file_list = _create_mock_extraction({
+            "owner-repo-abc123/skill-a/SKILL.md": "# Skill A",
+        })
+
+        result_dir, _, _, findings = narrow_to_sub_path(
+            temp_dir, "../../etc/passwd", file_list
+        )
+
+        assert len(findings) == 1
+        assert findings[0].type == "invalid_sub_path"
+        assert findings[0].severity == "critical"
+
+        import shutil
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def test_absolute_path_blocked(self):
+        """Rejects absolute sub_path."""
+        temp_dir, file_list = _create_mock_extraction({
+            "owner-repo-abc123/skill-a/SKILL.md": "# Skill A",
+        })
+
+        result_dir, _, _, findings = narrow_to_sub_path(
+            temp_dir, "/etc/passwd", file_list
+        )
+
+        assert len(findings) == 1
+        assert findings[0].type == "invalid_sub_path"
+        assert findings[0].severity == "critical"
+
+        import shutil
+        shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Adds an optional `sub_path` field to `ScanRequest` that narrows the scan to a specific subdirectory within the tarball. This enables scanning individual skills in monorepos without analyzing the entire repository.

**Problem:** When scanning monorepos (e.g., a category repo containing 20 skills), Tank downloads and scans the entire tarball. There is no way to target a specific skill directory, which leads to:
- Wasted compute scanning unrelated files
- Combined findings from multiple skills in a single result
- Inability to attribute security findings to a specific skill

**Our use case:** We maintain a [directory of AI agent skills](https://agentskills.co.il) organized in category repos (e.g., `tax-and-finance/` with 20 skill subdirectories). We use Tank via the `/api/analyze/scan` endpoint to scan each skill individually. Currently we send `sub_path` in the request body but `ScanRequest` doesn't include this field, so Pydantic silently drops it and the entire repo gets scanned.

## Changes

| File | Change |
|------|--------|
| `models.py` | Add optional `sub_path: str \| None` to `ScanRequest` |
| `stage0_ingest.py` | Add `narrow_to_sub_path()` function + accept `sub_path` param |
| `scan.py` | Pass `request.sub_path` through to `stage0_ingest()` |
| `test_sub_path.py` | Tests for the narrowing logic |

### How it works

1. After tarball extraction in Stage 0, if `sub_path` is provided:
   - Detects the GitHub tarball prefix directory (e.g., `owner-repo-sha/`)
   - Locates the target subdirectory within it
   - Creates a clean temp dir with only the sub_path contents
   - Cleans up the original extraction
2. All downstream stages (1-5) scan the narrowed directory transparently
3. Omitting `sub_path` preserves existing behavior (full tarball scan)

### Security

- Path traversal attempts (`../`, absolute paths) are rejected with a critical finding
- Defense-in-depth: resolved path is verified to stay within the extraction directory
- Missing sub_path returns a medium-severity finding (scan continues on full tarball)

## Usage

```json
POST /api/analyze/scan
{
  "tarball_url": "https://api.github.com/repos/org/monorepo/tarball/main",
  "version_id": "sync-123",
  "manifest": {},
  "permissions": {},
  "sub_path": "my-specific-skill"
}
```

## Test plan

- [x] Unit tests for `narrow_to_sub_path()` covering: GitHub prefix detection, no-prefix repos, missing sub_path, path traversal rejection, absolute path rejection
- [ ] Integration test with a real GitHub monorepo tarball
- [ ] Verify existing scans without `sub_path` are unaffected (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)