### PR TITLE
docs: add TypeScript and Python SDK reference pages

### DIFF
--- a/.opencode/plans/1775114378382-quick-river.md
+++ b/.opencode/plans/1775114378382-quick-river.md
@@ -1,0 +1,157 @@
+# Plan: Integrate prompt2bot "Talk to this Skill" on Skill Detail Page
+
+## Context
+
+- **Who**: `uriva` (uri from issue #292) — founder of prompt2bot.com
+- **What**: prompt2bot is an AI agent platform. Their `create-bot-api` takes a skill's README and creates a bot with a public `chatLink` users can chat with.
+- **Reference implementation**: agentskills.co.il shows an "Ask this Skill" button at the top of skill detail pages.
+- **Attribution requirements**: "Powered by prompt2bot" + link near the button, plus list on about/tech page.
+
+## Approach
+
+Lazy bot creation: when a user first clicks "Talk to this skill", call `create-bot-api`, store the `chatLink` in DB, then open it in a new tab. Subsequent clicks go straight to the stored link. No changes to publish flow.
+
+## Files to Create / Modify
+
+### 1. DB Schema — `apps/registry/src/lib/db/schema.ts`
+
+Add two nullable columns to `skillVersions`:
+
+```ts
+prompt2botChatLink: text('prompt2bot_chat_link'),
+prompt2botBotId: text('prompt2bot_bot_id'),
+```
+
+### 2. DB Migration
+
+Run `just db generate` after schema change to create a new Drizzle migration.
+
+### 3. Env Config (wherever env is validated in `apps/registry`)
+
+Add:
+
+```
+PROMPT2BOT_API_TOKEN=p2b_...
+```
+
+Register in the Zod env schema as `z.string().optional()` so the app works without it but disables the button when unset.
+
+### 4. NEW — `apps/registry/src/lib/prompt2bot.ts`
+
+```ts
+export async function createSkillBot(params: {
+  skillName: string;
+  readme: string | null;
+  description: string | null;
+  apiToken: string;
+}): Promise<{ chatLink: string; botId: string } | null>;
+```
+
+Calls `POST https://api.prompt2bot.com/api` with:
+
+```json
+{
+  "endpoint": "create-bot-api",
+  "payload": {
+    "apiToken": "...",
+    "name": "<skillName>",
+    "prompt": "You are a specialist assistant for the Tank skill: <skillName>.\n\n<readme or description>"
+  }
+}
+```
+
+Returns `{ chatLink, botId }` or `null` on failure (fail silently — non-blocking side effect).
+
+### 5. NEW API endpoint — create in `apps/registry/src/api/` (follow existing Hono pattern)
+
+`POST /api/skills/:encodedName/talk`
+
+Logic:
+
+1. Decode skill name, load latest published version from DB
+2. If `prompt2botChatLink` already set → return it immediately
+3. Otherwise: call `createSkillBot(...)`, save `chatLink` + `botId` to `skillVersions`, return `chatLink`
+4. Gate on `env.PROMPT2BOT_API_TOKEN` being set; return 503 if not
+
+Route must be registered in the main Hono app (check `apps/registry/src/api/index.ts` or similar router entry point).
+
+### 6. Skill data — `apps/registry/src/lib/skills/data.ts`
+
+Add to `SkillDetailResult`:
+
+```ts
+prompt2botChatLink: string | null;
+```
+
+Include `latestVersion.prompt2botChatLink` in the DB query so the UI can show the button without an extra request (button state: "already created" vs. "not yet created").
+
+### 7. Skill detail screen — `apps/registry/src/screens/skill-detail-screen.tsx`
+
+Pass `prompt2botChatLink` from `data.latestVersion` down to `SkillSidebar` and `SkillTabs` (for the Readme tab where sidebar lives).
+
+### 8. Skill sidebar — `apps/registry/src/components/skills/skill-sidebar.tsx`
+
+After the Star + Download buttons section, add:
+
+```tsx
+{
+  /* Talk to Skill */
+}
+<div className="space-y-1.5">
+  <TalkToSkillButton initialChatLink={props.prompt2botChatLink} skillName={props.name} />
+  <p className="text-center text-[11px] text-muted-foreground">
+    Powered by{" "}
+    <a
+      href="https://prompt2bot.com"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline underline-offset-2 hover:text-foreground">
+      prompt2bot
+    </a>
+  </p>
+</div>;
+```
+
+### 9. NEW component — `apps/registry/src/components/skills/talk-to-skill-button.tsx`
+
+Client component. State:
+
+- If `initialChatLink` is provided → button opens it directly in new tab (no API call needed)
+- If null → button shows "Talk to this skill", onClick calls `/api/skills/:name/talk`, shows loading spinner, then opens returned `chatLink`
+
+Button style: `variant="outline" size="sm" className="w-full"` with a `MessageSquare` Lucide icon.
+
+### 10. Attribution on About page
+
+Find the About page / tech stack section in `apps/registry/src`. Add prompt2bot as a technology partner with link.
+
+## Prompt Template for Bot Creation
+
+```
+You are a specialist assistant for the Tank skill: "{skillName}".
+
+Your purpose is to help users understand what this skill does, how to install it,
+when to use it, and answer any questions about it.
+
+{readme || description || "No documentation available."}
+
+When asked how to install, tell them to run: tank install {skillName}
+```
+
+## Verification
+
+1. `just db push` — apply migration cleanly
+2. Set `PROMPT2BOT_API_TOKEN` in `.env`
+3. Visit any skill page → "Talk to this skill" button appears in sidebar
+4. Click it → brief loading spinner → opens prompt2bot chat in new tab
+5. Reload skill page → button now opens directly without API call (chatLink cached)
+6. Unset `PROMPT2BOT_API_TOKEN` → button does not appear
+7. "Powered by prompt2bot" attribution visible below button
+8. Check about page for listing
+
+## Open Questions
+
+1. **API token**: Need `PROMPT2BOT_API_TOKEN` from uri before this can be tested end-to-end.
+2. **Bot reuse per version**: Should we create one bot per skill (reusing across versions) or one per skill version? Recommend one per skill version so the README context is always accurate.
+3. **Mobile CTA**: Should the button also appear in the mobile action bar (currently has Star + Download)? Probably yes — worth confirming with the user.
+4. **Existing skills**: Do we backfill prompt2bot bots for already-published skills? Lazy approach handles this naturally.

--- a/apps/registry/public/docs/meta.json
+++ b/apps/registry/public/docs/meta.json
@@ -19,6 +19,8 @@
     "cli",
     "mcp",
     "api",
+    "sdk",
+    "sdk-python",
     "---Quick Starts---",
     "publish-first-skill",
     "self-host-quickstart"

--- a/apps/registry/public/docs/sdk-python.md
+++ b/apps/registry/public/docs/sdk-python.md
@@ -1,0 +1,308 @@
+---
+title: Python SDK
+description: Official Python SDK for the Tank registry — search, download, read, and audit AI agent skills programmatically from Python applications.
+---
+
+# Python SDK
+
+`tankpkg` gives your Python application programmatic access to the Tank skill registry. Search skills, read their full content (including references and scripts), download tarballs with integrity verification, and inspect security audit results — with typed exceptions, streaming downloads, and context manager support.
+
+```bash
+pip install tankpkg
+```
+
+---
+
+## Quick Start
+
+```python
+from tankpkg import TankClient
+
+with TankClient() as client:
+    # Search for skills
+    results = client.search("react")
+    print(f"{results['total']} skills found")
+
+    # Read a skill's full content (SKILL.md + references + scripts)
+    skill = client.read_skill("@tank/react")
+    print(skill.content)          # SKILL.md text
+    print(skill.references)       # {'hooks.md': '...', 'performance.md': '...'}
+    print(skill.scripts)          # {'setup.sh': '...'}
+
+    # Feed to an LLM as system context
+    system_prompt = "\n".join([
+        skill.content,
+        *[f"--- {name} ---\n{text}" for name, text in skill.references.items()]
+    ])
+```
+
+---
+
+## Constructor
+
+```python
+client = TankClient(**options)
+```
+
+| Parameter      | Type          | Default                   | Description                                                             |
+| -------------- | ------------- | ------------------------- | ----------------------------------------------------------------------- |
+| `token`        | `str \| None` | auto-discovered           | API key. If omitted, reads `~/.tank/config.json` then `TANK_TOKEN` env. |
+| `registry_url` | `str \| None` | `https://www.tankpkg.dev` | Registry URL. Set for self-hosted/on-prem instances. `http://` allowed. |
+| `config_dir`   | `str \| None` | `~/.tank`                 | Directory containing `config.json`.                                     |
+| `max_retries`  | `int`         | `3`                       | Retry count for 429 and 5xx responses (exponential backoff).            |
+| `timeout`      | `float`       | `30.0`                    | HTTP request timeout in seconds.                                        |
+
+**Auth discovery order:** explicit `token` > `TANK_TOKEN` env > `~/.tank/config.json`
+
+```python
+# Explicit token (CI/server)
+client = TankClient(token="tank_xxx")
+
+# Self-hosted
+client = TankClient(registry_url="http://tank.internal:5555")
+
+# Zero-config (uses CLI auth)
+client = TankClient()
+```
+
+### Context Manager
+
+`TankClient` supports `with` statements. The underlying `httpx.Client` is closed automatically on exit:
+
+```python
+with TankClient() as client:
+    skill = client.read_skill("@tank/react")
+    # httpx client closed automatically here
+```
+
+Without `with`, call `client.close()` explicitly when done.
+
+---
+
+## Skill Content
+
+The most important methods for AI agent integrations. These let you load a skill's full content — SKILL.md plus all reference files and scripts — for use as LLM context.
+
+### `read_skill(name, version=None)`
+
+Loads the complete skill content in a single call.
+
+```python
+skill = client.read_skill("@tank/react")
+```
+
+**Returns: `SkillContent` dataclass**
+
+| Field        | Type             | Description                       |
+| ------------ | ---------------- | --------------------------------- |
+| `name`       | `str`            | Skill name                        |
+| `version`    | `str`            | Resolved version                  |
+| `content`    | `str`            | SKILL.md text                     |
+| `references` | `dict[str, str]` | Reference files keyed by filename |
+| `scripts`    | `dict[str, str]` | Script files keyed by filename    |
+| `files`      | `list[str]`      | All file paths in the package     |
+
+### `list_files(name, version=None)`
+
+Lists all files in a skill package.
+
+```python
+files = client.list_files("@tank/react")
+# ['SKILL.md', 'references/hooks.md', 'references/performance.md', 'scripts/setup.sh', 'skills.json']
+```
+
+### `read_file(name, version, file_path)`
+
+Reads a single file from a skill package.
+
+```python
+content = client.read_file("@tank/react", "2.2.0", "references/hooks.md")
+```
+
+> Path traversal (`..`), absolute paths, and null bytes are rejected with `TankNetworkError`.
+
+---
+
+## Discovery
+
+### `search(query, *, page=1, limit=20)`
+
+```python
+results = client.search("typescript", page=1, limit=10)
+for skill in results["results"]:
+    print(skill["name"], skill["description"])
+```
+
+### `info(name)`
+
+```python
+info = client.info("@tank/react")
+print(info["latestVersion"])  # '2.2.0'
+print(info["downloads"])      # 1234
+```
+
+### `versions(name)`
+
+```python
+result = client.versions("@tank/react")
+for v in result["versions"]:
+    print(v["version"], v["auditScore"], v["publishedAt"])
+```
+
+---
+
+## Download
+
+### `download(name, version, *, dest=None)`
+
+Downloads a skill tarball. Always returns the raw bytes. If `dest` is provided, also writes to disk.
+
+```python
+# Buffer only — returns bytes, integrity verified
+data = client.download("@tank/react", "2.2.0")
+
+# Write to disk — also returns bytes
+data = client.download("@tank/react", "2.2.0", dest="./skills/")
+```
+
+SHA-512 integrity is always verified against the registry hash. Download size is capped at 100MB with streaming enforcement.
+
+---
+
+## Security & Audit
+
+### `audit(name, version=None)`
+
+Returns the full security analysis as a `VersionDetail` dataclass.
+
+```python
+result = client.audit("@tank/react")
+print(result.audit_score)     # 9.5
+print(result.scan_findings)   # [{'stage': 'static', 'severity': 'low', ...}]
+```
+
+### `permissions(name, version=None)`
+
+```python
+perms = client.permissions("@tank/react")
+# {'network': {'outbound': ['*.api.com']}, 'filesystem': {'read': ['./data/**']}, 'subprocess': False}
+```
+
+---
+
+## Auth
+
+### `whoami()`
+
+Returns `UserInfo` if authenticated, `None` otherwise.
+
+```python
+user = client.whoami()
+if user:
+    print(user.user_id, user.name, user.email)
+```
+
+---
+
+## Stars
+
+```python
+# Get star count
+stars = client.get_star_count("@tank/react")
+print(stars["count"], stars["isStarred"])
+
+# Star/unstar (requires session auth)
+client.star("@tank/react")
+client.unstar("@tank/react")
+```
+
+---
+
+## Error Handling
+
+All errors extend `TankError`. Catch specific types for programmatic handling:
+
+```python
+from tankpkg import TankClient, TankNotFoundError, TankAuthError
+
+try:
+    client.info("@acme/missing")
+except TankNotFoundError as e:
+    print(e.status)       # 404
+    print(e.skill_name)   # '@acme/missing'
+except TankAuthError:
+    print("Invalid token")
+```
+
+| Exception             | HTTP Status | When                                  |
+| --------------------- | ----------- | ------------------------------------- |
+| `TankAuthError`       | 401         | Invalid or missing token              |
+| `TankNotFoundError`   | 404         | Skill or file not found               |
+| `TankPermissionError` | 403         | Insufficient permissions              |
+| `TankNetworkError`    | —           | Connection failure, timeout, redirect |
+| `TankIntegrityError`  | —           | SHA-512 hash mismatch                 |
+| `TankConflictError`   | 409         | Dependency resolution conflict        |
+
+---
+
+## Full Example: Load Skill into OpenAI
+
+```python
+from tankpkg import TankClient
+from openai import OpenAI
+
+tank = TankClient()
+openai = OpenAI()
+
+# 1. Load skill with all references
+skill = tank.read_skill("@tank/react")
+
+# 2. Build system prompt
+parts = [skill.content]
+for name, text in skill.references.items():
+    parts.append(f"\n--- Reference: {name} ---\n{text}")
+system_prompt = "\n".join(parts)
+
+# 3. Use as LLM context
+response = openai.chat.completions.create(
+    model="gpt-4o",
+    messages=[
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": "How should I handle data fetching in React?"},
+    ],
+)
+```
+
+---
+
+## Types
+
+```python
+from tankpkg import (
+    TankClient,
+    SkillContent,       # dataclass: name, version, content, references, scripts, files
+    UserInfo,           # dataclass: user_id, name, email
+    VersionDetail,      # dataclass: name, version, integrity, audit_score, ...
+    TankError,
+    TankAuthError,
+    TankNotFoundError,
+    TankPermissionError,
+    TankNetworkError,
+    TankIntegrityError,
+    TankConflictError,
+)
+```
+
+---
+
+## Differences from TypeScript SDK
+
+| Feature             | TypeScript                     | Python                         |
+| ------------------- | ------------------------------ | ------------------------------ |
+| Install             | `npm install @tankpkg/sdk`     | `pip install tankpkg`          |
+| Naming              | `camelCase`                    | `snake_case`                   |
+| Client cleanup      | Garbage collected              | `with` statement or `.close()` |
+| Download default    | Returns `ReadableStream`       | Returns `bytes`                |
+| File read batching  | Concurrent (6 at a time)       | Sequential                     |
+| Install pipeline    | Available (extracted from CLI) | Not yet available              |
+| Native acceleration | Optional Rust core via NAPI-RS | Future via PyO3                |

--- a/apps/registry/public/docs/sdk.md
+++ b/apps/registry/public/docs/sdk.md
@@ -1,0 +1,318 @@
+---
+title: TypeScript SDK
+description: Official TypeScript SDK for the Tank registry — search, download, read, and install AI agent skills programmatically from Node.js applications.
+---
+
+# TypeScript SDK
+
+`@tankpkg/sdk` gives your Node.js application programmatic access to the Tank skill registry. Search skills, read their full content (including references and scripts), download tarballs with integrity verification, and manage the install pipeline — all with typed errors, exponential backoff, and zero manual HTTP.
+
+```bash
+npm install @tankpkg/sdk
+```
+
+---
+
+## Quick Start
+
+```typescript
+import { TankClient } from "@tankpkg/sdk";
+
+const client = new TankClient();
+
+// Search for skills
+const results = await client.search("react");
+console.log(results.total, "skills found");
+
+// Read a skill's full content (SKILL.md + references + scripts)
+const skill = await client.readSkill("@tank/react");
+console.log(skill.content); // SKILL.md text
+console.log(skill.references); // { 'hooks.md': '...', 'performance.md': '...' }
+console.log(skill.scripts); // { 'setup.sh': '...' }
+
+// Feed to an LLM as system context
+const systemPrompt = [
+  skill.content,
+  ...Object.entries(skill.references).map(([name, text]) => `--- ${name} ---\n${text}`),
+].join("\n");
+```
+
+---
+
+## Constructor
+
+```typescript
+const client = new TankClient(options?)
+```
+
+| Option        | Type     | Default                   | Description                                                             |
+| ------------- | -------- | ------------------------- | ----------------------------------------------------------------------- |
+| `token`       | `string` | auto-discovered           | API key. If omitted, reads `~/.tank/config.json` then `TANK_TOKEN` env. |
+| `registryUrl` | `string` | `https://www.tankpkg.dev` | Registry URL. Set for self-hosted/on-prem instances. `http://` allowed. |
+| `configDir`   | `string` | `~/.tank`                 | Directory containing `config.json`.                                     |
+| `maxRetries`  | `number` | `3`                       | Retry count for 429 and 5xx responses (exponential backoff).            |
+| `timeoutMs`   | `number` | `30000`                   | HTTP request timeout in milliseconds.                                   |
+
+**Auth discovery order:** explicit `token` > `TANK_TOKEN` env > `~/.tank/config.json`
+
+```typescript
+// Explicit token (CI/server)
+const client = new TankClient({ token: "tank_xxx" });
+
+// Self-hosted
+const client = new TankClient({ registryUrl: "http://tank.internal:5555" });
+
+// Zero-config (uses CLI auth)
+const client = new TankClient();
+```
+
+---
+
+## Skill Content
+
+The most important methods for AI agent integrations. These let you load a skill's full content — SKILL.md plus all reference files and scripts — for use as LLM context.
+
+### `readSkill(name, version?)`
+
+Loads the complete skill content in a single call. Returns SKILL.md text, all reference files, all scripts, and the full file list.
+
+```typescript
+const skill = await client.readSkill("@tank/react");
+```
+
+**Returns: `SkillContent`**
+
+| Field        | Type                     | Description                                                      |
+| ------------ | ------------------------ | ---------------------------------------------------------------- |
+| `name`       | `string`                 | Skill name                                                       |
+| `version`    | `string`                 | Resolved version                                                 |
+| `content`    | `string`                 | SKILL.md text                                                    |
+| `references` | `Record<string, string>` | Reference files keyed by filename (e.g. `{ 'hooks.md': '...' }`) |
+| `scripts`    | `Record<string, string>` | Script files keyed by filename (e.g. `{ 'setup.sh': '...' }`)    |
+| `files`      | `string[]`               | All file paths in the package                                    |
+
+### `listFiles(name, version?)`
+
+Lists all files in a skill package.
+
+```typescript
+const files = await client.listFiles("@tank/react");
+// ['SKILL.md', 'references/hooks.md', 'references/performance.md', 'scripts/setup.sh', 'skills.json']
+```
+
+### `readFile(name, version, path)`
+
+Reads a single file from a skill package.
+
+```typescript
+const content = await client.readFile("@tank/react", "2.2.0", "references/hooks.md");
+```
+
+> Path traversal (`..`), absolute paths, and backslashes are rejected with `TankNetworkError`.
+
+---
+
+## Discovery
+
+### `search(query, options?)`
+
+```typescript
+const results = await client.search("typescript", { page: 1, limit: 10 });
+```
+
+**Returns:** `{ results: SearchResult[], total: number, page: number, limit: number }`
+
+### `info(name)`
+
+Returns full metadata for a skill.
+
+```typescript
+const info = await client.info("@tank/react");
+console.log(info.latestVersion); // '2.2.0'
+console.log(info.downloads); // 1234
+console.log(info.publisher); // { name: 'Tank Bot' }
+```
+
+### `versions(name)`
+
+Lists all published versions with audit scores.
+
+```typescript
+const result = await client.versions("@tank/react");
+for (const v of result.versions) {
+  console.log(v.version, v.auditScore, v.publishedAt);
+}
+```
+
+---
+
+## Download
+
+### `download(name, version, options?)`
+
+Downloads a skill tarball. Three modes:
+
+```typescript
+// Stream (default) — returns ReadableStream
+const stream = await client.download("@tank/react", "2.2.0");
+
+// Buffer — returns Buffer, integrity verified
+const buffer = await client.download("@tank/react", "2.2.0", { buffer: true });
+
+// Disk — writes to directory, integrity verified
+await client.download("@tank/react", "2.2.0", { dest: "./skills/" });
+```
+
+All modes verify SHA-512 integrity when the registry provides a hash. Download size is capped at 100MB with streaming enforcement.
+
+---
+
+## Security & Audit
+
+### `audit(name, version?)`
+
+Returns the full security analysis for a skill version.
+
+```typescript
+const result = await client.audit("@tank/react");
+console.log(result.auditScore); // 9.5
+console.log(result.scanFindings); // [{ stage: 'static', severity: 'low', ... }]
+```
+
+### `permissions(name, version?)`
+
+Returns the declared permission set.
+
+```typescript
+const perms = await client.permissions("@tank/react");
+// { network: { outbound: ['*.api.com'] }, filesystem: { read: ['./data/**'] }, subprocess: false }
+```
+
+---
+
+## Auth
+
+### `whoami()`
+
+Returns user info if authenticated, `null` otherwise.
+
+```typescript
+const user = await client.whoami();
+if (user) {
+  console.log(user.userId, user.name, user.email);
+}
+```
+
+---
+
+## Stars
+
+```typescript
+// Get star count
+const { count, isStarred } = await client.getStarCount("@tank/react");
+
+// Star/unstar (requires session auth)
+await client.star("@tank/react");
+await client.unstar("@tank/react");
+```
+
+> Star and unstar require session-based authentication (browser cookies), not API keys. Use `getStarCount()` with API key auth.
+
+---
+
+## Error Handling
+
+All errors extend `TankError`. Catch specific types for programmatic handling:
+
+```typescript
+import { TankClient, TankNotFoundError, TankAuthError } from "@tankpkg/sdk";
+
+try {
+  await client.info("@acme/missing");
+} catch (e) {
+  if (e instanceof TankNotFoundError) {
+    console.log(e.status); // 404
+    console.log(e.skillName); // '@acme/missing'
+  }
+}
+```
+
+| Error Class           | HTTP Status | When                                  |
+| --------------------- | ----------- | ------------------------------------- |
+| `TankAuthError`       | 401         | Invalid or missing token              |
+| `TankNotFoundError`   | 404         | Skill or file not found               |
+| `TankPermissionError` | 403         | Insufficient permissions              |
+| `TankNetworkError`    | —           | Connection failure, timeout, redirect |
+| `TankIntegrityError`  | —           | SHA-512 hash mismatch                 |
+| `TankConflictError`   | 409         | Dependency resolution conflict        |
+
+All errors include `status`, `message`, and `cause` (for network errors).
+
+---
+
+## Full Example: Load Skill into OpenAI
+
+```typescript
+import { TankClient } from "@tankpkg/sdk";
+import OpenAI from "openai";
+
+const tank = new TankClient();
+const openai = new OpenAI();
+
+// 1. Load skill with all references
+const skill = await tank.readSkill("@tank/react");
+
+// 2. Build system prompt
+const systemPrompt = [
+  skill.content,
+  ...Object.entries(skill.references).map(([name, text]) => `\n--- Reference: ${name} ---\n${text}`),
+].join("\n");
+
+// 3. Use as LLM context
+const response = await openai.chat.completions.create({
+  model: "gpt-4o",
+  messages: [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: "How should I handle data fetching in React?" },
+  ],
+});
+```
+
+---
+
+## Exports
+
+Everything is importable from `@tankpkg/sdk`:
+
+```typescript
+import {
+  // Client
+  TankClient,
+
+  // Errors
+  TankError,
+  TankAuthError,
+  TankNotFoundError,
+  TankPermissionError,
+  TankNetworkError,
+  TankIntegrityError,
+  TankConflictError,
+
+  // Types
+  type SkillContent,
+  type SearchResponse,
+  type SkillInfoResponse,
+  type VersionDetail,
+  type UserInfo,
+  type TankClientOptions,
+
+  // Constants
+  SDK_VERSION,
+  DEFAULT_REGISTRY_URL,
+  SUPPORTED_AGENTS,
+  AGENT_PATHS,
+
+  // Utilities
+  hasNativeAcceleration,
+} from "@tankpkg/sdk";
+```


### PR DESCRIPTION
## Summary

Adds SDK documentation to the public docs site.

- **`sdk.md`** — TypeScript SDK reference: constructor, readSkill(), search, download, audit, errors, full OpenAI example
- **`sdk-python.md`** — Python SDK reference: same structure, snake_case, context manager, differences table vs TS
- **`meta.json`** — Both added to Reference section navigation

No code changes. Docs only.