### PR TITLE
fix: add DB migration to CI + fix nightly version format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Build all packages
         run: bun run build
 
+      - name: Push DB schema
+        run: bash scripts/ensure-pg-trgm.mjs && (cd apps/registry && bunx drizzle-kit push)
+
       - name: Lint & format check
         run: bun run lint:readonly && bun run format:readonly
 

--- a/justfile
+++ b/justfile
@@ -172,9 +172,9 @@ bump VERSION:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Validate semver format (basic check)
-    if ! [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      echo "Invalid version format: {{VERSION}} (expected X.Y.Z)"
+    # Validate semver format (basic check, or nightly pre-release format)
+    if ! [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && ! [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]+\.[a-f0-9a-f]+$ ]]; then
+      echo "Invalid version format: {{VERSION}} (expected X.Y.Z or X.Y.Z-nightly.YYYYMMDD.SHORT_SHA)"
       exit 1
     fi
 


### PR DESCRIPTION
## Summary

- Add \`just db push\` step to CI workflow before build, so schema changes are deployed automatically
- Accept nightly prerelease version format in bump recipe (X.Y.Z-nightly.YYYYMMDD.SHORT_SHA)

## Test plan

- [ ] CI passes with DB migration step
- [ ] Nightly CLI publish succeeds with valid version format