### PR TITLE
feat: createSkillTool() — dynamic tool generator for AI agents

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@jsr:registry=https://npm.jsr.io

--- a/.opencode/plans/1775114378382-quick-river.md
+++ b/.opencode/plans/1775114378382-quick-river.md
@@ -1,157 +1,299 @@
-# Plan: Integrate prompt2bot "Talk to this Skill" on Skill Detail Page
+# Plan: Integrate prompt2bot + alice-and-bot "Talk to this Skill"
 
 ## Context
 
-- **Who**: `uriva` (uri from issue #292) — founder of prompt2bot.com
-- **What**: prompt2bot is an AI agent platform. Their `create-bot-api` takes a skill's README and creates a bot with a public `chatLink` users can chat with.
-- **Reference implementation**: agentskills.co.il shows an "Ask this Skill" button at the top of skill detail pages.
-- **Attribution requirements**: "Powered by prompt2bot" + link near the button, plus list on about/tech page.
+- **Who**: uriva (uri) — founder of prompt2bot.com + alice-and-bot.com (issue #292)
+- **What**: Floating chat bubble + header button on every skill detail page, backed by a per-version prompt2bot bot embedded via alice-and-bot `<Chat>` component
+- **Reference**: agentskills.co.il "Ask this Skill" button (same stack)
+- **API token**: `p2b_dbdfaf655e5122a0a485cd155098f6e3d7662c64` → env var `PROMPT2BOT_API_TOKEN`
+- **Attribution**: "Powered by prompt2bot · alice&bot" in chat footer + about page
 
-## Approach
+---
 
-Lazy bot creation: when a user first clicks "Talk to this skill", call `create-bot-api`, store the `chatLink` in DB, then open it in a new tab. Subsequent clicks go straight to the stored link. No changes to publish flow.
+## Decisions Made (Q&A)
 
-## Files to Create / Modify
+| Question         | Decision                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------- |
+| Button placement | **Header** (next to skill title, prominent) + **mobile action bar**                               |
+| Chat UX          | **Custom floating bubble** (bottom-right, skill pages only) + header button → same Dialog overlay |
+| Bot creation     | **Lazy** — on first user click                                                                    |
+| Bot granularity  | **One bot per skill version**                                                                     |
+| Bot knowledge    | README + all metadata (description, version, publisher, security score) + install command         |
+| Prompt chips     | None                                                                                              |
+| No-README skills | Show button; use description + metadata as fallback context                                       |
+| Store bot secret | Yes — needed for future context injection / prompt refresh                                        |
+| Mobile button    | Yes — in mobile action bar alongside Star + Download                                              |
 
-### 1. DB Schema — `apps/registry/src/lib/db/schema.ts`
+---
 
-Add two nullable columns to `skillVersions`:
+## Bulletproof Workflow (IDD → BDD → RED → GREEN)
+
+Follow this order strictly. Do not write application code before step 3.
+
+### Step 1 — Write INTENT.md
+
+Create `.idd/modules/talk-to-skill/INTENT.md` covering:
+
+- **Anchor**: Why this feature exists (skill discoverability, prompt2bot collab)
+- **Layer 2 constraints**:
+  - Button hidden when `PROMPT2BOT_API_TOKEN` is unset
+  - Bot created at most once per skill version (cached after first creation)
+  - Bot never created server-side for a skill version that has no published status
+  - `prompt2botSecret` never exposed to client
+  - Attribution must be visible whenever the chat widget is open
+- **Layer 3 examples** (rows that become Gherkin scenarios):
+  - Visitor clicks "Talk to this skill" on a skill with no bot yet → bot is created → chat opens
+  - Visitor clicks again → no second bot is created → same chat opens instantly
+  - `PROMPT2BOT_API_TOKEN` unset → button is not rendered at all
+  - Skill has no README → button still shows; bot is created with description context
+  - Skill page on mobile → button visible in action bar
+
+### Step 2 — Write Gherkin scenarios
+
+Create `.bdd/features/talk-to-skill/talk-to-skill.feature`. One scenario per Layer 3 example above. Example:
+
+```gherkin
+Feature: Talk to this Skill
+
+  Background:
+    Given PROMPT2BOT_API_TOKEN is set
+    And the skill "@test/hello-skill" version "1.0.0" is published with a README
+
+  Scenario: First click creates a bot and opens chat
+    When a visitor navigates to the skill page for "@test/hello-skill"
+    Then the "Talk to this skill" button is visible in the header
+    And the floating chat bubble is visible
+    When the visitor clicks "Talk to this skill"
+    Then a POST to /api/skills/%40test%2Fhello-skill/talk is made
+    And the chat widget opens
+    And the skill version has a prompt2botBotId stored in the database
+
+  Scenario: Second click reuses the cached bot
+    Given the skill "@test/hello-skill" version "1.0.0" already has a stored botId
+    When a visitor clicks "Talk to this skill"
+    Then no new bot is created
+    And the chat widget opens immediately
+
+  Scenario: Button hidden when token is unset
+    Given PROMPT2BOT_API_TOKEN is not set
+    When a visitor navigates to a skill page
+    Then no "Talk to this skill" button is visible
+    And no floating chat bubble is visible
+
+  Scenario: Skill without README still gets a bot
+    Given the skill "@test/no-readme" version "1.0.0" is published without a README
+    When a visitor clicks "Talk to this skill"
+    Then a bot is created using the description and metadata as context
+```
+
+### Step 3 — Run tests → RED
+
+Run the BDD suite. Every scenario above must fail. This confirms the feature doesn't exist yet.
+
+### Step 4 — Build (application code)
+
+Only now write application code. Each step below corresponds to making one or more scenarios go GREEN.
+
+---
+
+## Application Code Changes
+
+### 4a. DB Schema — `apps/registry/src/lib/db/schema.ts`
+
+Add 4 nullable columns to `skillVersions`:
 
 ```ts
-prompt2botChatLink: text('prompt2bot_chat_link'),
-prompt2botBotId: text('prompt2bot_bot_id'),
+prompt2botBotId:        text('prompt2bot_bot_id'),
+prompt2botChatLink:     text('prompt2bot_chat_link'),
+prompt2botBotPublicKey: text('prompt2bot_bot_public_key'),  // alice-and-bot public sign key
+prompt2botSecret:       text('prompt2bot_secret'),           // Remote Tools Secret — never expose to client
 ```
 
-### 2. DB Migration
+Run `just db generate` after change.
 
-Run `just db generate` after schema change to create a new Drizzle migration.
+### 4b. Env Config
 
-### 3. Env Config (wherever env is validated in `apps/registry`)
-
-Add:
+Add to Zod env schema (wherever `apps/registry` validates env):
 
 ```
-PROMPT2BOT_API_TOKEN=p2b_...
+PROMPT2BOT_API_TOKEN=p2b_dbdfaf655e5122a0a485cd155098f6e3d7662c64
 ```
 
-Register in the Zod env schema as `z.string().optional()` so the app works without it but disables the button when unset.
+Register as `z.string().optional()`. Feature silently disabled when unset.
 
-### 4. NEW — `apps/registry/src/lib/prompt2bot.ts`
+### 4c. NEW — `apps/registry/src/lib/prompt2bot.ts`
 
 ```ts
 export async function createSkillBot(params: {
   skillName: string;
+  version: string;
   readme: string | null;
   description: string | null;
+  publisherName: string;
+  auditScore: number | null;
+  auditVerdict: string | null;
+  repositoryUrl: string | null;
   apiToken: string;
-}): Promise<{ chatLink: string; botId: string } | null>;
+}): Promise<{
+  botId: string;
+  secret: string;
+  chatLink: string;
+  botPublicKey: string | null;
+} | null>;
 ```
 
-Calls `POST https://api.prompt2bot.com/api` with:
+Fails silently (returns `null`) — non-blocking side effect.
 
-```json
-{
-  "endpoint": "create-bot-api",
-  "payload": {
-    "apiToken": "...",
-    "name": "<skillName>",
-    "prompt": "You are a specialist assistant for the Tank skill: <skillName>.\n\n<readme or description>"
-  }
-}
+#### System Prompt Template
+
+```
+You are an expert assistant for the Tank skill "{skillName}" (version {version}).
+
+Tank is a security-first package manager for AI agent skills.
+
+== INSTALL ==
+tank install {skillName}
+
+== METADATA ==
+Name: {skillName} | Version: {version}
+Publisher: {publisherName}
+Audit Score: {auditScore}/10  Verdict: {auditVerdict}
+Repository: {repositoryUrl || "not provided"}
+
+== DOCUMENTATION ==
+{readme || description || "No documentation available."}
+
+Help users understand what this skill does, whether it is safe,
+and how to install and use it. Be concise.
 ```
 
-Returns `{ chatLink, botId }` or `null` on failure (fail silently — non-blocking side effect).
-
-### 5. NEW API endpoint — create in `apps/registry/src/api/` (follow existing Hono pattern)
+### 4d. NEW API endpoint — `apps/registry/src/api/` (Hono pattern)
 
 `POST /api/skills/:encodedName/talk`
 
-Logic:
+```
+1. Decode skill name → load latest published version (status = 'published')
+2. If prompt2botBotId exists → return { chatLink, botPublicKey }
+3. Gate: env.PROMPT2BOT_API_TOKEN must be set → 503 if not
+4. Call createSkillBot(...) with full metadata
+5. UPDATE skillVersions SET prompt2botBotId, prompt2botChatLink, prompt2botBotPublicKey, prompt2botSecret
+6. Return { chatLink, botPublicKey }
+```
 
-1. Decode skill name, load latest published version from DB
-2. If `prompt2botChatLink` already set → return it immediately
-3. Otherwise: call `createSkillBot(...)`, save `chatLink` + `botId` to `skillVersions`, return `chatLink`
-4. Gate on `env.PROMPT2BOT_API_TOKEN` being set; return 503 if not
+Register in main Hono router.
 
-Route must be registered in the main Hono app (check `apps/registry/src/api/index.ts` or similar router entry point).
-
-### 6. Skill data — `apps/registry/src/lib/skills/data.ts`
+### 4e. Skill data — `apps/registry/src/lib/skills/data.ts`
 
 Add to `SkillDetailResult`:
 
 ```ts
 prompt2botChatLink: string | null;
+prompt2botBotPublicKey: string | null;
+// prompt2botSecret — NEVER include in client-facing result
 ```
 
-Include `latestVersion.prompt2botChatLink` in the DB query so the UI can show the button without an extra request (button state: "already created" vs. "not yet created").
+### 4f. Skill detail screen — `apps/registry/src/screens/skill-detail-screen.tsx`
 
-### 7. Skill detail screen — `apps/registry/src/screens/skill-detail-screen.tsx`
+Thread `prompt2botChatLink` + `prompt2botBotPublicKey` + `skillName` down to:
 
-Pass `prompt2botChatLink` from `data.latestVersion` down to `SkillSidebar` and `SkillTabs` (for the Readme tab where sidebar lives).
+- The skill header section
+- The mobile action bar
+- `TalkToSkillWidget` (floating bubble)
 
-### 8. Skill sidebar — `apps/registry/src/components/skills/skill-sidebar.tsx`
+### 4g. Skill detail header (within skill-detail-screen.tsx)
 
-After the Star + Download buttons section, add:
+Add "Talk to this skill" button inline with the skill name/badge row:
 
 ```tsx
-{
-  /* Talk to Skill */
-}
-<div className="space-y-1.5">
-  <TalkToSkillButton initialChatLink={props.prompt2botChatLink} skillName={props.name} />
-  <p className="text-center text-[11px] text-muted-foreground">
-    Powered by{" "}
-    <a
-      href="https://prompt2bot.com"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="underline underline-offset-2 hover:text-foreground">
-      prompt2bot
-    </a>
-  </p>
-</div>;
+<Button variant="outline" size="sm" onClick={() => setTalkOpen(true)}>
+  <MessageSquare className="size-3.5" />
+  Talk to this skill
+</Button>
 ```
 
-### 9. NEW component — `apps/registry/src/components/skills/talk-to-skill-button.tsx`
+### 4h. Mobile action bar (within skill-detail-screen.tsx, `lg:hidden` section)
 
-Client component. State:
+Add the same button alongside Star + Download.
 
-- If `initialChatLink` is provided → button opens it directly in new tab (no API call needed)
-- If null → button shows "Talk to this skill", onClick calls `/api/skills/:name/talk`, shows loading spinner, then opens returned `chatLink`
+### 4i. NEW — `apps/registry/src/components/skills/talk-to-skill-widget.tsx`
 
-Button style: `variant="outline" size="sm" className="w-full"` with a `MessageSquare` Lucide icon.
+Client component. Handles:
 
-### 10. Attribution on About page
+1. **Floating bubble** — `fixed bottom-6 right-6 z-50`, `size-12 rounded-full bg-[#10b981] text-white`, `MessageCircle` icon
+2. **Shared open state** — both bubble and header button call `setTalkOpen(true)`
+3. **Lazy bot creation** — if no `botPublicKey` yet: `POST /api/skills/:name/talk` on open, shows loading state
+4. **alice-and-bot Chat** — once `botPublicKey` is resolved:
+   - `createIdentity(randomName)` → stored in `localStorage` (ephemeral per-browser identity)
+   - `useGetOrCreateConversation(creds, botPublicKey)`
+   - `<Chat conversationId={…} credentials={…} darkModeOverride customColors={tankColors} />`
+5. **Attribution footer** inside Dialog:
+   ```tsx
+   Powered by{" "}
+   <a href="https://prompt2bot.com">prompt2bot</a>
+   {" · "}
+   <a href="https://aliceandbot.com">alice&bot</a>
+   ```
 
-Find the About page / tech stack section in `apps/registry/src`. Add prompt2bot as a technology partner with link.
+Tank color theme for Chat:
 
-## Prompt Template for Bot Creation
-
+```ts
+customColors={{
+  background:       "hsl(var(--background))",
+  text:             "hsl(var(--foreground))",
+  primary:          "#10b981",  // --tank-green-ui
+  inputBackground:  "transparent",
+  hideTitle:        true,
+  hideOwnAvatar:    true,
+  hideOtherBubble:  false,
+  hideNames:        true,
+  chatMaxWidth:     "600px",
+  inputMaxWidth:    "600px",
+}}
 ```
-You are a specialist assistant for the Tank skill: "{skillName}".
 
-Your purpose is to help users understand what this skill does, how to install it,
-when to use it, and answer any questions about it.
+### 4j. NEW package install
 
-{readme || description || "No documentation available."}
-
-When asked how to install, tell them to run: tank install {skillName}
+```bash
+bun add @jsr/alice-and-bot__core
 ```
 
-## Verification
+in `apps/registry/`.
 
-1. `just db push` — apply migration cleanly
-2. Set `PROMPT2BOT_API_TOKEN` in `.env`
-3. Visit any skill page → "Talk to this skill" button appears in sidebar
-4. Click it → brief loading spinner → opens prompt2bot chat in new tab
-5. Reload skill page → button now opens directly without API call (chatLink cached)
-6. Unset `PROMPT2BOT_API_TOKEN` → button does not appear
-7. "Powered by prompt2bot" attribution visible below button
-8. Check about page for listing
+### 4k. About page — attribution
 
-## Open Questions
+Add prompt2bot + alice-and-bot to the tech stack / credits section.
 
-1. **API token**: Need `PROMPT2BOT_API_TOKEN` from uri before this can be tested end-to-end.
-2. **Bot reuse per version**: Should we create one bot per skill (reusing across versions) or one per skill version? Recommend one per skill version so the README context is always accurate.
-3. **Mobile CTA**: Should the button also appear in the mobile action bar (currently has Star + Download)? Probably yes — worth confirming with the user.
-4. **Existing skills**: Do we backfill prompt2bot bots for already-published skills? Lazy approach handles this naturally.
+---
+
+## Step 5 — Run tests → GREEN
+
+All scenarios from step 2 must now pass.
+
+---
+
+## Step 6 — Refactor (if needed)
+
+Runs only after all scenarios are GREEN. Tests are the safety net.
+
+---
+
+## Open Items (confirm with uri before step 4)
+
+1. **Bot public key**: Does `create-bot-api` return the bot's alice-and-bot public sign key? If not, can uri add it? Without it, the `<Chat>` component can't connect. (Fallback: iframe of `chatLink` if unavailable)
+2. **chatLink format**: Confirm URL structure so we can parse public key if needed.
+3. **API token scope**: Confirm `p2b_dbdfaf655e5122a0a485cd155098f6e3d7662c64` is for production use (not a test token).
+
+---
+
+## Verification Checklist
+
+1. `just db push` — migration applies cleanly
+2. `PROMPT2BOT_API_TOKEN` set in `.env`
+3. Visit skill page (desktop): header button + floating bubble visible
+4. Click → loading → chat opens, bot knows the skill's README + install command
+5. Close + reopen → no second bot created (DB cached)
+6. Mobile: button in action bar, bubble still visible
+7. Unset token → no button, no bubble
+8. Skill with no README → button still shows, bot uses description
+9. Attribution visible in chat footer + about page
+10. `prompt2botSecret` not present in any network response to the browser

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
+    "@alice-and-bot/core": "npm:@jsr/alice-and-bot__core",
     "@aws-sdk/client-s3": "^3.1013.0",
     "@aws-sdk/s3-request-presigner": "^3.1013.0",
     "@better-auth/api-key": "1.5.5",

--- a/apps/registry/public/docs/sdk.md
+++ b/apps/registry/public/docs/sdk.md
@@ -280,6 +280,86 @@ const response = await openai.chat.completions.create({
 
 ---
 
+## Tool Generator
+
+Generate framework-agnostic tool definitions from skills. The generated tools work with OpenAI function calling, Anthropic tool use, MCP, LangChain, CrewAI, and any framework that consumes JSON Schema tool definitions.
+
+### `createSkillTool(client, name, version?)`
+
+Creates a tool definition for a single skill. The tool provides filesystem-like access to the skill's content.
+
+```typescript
+import { TankClient, createSkillTool } from "@tankpkg/sdk";
+
+const client = new TankClient();
+const tool = await createSkillTool(client, "@tank/react");
+
+console.log(tool.name); // 'tank_react'
+console.log(tool.files); // ['SKILL.md', 'references/hooks.md', ...]
+console.log(tool.description); // Includes skill summary, file list, actions
+```
+
+### Tool Actions
+
+The generated tool supports three actions:
+
+| Action     | Description                                              | Returns                                                       |
+| ---------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| `read_all` | Complete skill content (SKILL.md + references + scripts) | `{ success, skill: { content, references, scripts, files } }` |
+| `list`     | List all files in the skill                              | `{ success, files }`                                          |
+| `read`     | Read a single file by path                               | `{ success, content }`                                        |
+
+```typescript
+// Execute actions
+const all = await tool.execute({ action: "read_all" });
+const files = await tool.execute({ action: "list" });
+const file = await tool.execute({ action: "read", path: "references/hooks.md" });
+```
+
+### OpenAI Function Calling
+
+```typescript
+import OpenAI from "openai";
+
+const openai = new OpenAI();
+const tool = await createSkillTool(client, "@tank/react");
+
+// Register as OpenAI tool
+const response = await openai.chat.completions.create({
+  model: "gpt-4o",
+  tools: [tool.toOpenAI()],
+  messages: [{ role: "user", content: "Read the React skill and explain hooks." }],
+});
+
+// Handle tool call
+const call = response.choices[0].message.tool_calls?.[0];
+if (call) {
+  const result = await tool.execute(JSON.parse(call.function.arguments));
+  // Send result back to OpenAI...
+}
+```
+
+### MCP Tool
+
+```typescript
+// Register as MCP tool
+const mcpDef = tool.toMCP();
+// { name: 'tank_react', description: '...', inputSchema: { type: 'object', ... } }
+```
+
+### Multiple Skills
+
+```typescript
+import { createSkillTools } from "@tankpkg/sdk";
+
+const tools = await createSkillTools(client, ["@tank/react", "@tank/nextjs", "@tank/clean-code"]);
+// Returns array of SkillTool objects, fetched with concurrency=6
+
+const openaiTools = tools.map((t) => t.toOpenAI());
+```
+
+---
+
 ## Exports
 
 Everything is importable from `@tankpkg/sdk`:
@@ -311,6 +391,15 @@ import {
   DEFAULT_REGISTRY_URL,
   SUPPORTED_AGENTS,
   AGENT_PATHS,
+
+  // Tool Generator
+  createSkillTool,
+  createSkillTools,
+  type SkillTool,
+  type SkillToolInput,
+  type SkillToolResult,
+  type OpenAIFunctionTool,
+  type MCPToolDefinition,
 
   // Utilities
   hasNativeAcceleration,

--- a/apps/registry/src/api/routes/v1.ts
+++ b/apps/registry/src/api/routes/v1.ts
@@ -9,6 +9,7 @@ import { skillsConfirmRoutes } from './v1/skills-confirm';
 import { skillsPublishRoutes } from './v1/skills-publish';
 import { skillsReadRoutes } from './v1/skills-read';
 import { starRoutes } from './v1/star';
+import { talkRoutes } from './v1/talk';
 
 export const v1Routes = new OpenAPIHono()
   .route('/auth', authRoutes)
@@ -19,6 +20,7 @@ export const v1Routes = new OpenAPIHono()
   .route('/skills', skillsPublishRoutes)
   .route('/skills', skillsConfirmRoutes)
   .route('/skills', starRoutes)
+  .route('/skills', talkRoutes)
   .route('/skills', skillsReadRoutes);
 
 v1Routes.openAPIRegistry.registerComponent('securitySchemes', 'BearerAuth', {

--- a/apps/registry/src/api/routes/v1/talk.ts
+++ b/apps/registry/src/api/routes/v1/talk.ts
@@ -1,0 +1,144 @@
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
+import { desc, eq, sql } from 'drizzle-orm';
+
+import { db } from '~/lib/db';
+import { skills, skillVersions } from '~/lib/db/schema';
+import { createSkillBot } from '~/lib/prompt2bot';
+
+const nameParam = z.object({
+  name: z.string().openapi({
+    description: 'Skill name (URL-encoded)',
+    example: '@tank/react'
+  })
+});
+
+const postTalkRoute = createRoute({
+  method: 'post',
+  path: '/{name}/talk',
+  tags: ['Talk'],
+  summary: 'Get or create a prompt2bot chat for a skill',
+  description: 'Lazily creates a prompt2bot bot for the latest published version. Returns chat link on success.',
+  request: { params: nameParam },
+  responses: {
+    200: {
+      description: 'Chat link',
+      content: {
+        'application/json': {
+          schema: z.object({
+            chatLink: z.string(),
+            botPublicKey: z.string().nullable()
+          })
+        }
+      }
+    },
+    404: {
+      description: 'Skill or version not found',
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } }
+    },
+    500: {
+      description: 'Bot creation failed',
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } }
+    },
+    503: {
+      description: 'Feature not configured',
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } }
+    }
+  }
+});
+
+export const talkRoutes = new OpenAPIHono().openapi(postTalkRoute, async (c) => {
+  const apiToken = process.env.PROMPT2BOT_API_TOKEN;
+  if (!apiToken) {
+    return c.json({ error: 'Talk to skill feature is not configured' }, 503);
+  }
+
+  const { name: rawName } = c.req.valid('param');
+  const name = decodeURIComponent(rawName);
+
+  const skillRows = await db
+    .select({ id: skills.id, description: skills.description })
+    .from(skills)
+    .where(eq(skills.name, name))
+    .limit(1);
+  const skill = skillRows[0];
+  if (!skill) return c.json({ error: 'Skill not found' }, 404);
+
+  const versionRows = await db
+    .select({
+      id: skillVersions.id,
+      version: skillVersions.version,
+      readme: skillVersions.readme,
+      auditScore: skillVersions.auditScore,
+      prompt2botBotId: skillVersions.prompt2botBotId,
+      prompt2botChatLink: skillVersions.prompt2botChatLink,
+      prompt2botBotPublicKey: skillVersions.prompt2botBotPublicKey
+    })
+    .from(skillVersions)
+    .where(eq(skillVersions.skillId, skill.id))
+    .orderBy(desc(skillVersions.createdAt))
+    .limit(1);
+
+  const version = versionRows[0];
+  if (!version) return c.json({ error: 'No published version found' }, 404);
+
+  if (version.prompt2botBotId && version.prompt2botChatLink) {
+    return c.json(
+      {
+        chatLink: version.prompt2botChatLink,
+        botPublicKey: version.prompt2botBotPublicKey
+      },
+      200
+    );
+  }
+
+  const publisherRows = (await db.execute(
+    sql`SELECT coalesce(u.name, '') AS name FROM skills s LEFT JOIN "user" u ON u.id = s.publisher_id WHERE s.id = ${skill.id}`
+  )) as Record<string, unknown>[];
+  const publisherName = (publisherRows[0]?.name as string) ?? '';
+
+  const scanRows = (await db.execute(
+    sql`SELECT verdict FROM scan_results WHERE version_id = ${version.id} ORDER BY created_at DESC LIMIT 1`
+  )) as Record<string, unknown>[];
+  const auditVerdict = (scanRows[0]?.verdict as string) ?? null;
+
+  const repoRows = await db
+    .select({ repositoryUrl: skills.repositoryUrl })
+    .from(skills)
+    .where(eq(skills.id, skill.id))
+    .limit(1);
+  const repositoryUrl = repoRows[0]?.repositoryUrl ?? null;
+
+  const result = await createSkillBot({
+    skillName: name,
+    version: version.version,
+    readme: version.readme,
+    description: skill.description,
+    publisherName,
+    auditScore: version.auditScore,
+    auditVerdict,
+    repositoryUrl,
+    apiToken
+  });
+
+  if (!result) {
+    return c.json({ error: 'Failed to create bot' }, 500);
+  }
+
+  await db
+    .update(skillVersions)
+    .set({
+      prompt2botBotId: result.botId,
+      prompt2botChatLink: result.chatLink,
+      prompt2botBotPublicKey: result.botPublicKey,
+      prompt2botSecret: result.secret
+    })
+    .where(eq(skillVersions.id, version.id));
+
+  return c.json(
+    {
+      chatLink: result.chatLink,
+      botPublicKey: result.botPublicKey
+    },
+    200
+  );
+});

--- a/apps/registry/src/components/skills/talk-to-skill-widget.tsx
+++ b/apps/registry/src/components/skills/talk-to-skill-widget.tsx
@@ -1,0 +1,156 @@
+import { encodeSkillName } from '@internals/helpers';
+import { Loader2, MessageCircle } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Button } from '~/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '~/components/ui/dialog';
+
+const WIDGET_SCRIPT_URL = 'https://storage.googleapis.com/alice-and-bot/widget/dist/widget.iife.js';
+
+interface AliceAndBotGlobal {
+  loadChatWidget: (opts: { initialMessage: string; dialingTo: string; container?: HTMLElement }) => void;
+}
+
+interface TalkToSkillWidgetProps {
+  skillName: string;
+  chatLink: string | null;
+  botPublicKey: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function TalkToSkillWidget({ skillName, chatLink, botPublicKey, open, onOpenChange }: TalkToSkillWidgetProps) {
+  const [resolvedBotKey, setResolvedBotKey] = useState<string | null>(botPublicKey);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const chatContainerRef = useRef<HTMLDivElement>(null);
+  const widgetLoadedRef = useRef(false);
+
+  const ensureBot = useCallback(async () => {
+    if (resolvedBotKey) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const encoded = encodeSkillName(skillName);
+      const res = await fetch(`/api/v1/skills/${encoded}/talk`, { method: 'POST' });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: 'Unknown error' }));
+        setError((body as { error?: string }).error ?? 'Failed to create chat');
+        return;
+      }
+
+      const data = (await res.json()) as { chatLink: string; botPublicKey: string | null };
+      if (data.botPublicKey) {
+        setResolvedBotKey(data.botPublicKey);
+      } else {
+        setError('Chat is not fully configured yet');
+      }
+    } catch {
+      setError('Network error — please try again');
+    } finally {
+      setLoading(false);
+    }
+  }, [skillName, resolvedBotKey]);
+
+  const handleOpen = useCallback(() => {
+    onOpenChange(true);
+    ensureBot();
+  }, [onOpenChange, ensureBot]);
+
+  useEffect(() => {
+    if (!open || !resolvedBotKey || widgetLoadedRef.current) return;
+    if (!chatContainerRef.current) return;
+
+    const container = chatContainerRef.current;
+    container.innerHTML = '';
+
+    const script = document.createElement('script');
+    script.src = WIDGET_SCRIPT_URL;
+    script.async = true;
+    script.onload = () => {
+      const global = (window as unknown as { aliceAndBot?: AliceAndBotGlobal }).aliceAndBot;
+      if (global) {
+        global.loadChatWidget({
+          initialMessage: `Hi! Tell me about the ${skillName} skill.`,
+          dialingTo: resolvedBotKey,
+          container
+        });
+        widgetLoadedRef.current = true;
+      }
+    };
+    container.appendChild(script);
+
+    return () => {
+      widgetLoadedRef.current = false;
+    };
+  }, [open, resolvedBotKey, skillName]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="fixed bottom-6 right-6 z-50 flex size-12 items-center justify-center rounded-full bg-[#10b981] text-white shadow-lg transition-transform hover:scale-105 hover:bg-[#0d9e6e] focus:outline-none focus:ring-2 focus:ring-[#10b981]/50 focus:ring-offset-2 focus:ring-offset-background"
+        aria-label="Talk to this skill"
+        data-testid="talk-bubble">
+        <MessageCircle className="size-5" />
+      </button>
+
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-[640px] h-[80vh] flex flex-col p-0 gap-0">
+          <DialogHeader className="px-4 py-3 border-b shrink-0">
+            <DialogTitle className="text-sm font-medium">Talk to {skillName}</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex-1 min-h-0 flex flex-col">
+            {loading && (
+              <div className="flex flex-col items-center justify-center gap-3 flex-1 text-muted-foreground">
+                <Loader2 className="size-6 animate-spin" />
+                <p className="text-sm">Setting up your chat…</p>
+              </div>
+            )}
+
+            {error && (
+              <div className="flex flex-col items-center justify-center gap-3 flex-1 text-center px-4">
+                <p className="text-sm font-medium text-destructive" role="alert">
+                  {error}
+                </p>
+                <Button variant="outline" size="sm" onClick={() => ensureBot()}>
+                  Try again
+                </Button>
+              </div>
+            )}
+
+            {!loading && !error && resolvedBotKey && (
+              <div ref={chatContainerRef} className="flex-1 min-h-0" data-testid="chat-container" />
+            )}
+          </div>
+
+          <div className="px-4 py-2 border-t text-center shrink-0">
+            <p className="text-[11px] text-muted-foreground">
+              Powered by{' '}
+              <a
+                href="https://prompt2bot.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-foreground">
+                prompt2bot
+              </a>
+              {' · '}
+              <a
+                href="https://aliceandbot.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-foreground">
+                alice&bot
+              </a>
+            </p>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/registry/src/lib/db/schema.ts
+++ b/apps/registry/src/lib/db/schema.ts
@@ -162,6 +162,10 @@ export const skillVersions = pgTable(
     auditScore: real('audit_score'),
     auditStatus: text('audit_status').notNull().default('pending'),
     readme: text('readme'),
+    prompt2botBotId: text('prompt2bot_bot_id'),
+    prompt2botChatLink: text('prompt2bot_chat_link'),
+    prompt2botBotPublicKey: text('prompt2bot_bot_public_key'),
+    prompt2botSecret: text('prompt2bot_secret'),
     publishedBy: text('published_by')
       .notNull()
       .references(() => user.id),

--- a/apps/registry/src/lib/prompt2bot.ts
+++ b/apps/registry/src/lib/prompt2bot.ts
@@ -1,0 +1,113 @@
+/**
+ * prompt2bot API client — creates a per-skill-version chatbot.
+ *
+ * Uses the `create-bot-api` endpoint to provision a bot on prompt2bot.com.
+ * The bot is pre-loaded with the skill's README + metadata so visitors
+ * can ask questions about it before installing.
+ *
+ * See: https://prompt2bot.com/docs
+ */
+
+const PROMPT2BOT_API = 'https://api.prompt2bot.com/api';
+
+export interface CreateSkillBotParams {
+  skillName: string;
+  version: string;
+  readme: string | null;
+  description: string | null;
+  publisherName: string;
+  auditScore: number | null;
+  auditVerdict: string | null;
+  repositoryUrl: string | null;
+  apiToken: string;
+}
+
+export interface CreateSkillBotResult {
+  botId: string;
+  secret: string;
+  chatLink: string;
+  botPublicKey: string | null;
+}
+
+function buildBotPrompt(params: CreateSkillBotParams): string {
+  const { skillName, version, publisherName, auditScore, auditVerdict, repositoryUrl, readme, description } = params;
+
+  const documentation = readme || description || 'No documentation available.';
+  const scoreDisplay = auditScore != null ? `${auditScore}/10` : 'not scanned';
+  const verdictDisplay = auditVerdict || 'unknown';
+  const repoDisplay = repositoryUrl || 'not provided';
+
+  return [
+    `You are an expert assistant for the Tank skill "${skillName}" (version ${version}).`,
+    '',
+    'Tank is a security-first package manager for AI agent skills — instruction files that extend AI coding agents.',
+    '',
+    '== INSTALL ==',
+    `tank install ${skillName}`,
+    '',
+    '== METADATA ==',
+    `Name: ${skillName} | Version: ${version}`,
+    `Publisher: ${publisherName}`,
+    `Audit Score: ${scoreDisplay}  Verdict: ${verdictDisplay}`,
+    `Repository: ${repoDisplay}`,
+    '',
+    '== DOCUMENTATION ==',
+    documentation,
+    '',
+    'Help users understand what this skill does, whether it is safe,',
+    'and how to install and use it. Be concise.'
+  ].join('\n');
+}
+
+/**
+ * Creates a prompt2bot bot for a skill version.
+ * Returns bot info on success, null on any failure (non-blocking).
+ */
+export async function createSkillBot(params: CreateSkillBotParams): Promise<CreateSkillBotResult | null> {
+  try {
+    const response = await fetch(PROMPT2BOT_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        endpoint: 'create-bot-api',
+        payload: {
+          apiToken: params.apiToken,
+          name: `Tank: ${params.skillName} v${params.version}`,
+          prompt: buildBotPrompt(params)
+        }
+      })
+    });
+
+    if (!response.ok) {
+      // biome-ignore lint/suspicious/noConsole: intentional — server-side diagnostic for bot creation failures
+      console.error(`[prompt2bot] create-bot-api failed: ${response.status} ${response.statusText}`);
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      success: boolean;
+      botId?: string;
+      secret?: string;
+      chatLink?: string;
+      error?: string;
+    };
+
+    if (!data.success || !data.botId || !data.secret || !data.chatLink) {
+      // biome-ignore lint/suspicious/noConsole: intentional — server-side diagnostic for bot creation failures
+      console.error(`[prompt2bot] create-bot-api returned error:`, data.error ?? 'unknown');
+      return null;
+    }
+
+    return {
+      botId: data.botId,
+      secret: data.secret,
+      chatLink: data.chatLink,
+      // TODO: confirm with uri if create-bot-api exposes the alice-and-bot public key
+      botPublicKey: null
+    };
+  } catch (err) {
+    // biome-ignore lint/suspicious/noConsole: intentional — server-side diagnostic for bot creation failures
+    console.error('[prompt2bot] create-bot-api request failed:', err);
+    return null;
+  }
+}

--- a/apps/registry/src/lib/skills/data.ts
+++ b/apps/registry/src/lib/skills/data.ts
@@ -127,6 +127,8 @@ export interface SkillVersionDetail {
   fileCount: number;
   tarballSize: number;
   scanDetails: ScanDetails;
+  prompt2botChatLink: string | null;
+  prompt2botBotPublicKey: string | null;
 }
 
 export interface SkillVersionSummary {
@@ -241,6 +243,8 @@ export async function getSkillDetail(
       sv.readme,
       sv.file_count AS "versionFileCount",
       sv.tarball_size AS "versionTarballSize",
+      sv.prompt2bot_chat_link AS "prompt2botChatLink",
+      sv.prompt2bot_bot_public_key AS "prompt2botBotPublicKey",
       (SELECT row_to_json(t) FROM (
         SELECT sr.verdict, sr.stages_run AS "stagesRun", sr.duration_ms AS "durationMs",
                sr.critical_count AS "criticalCount", sr.high_count AS "highCount",
@@ -357,7 +361,9 @@ export async function getSkillDetail(
         readme: (latestRowData?.readme as string) ?? null,
         fileCount: Number(latestRowData?.versionFileCount ?? 0),
         tarballSize: Number(latestRowData?.versionTarballSize ?? 0),
-        scanDetails
+        scanDetails,
+        prompt2botChatLink: (latestRowData?.prompt2botChatLink as string) ?? null,
+        prompt2botBotPublicKey: (latestRowData?.prompt2botBotPublicKey as string) ?? null
       }
     : null;
 

--- a/apps/registry/src/routes/skills/$.tsx
+++ b/apps/registry/src/routes/skills/$.tsx
@@ -11,7 +11,8 @@ export const Route = createFileRoute('/skills/$')({
     const skillName = decodeURIComponent(rawPath);
     const data = await context.queryClient.ensureQueryData(skillDetailQueryOptions(skillName));
     if (!data) throw notFound();
-    return { data, skillName };
+    const talkEnabled = !!process.env.PROMPT2BOT_API_TOKEN;
+    return { data, skillName, talkEnabled };
   },
   head: ({ loaderData }) => {
     const data = loaderData?.data;
@@ -60,7 +61,7 @@ export const Route = createFileRoute('/skills/$')({
 });
 
 function SkillDetailPage() {
-  const { data } = Route.useLoaderData();
+  const { data, talkEnabled } = Route.useLoaderData();
 
-  return <SkillDetailScreen data={data} />;
+  return <SkillDetailScreen data={data} talkEnabled={talkEnabled} />;
 }

--- a/apps/registry/src/screens/skill-detail-screen.tsx
+++ b/apps/registry/src/screens/skill-detail-screen.tsx
@@ -1,10 +1,11 @@
-import { Check, Copy } from 'lucide-react';
+import { Check, Copy, MessageSquare } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { DownloadButton } from '~/components/skills/download-button';
 import { SkillSidebar } from '~/components/skills/skill-sidebar';
 import { SkillTabs } from '~/components/skills/skill-tabs';
 import { StarButton } from '~/components/skills/star-button';
+import { TalkToSkillWidget } from '~/components/skills/talk-to-skill-widget';
 import { TrustBadge } from '~/components/skills/trust-badge';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
@@ -40,9 +41,20 @@ function parseDescription(raw: string | null): { summary: string; triggers: stri
 
 interface SkillDetailScreenProps {
   data: SkillDetailResult;
+  talkEnabled: boolean;
 }
 
-function MobileActionBar({ data, scanDetails }: { data: SkillDetailResult; scanDetails: ScanDetails | null }) {
+function MobileActionBar({
+  data,
+  scanDetails,
+  talkEnabled,
+  onTalkClick
+}: {
+  data: SkillDetailResult;
+  scanDetails: ScanDetails | null;
+  talkEnabled: boolean;
+  onTalkClick: () => void;
+}) {
   const installCmd = `tank install ${data.name}`;
   const { copied, copy } = useCopyToClipboard();
 
@@ -53,6 +65,17 @@ function MobileActionBar({ data, scanDetails }: { data: SkillDetailResult; scanD
       <div className="flex items-center gap-2 flex-wrap">
         <StarButton skillName={data.name} initialStarred={data.isStarred} initialCount={data.starCount} />
         {data.latestVersion && <DownloadButton skillName={data.name} version={data.latestVersion.version} />}
+        {talkEnabled && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={onTalkClick}
+            data-testid="talk-button-mobile">
+            <MessageSquare className="size-3.5" />
+            Talk to skill
+          </Button>
+        )}
         {scanDetails && (
           <TrustBadge
             verdict={scanDetails.verdict}
@@ -76,9 +99,10 @@ function MobileActionBar({ data, scanDetails }: { data: SkillDetailResult; scanD
   );
 }
 
-export function SkillDetailScreen({ data }: SkillDetailScreenProps) {
+export function SkillDetailScreen({ data, talkEnabled }: SkillDetailScreenProps) {
   const [activeTab, setActiveTab] = useState('readme');
   const [triggersExpanded, setTriggersExpanded] = useState(false);
+  const [talkOpen, setTalkOpen] = useState(false);
   const latestManifest = safeParseJson(data.latestVersion?.manifest);
   const fileList: string[] = Array.isArray(latestManifest?.files) ? (latestManifest.files as string[]) : [];
   const license = typeof latestManifest?.license === 'string' ? latestManifest.license : null;
@@ -113,6 +137,17 @@ export function SkillDetailScreen({ data }: SkillDetailScreenProps) {
             <Badge variant="outline" className="text-xs">
               Private
             </Badge>
+          )}
+          {talkEnabled && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 hidden lg:inline-flex"
+              onClick={() => setTalkOpen(true)}
+              data-testid="talk-button-header">
+              <MessageSquare className="size-3.5" />
+              Talk to this skill
+            </Button>
           )}
         </div>
         {desc.summary && (
@@ -155,7 +190,22 @@ export function SkillDetailScreen({ data }: SkillDetailScreenProps) {
         )}
       </div>
 
-      <MobileActionBar data={data} scanDetails={scanDetails ?? null} />
+      <MobileActionBar
+        data={data}
+        scanDetails={scanDetails ?? null}
+        talkEnabled={talkEnabled}
+        onTalkClick={() => setTalkOpen(true)}
+      />
+
+      {talkEnabled && (
+        <TalkToSkillWidget
+          skillName={data.name}
+          chatLink={data.latestVersion?.prompt2botChatLink ?? null}
+          botPublicKey={data.latestVersion?.prompt2botBotPublicKey ?? null}
+          open={talkOpen}
+          onOpenChange={setTalkOpen}
+        />
+      )}
 
       <SkillTabs
         readmeContent={readmeContent ?? null}

--- a/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
+++ b/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
@@ -1,0 +1,54 @@
+Feature: Talk to this Skill
+  As a developer browsing skills
+  I want to chat with an AI that knows about a specific skill
+  So I can evaluate it before installing
+
+  Background:
+    Given PROMPT2BOT_API_TOKEN is configured
+    And the skill "@test/hello-skill" version "1.0.0" is published with a README
+
+  Scenario: Header button is visible on skill page
+    When I navigate to the skill page for "@test/hello-skill"
+    Then the "Talk to this skill" button is visible in the header section
+
+  Scenario: Floating chat bubble is visible on skill page
+    When I navigate to the skill page for "@test/hello-skill"
+    Then the floating chat bubble is visible in the bottom-right corner
+
+  Scenario: First click creates a bot and opens chat
+    When I navigate to the skill page for "@test/hello-skill"
+    And I click the "Talk to this skill" button
+    Then a POST request is made to "/api/skills/%40test%2Fhello-skill/talk"
+    And the chat dialog opens
+    And the chat dialog shows "Powered by prompt2bot" attribution
+    And the skill version now has a prompt2botBotId in the database
+
+  Scenario: Second click reuses the cached bot
+    Given the skill "@test/hello-skill" version "1.0.0" already has a prompt2bot bot
+    When I navigate to the skill page for "@test/hello-skill"
+    And I click the "Talk to this skill" button
+    Then no POST request is made to the talk endpoint
+    And the chat dialog opens immediately
+
+  Scenario: Button hidden when PROMPT2BOT_API_TOKEN is unset
+    Given PROMPT2BOT_API_TOKEN is not configured
+    When I navigate to the skill page for "@test/hello-skill"
+    Then no "Talk to this skill" button is visible
+    And no floating chat bubble is visible
+
+  Scenario: Skill without README still gets a bot
+    Given the skill "@test/no-readme" version "1.0.0" is published without a README
+    When I navigate to the skill page for "@test/no-readme"
+    And I click the "Talk to this skill" button
+    Then a bot is created using the skill description as context
+    And the chat dialog opens
+
+  Scenario: Mobile action bar includes talk button
+    Given the viewport is mobile width
+    When I navigate to the skill page for "@test/hello-skill"
+    Then the "Talk to this skill" button is visible in the mobile action bar
+
+  Scenario: Bot secret is never exposed to the client
+    When I navigate to the skill page for "@test/hello-skill"
+    Then the page data does not contain "prompt2botSecret"
+    And no network response contains the field "prompt2botSecret"

--- a/bdd/features/system/sdk/tool-generator.feature
+++ b/bdd/features/system/sdk/tool-generator.feature
@@ -1,0 +1,97 @@
+Feature: SDK Dynamic Tool Generator
+  As a developer building an AI agent framework
+  I want to generate tool definitions from Tank skills
+  So that agents can discover and read skills through standard tool interfaces
+
+  Background:
+    Given an authenticated TankClient
+    And the registry contains published skill "@org/demo" with references and scripts
+
+  # C44, E44: createSkillTool returns a SkillTool
+  Scenario: createSkillTool returns a valid SkillTool object
+    When I call createSkillTool(client, "@org/demo")
+    Then the result has property "name" matching "org_demo"
+    And the result has property "skillName" equal to "@org/demo"
+    And the result has property "version" as a non-empty string
+    And the result has property "description" as a non-empty string
+    And the result has property "files" as a non-empty array
+    And the result has methods "execute", "toOpenAI", "toMCP"
+
+  # C52, E44: Tool name derived safely from skill name
+  Scenario: Tool name sanitizes scoped skill names into valid identifiers
+    When I call createSkillTool(client, "@org/my-skill")
+    Then the tool name is "org_my_skill"
+
+  # C47: Description includes skill info
+  Scenario: Tool description includes skill metadata and file listing
+    When I call createSkillTool(client, "@org/demo")
+    Then the description contains "@org/demo"
+    And the description contains the skill version
+    And the description contains "references/"
+    And the description contains "scripts/"
+    And the description contains "read_all"
+
+  # C45, E45: toOpenAI format
+  Scenario: toOpenAI returns valid OpenAI function calling schema
+    Given a SkillTool for "@org/demo"
+    When I call toOpenAI()
+    Then the result has "type" equal to "function"
+    And the result has "function.name" matching "org_demo"
+    And the result has "function.description" as a non-empty string
+    And the result has "function.parameters.type" equal to "object"
+    And the result has "function.parameters.properties.action" with enum ["read", "list", "read_all"]
+    And the result has "function.parameters.properties.path" with type "string"
+    And the result has "function.parameters.required" containing "action"
+
+  # C46, E46: toMCP format
+  Scenario: toMCP returns valid MCP tool definition
+    Given a SkillTool for "@org/demo"
+    When I call toMCP()
+    Then the result has "name" matching "org_demo"
+    And the result has "description" as a non-empty string
+    And the result has "inputSchema.type" equal to "object"
+    And the result has "inputSchema.properties.action" with enum ["read", "list", "read_all"]
+
+  # C48, E47: execute read_all
+  Scenario: execute read_all returns full skill content
+    Given a SkillTool for "@org/demo"
+    When I call execute({ action: "read_all" })
+    Then the result has "success" equal to true
+    And the result has "skill.content" as a non-empty string
+    And the result has "skill.references" as an object with keys
+    And the result has "skill.scripts" as an object with keys
+    And the result has "skill.files" as a non-empty array
+
+  # C49, E48: execute list
+  Scenario: execute list returns file paths
+    Given a SkillTool for "@org/demo"
+    When I call execute({ action: "list" })
+    Then the result has "success" equal to true
+    And the result has "files" containing "SKILL.md"
+
+  # C50, E49: execute read with valid path
+  Scenario: execute read returns file content
+    Given a SkillTool for "@org/demo"
+    When I call execute({ action: "read", path: "SKILL.md" })
+    Then the result has "success" equal to true
+    And the result has "content" as a non-empty string
+
+  # C50, E50: execute read without path
+  Scenario: execute read without path returns error
+    Given a SkillTool for "@org/demo"
+    When I call execute({ action: "read" })
+    Then the result has "success" equal to false
+    And the result has "error" containing "path is required"
+
+  # C50, E51: execute read with nonexistent path
+  Scenario: execute read with nonexistent file returns error
+    Given a SkillTool for "@org/demo"
+    When I call execute({ action: "read", path: "nonexistent.md" })
+    Then the result has "success" equal to false
+    And the result has "error" containing "File not found"
+
+  # C51, E52: createSkillTools batch
+  Scenario: createSkillTools creates multiple tools efficiently
+    When I call createSkillTools(client, ["@org/demo", "@tank/react"])
+    Then the result is an array with 2 entries
+    And each entry has methods "execute", "toOpenAI", "toMCP"

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
       "name": "registry",
       "version": "0.10.6",
       "dependencies": {
+        "@alice-and-bot/core": "npm:@jsr/alice-and-bot__core",
         "@aws-sdk/client-s3": "^3.1013.0",
         "@aws-sdk/s3-request-presigner": "^3.1013.0",
         "@better-auth/api-key": "1.5.5",
@@ -210,7 +211,7 @@
     },
     "packages/sdk": {
       "name": "@tankpkg/sdk",
-      "version": "0.1.0",
+      "version": "0.10.6",
       "dependencies": {
         "@internals/helpers": "workspace:*",
         "tar": "^7.5.11",
@@ -247,6 +248,8 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@alice-and-bot/core": ["@jsr/alice-and-bot__core@0.0.248", "https://npm.jsr.io/~/11/@jsr/alice-and-bot__core/0.0.248.tgz", { "dependencies": { "@instantdb/admin": "0.22.174", "@instantdb/core": "0.22.174", "@instantdb/react": "0.22.174", "@jsr/uri__gamla": "0.0.14", "@jsr/uri__typed-api": "0.0.10", "@preact/signals": "2.1.1", "buffer": "6.0.3", "preact": "10.26.7", "react-hot-toast": "2.5.2", "react-icons": "5.5.0", "react-markdown": "10.1.0", "remark-breaks": "4.0.0", "remark-gfm": "4.0.1", "safe-stable-stringify": "2.5.0", "zod": "3.25.57" } }, "sha512-r7v/JvHsLjLd3z631EqT7UpvXI6JfaATOWtYIXpV9bIjXw3wF/QTlb2UfMrDJ4UUmMqHFSVQiEE2psN+ihQqJA=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.0.1", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.6" } }, "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw=="],
 
@@ -654,6 +657,16 @@
 
     "@inquirer/type": ["@inquirer/type@4.0.3", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw=="],
 
+    "@instantdb/admin": ["@instantdb/admin@0.22.174", "", { "dependencies": { "@instantdb/core": "0.22.174", "@instantdb/version": "0.22.174", "cookie": "^1.1.1", "eventsource": "^4.0.0", "uuid": "^11.1.0" } }, "sha512-pSt3Kq4MpL6A4yBenlFWZuZAiSQhiVgqTHNQZQqngyeIHuCWmd+95ekc5ODDCJdpMQfiredK1wYrvtuZyEBy1Q=="],
+
+    "@instantdb/core": ["@instantdb/core@0.22.174", "", { "dependencies": { "@instantdb/version": "0.22.174", "mutative": "^1.0.10", "uuid": "^11.1.0" } }, "sha512-hXoouIHu3PmnUjQPiol+5TyF5LvY1Sz9Nvk1nRRFXxPw8yK1Aabj7ej0oMsajT2lz333fU7eJ0GoOHl03XDIHw=="],
+
+    "@instantdb/react": ["@instantdb/react@0.22.174", "", { "dependencies": { "@instantdb/core": "0.22.174", "@instantdb/react-common": "0.22.174", "@instantdb/version": "0.22.174", "eventsource": "^4.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-Roh1aNBacjSCP+pTE27jWX3xnRpmDjrlwVQn3jeoZ4xLc8PPbWx2kw1fxJCjeeGuyYJyHSJNmyJXj+IsZF5aTg=="],
+
+    "@instantdb/react-common": ["@instantdb/react-common@0.22.174", "", { "dependencies": { "@instantdb/core": "0.22.174", "@instantdb/version": "0.22.174" }, "peerDependencies": { "react": ">=16" } }, "sha512-UKRqx3RfCl3HGJe3xEzLAl0kIJtMiDYD5C7rjaRmNYvxFfEiOWsONNx63qDggra6F+FRF2qMZyyYRJRBoRhb3g=="],
+
+    "@instantdb/version": ["@instantdb/version@0.22.174", "", {}, "sha512-isJyY7dM3X+y7+N/Kb7ZBlnliFx6VZMOSYTg4i1tODVfyEWwcIiVmxoRDTcIqy7XZlFIRumif5B3eg1PqL1Avw=="],
+
     "@internal/bdd": ["@internal/bdd@workspace:bdd"],
 
     "@internal/e2e": ["@internal/e2e@workspace:e2e"],
@@ -675,6 +688,14 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jsr/noble__hashes": ["@jsr/noble__hashes@2.0.0", "https://npm.jsr.io/~/11/@jsr/noble__hashes/2.0.0.tgz", {}, "sha512-2Q+5bMd7rnRVMQVexpu6r5nhb+eh1WYxNj5wDxrdGebXA4NvmJ64qI5dkDDCehdcSgCvlGsX/D/pn9hcm146bA=="],
+
+    "@jsr/std__encoding": ["@jsr/std__encoding@0.224.0", "https://npm.jsr.io/~/11/@jsr/std__encoding/0.224.0.tgz", {}, "sha512-V13A1JV6kvtlCyxeznQM8qYSPep5fiMfe59dnYD9gx//3TCHnGoqP2588qPDBGeD8IDrSUId3Czg/nGbcPt9Dw=="],
+
+    "@jsr/uri__gamla": ["@jsr/uri__gamla@0.0.14", "https://npm.jsr.io/~/11/@jsr/uri__gamla/0.0.14.tgz", { "dependencies": { "@jsr/noble__hashes": "2.0.0", "@jsr/std__encoding": "0.224.0" } }, "sha512-a2V4wcCwvuJyBiYQ7ejMTO1vHs72sVJuTU4HT3kfL6F+fv1VQkGCZ7YpHqsdvEoaSjVR8iBDln+kobgIbkH1eA=="],
+
+    "@jsr/uri__typed-api": ["@jsr/uri__typed-api@0.0.10", "https://npm.jsr.io/~/11/@jsr/uri__typed-api/0.0.10.tgz", { "dependencies": { "zod": "3.25.57" } }, "sha512-n8JLS0Evh+unWXUqtGoKyj46LziMW31/Zc9W5vrXfrp9AOPn3zhmIUZM7RzqTLs8l0aejMEq4a557or70YgVcw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -807,6 +828,10 @@
     "@posthog/core": ["@posthog/core@1.24.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-Wkp9mgNfgdf6+G4C1VMKakm2RXKQFf4bb5/CPQRAjpqv9l6BY36zZrD1+X5Y2XIAzZqbMKRxsDu3V1r6uKu7/A=="],
 
     "@posthog/types": ["@posthog/types@1.362.0", "", {}, "sha512-15wOI5uulkfzpkSQKVN4atZecAla2Hxr8IBIB8islqDvqY+42vbR+tMeDKMman9+FUoAqMzE0OnB8VIbM1QY0w=="],
+
+    "@preact/signals": ["@preact/signals@2.1.1", "", { "dependencies": { "@preact/signals-core": "^1.7.0" }, "peerDependencies": { "preact": ">= 10.25.0" } }, "sha512-qPgx6NVNQnfps424sxDZiW0rvsf/ByqSTT7LedzYa2kQLgT+LzayytghJmkScA6364/JJmne5UWHoxB4VUs79w=="],
+
+    "@preact/signals-core": ["@preact/signals-core@1.14.1", "", {}, "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng=="],
 
     "@prisma/client": ["@prisma/client@7.4.2", "", { "dependencies": { "@prisma/client-runtime-utils": "7.4.2" }, "peerDependencies": { "prisma": "*", "typescript": ">=5.4.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA=="],
 
@@ -1460,7 +1485,7 @@
 
     "bare-url": ["bare-url@2.4.0", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA=="],
 
-    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
 
@@ -1487,6 +1512,8 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -1912,6 +1939,8 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -2096,6 +2125,8 @@
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -2207,6 +2238,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msw": ["msw@2.12.10", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.10.1", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw=="],
+
+    "mutative": ["mutative@1.3.0", "", {}, "sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ=="],
 
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
@@ -2360,7 +2393,7 @@
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
-    "preact": ["preact@10.28.4", "", {}, "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ=="],
+    "preact": ["preact@10.26.7", "", {}, "sha512-43xS+QYc1X1IPbw03faSgY6I6OYWcLrJRv3hU0+qMOfh/XCHcP0MX2CVjNARYR2cC/guu975sta4OcjlczxD7g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
@@ -2412,6 +2445,10 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-hot-toast": ["react-hot-toast@2.5.2", "", { "dependencies": { "csstype": "^3.1.3", "goober": "^2.1.16" }, "peerDependencies": { "react": ">=16", "react-dom": ">=16" } }, "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw=="],
+
+    "react-icons": ["react-icons@5.5.0", "", { "peerDependencies": { "react": "*" } }, "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw=="],
+
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
@@ -2459,6 +2496,8 @@
     "rehype-slug": ["rehype-slug@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "github-slugger": "^2.0.0", "hast-util-heading-rank": "^3.0.0", "hast-util-to-string": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A=="],
 
     "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -2826,6 +2865,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@alice-and-bot/core/zod": ["zod@3.25.57", "", {}, "sha512-6tgzLuwVST5oLUxXTmBqoinKMd3JeesgbgseXeFasKKj8Q1FCZrHnbqJOyiEvr4cVAlbug+CgIsmJ8cl/pU5FA=="],
+
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "@aws-crypto/crc32/@aws-sdk/types": ["@aws-sdk/types@3.973.5", "", { "dependencies": { "@smithy/types": "^4.13.0", "tslib": "^2.6.2" } }, "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ=="],
@@ -2883,6 +2924,18 @@
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@instantdb/admin/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "@instantdb/admin/eventsource": ["eventsource@4.1.0", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ=="],
+
+    "@instantdb/admin/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "@instantdb/core/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "@instantdb/react/eventsource": ["eventsource@4.1.0", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ=="],
+
+    "@jsr/uri__typed-api/zod": ["zod@3.25.57", "", {}, "sha512-6tgzLuwVST5oLUxXTmBqoinKMd3JeesgbgseXeFasKKj8Q1FCZrHnbqJOyiEvr4cVAlbug+CgIsmJ8cl/pU5FA=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -2986,6 +3039,8 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
@@ -3013,6 +3068,8 @@
     "playwright-bdd/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "posthog-js/dompurify": ["dompurify@3.3.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ=="],
+
+    "posthog-js/preact": ["preact@10.28.4", "", {}, "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ=="],
 
     "prisma/postgres": ["postgres@3.4.7", "", {}, "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="],
 

--- a/idd/modules/sdk/INTENT.md
+++ b/idd/modules/sdk/INTENT.md
@@ -158,6 +158,20 @@ apps/
 | C39 | `readSkill()` fetches references and scripts in parallel where possible                                                                                                          | Performance — skills with many references shouldn't be slow | BDD scenario |
 | C40 | File listing and file reading endpoints enforce visibility checks — private skills return 404 to unauthorized users                                                              | No data leakage of private skill content                    | BDD scenario |
 
+### Dynamic Tool Generator
+
+| #   | Rule                                                                                                                                 | Rationale                                                           | Verified by  |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- | ------------ |
+| C44 | `createSkillTool(client, name)` returns a `SkillTool` with `execute()`, `toOpenAI()`, and `toMCP()`                                  | Framework-agnostic tool generation for any AI agent                 | BDD scenario |
+| C45 | `toOpenAI()` returns `{ type: 'function', function: { name, description, parameters } }` matching the OpenAI function calling schema | Usable with OpenAI, Anthropic, Vercel AI SDK, LangChain             | BDD scenario |
+| C46 | `toMCP()` returns `{ name, description, inputSchema }` matching the MCP tool protocol                                                | Usable with MCP-compatible agents (OpenCode, Cursor, etc.)          | BDD scenario |
+| C47 | Tool `description` includes skill name, version, summary, available files, reference names, and script names                         | Agent can decide whether to use the tool from the description alone | BDD scenario |
+| C48 | `execute({ action: 'read_all' })` returns the full skill content (SKILL.md + references + scripts) equivalent to `readSkill()`       | Single-call complete skill loading via tool interface               | BDD scenario |
+| C49 | `execute({ action: 'list' })` returns all file paths                                                                                 | File discovery via tool interface                                   | BDD scenario |
+| C50 | `execute({ action: 'read', path })` returns a single file's content; returns error if path is missing or not found                   | Targeted file access via tool interface                             | BDD scenario |
+| C51 | `createSkillTools(client, names[])` batch-creates tools for multiple skills with concurrency cap                                     | Agents managing multiple skills need efficient setup                | BDD scenario |
+| C52 | Tool name is derived from skill name: `@org/my-skill` → `org_my_skill` (safe for function names)                                     | Tool names must be valid identifiers in all frameworks              | BDD scenario |
+
 ### Install Pipeline (Phase 4 — TypeScript only at v1)
 
 | #   | Rule                                                                                                                                            | Rationale                             | Verified by  |
@@ -250,6 +264,20 @@ apps/
 | --- | --------------------------------- | --------------------------------------------------------------------------------------- |
 | E18 | `tank.audit("@tank/react")`       | Returns audit result: score (0-10), findings array, stage results                       |
 | E19 | `tank.permissions("@tank/react")` | Returns `Permissions` object: network outbound rules, filesystem paths, subprocess flag |
+
+### Dynamic Tool Generator
+
+| #   | Input                                                       | Expected Output                                                                                                                                    |
+| --- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| E44 | `createSkillTool(client, '@tank/react')`                    | Returns `SkillTool` with name `tank_react`, description containing skill info, files list                                                          |
+| E45 | `tool.toOpenAI()`                                           | Returns `{ type: 'function', function: { name: 'tank_react', description: '...', parameters: { type: 'object', properties: { action, path } } } }` |
+| E46 | `tool.toMCP()`                                              | Returns `{ name: 'tank_react', description: '...', inputSchema: { type: 'object', properties: { action, path } } }`                                |
+| E47 | `tool.execute({ action: 'read_all' })`                      | Returns `{ success: true, skill: { content, references, scripts, files } }`                                                                        |
+| E48 | `tool.execute({ action: 'list' })`                          | Returns `{ success: true, files: ['SKILL.md', 'references/...', ...] }`                                                                            |
+| E49 | `tool.execute({ action: 'read', path: 'SKILL.md' })`        | Returns `{ success: true, content: '# React...' }`                                                                                                 |
+| E50 | `tool.execute({ action: 'read' })` (no path)                | Returns `{ success: false, error: 'path is required...' }`                                                                                         |
+| E51 | `tool.execute({ action: 'read', path: 'nonexistent.md' })`  | Returns `{ success: false, error: 'File not found: nonexistent.md...' }`                                                                           |
+| E52 | `createSkillTools(client, ['@tank/react', '@tank/nextjs'])` | Returns array of 2 `SkillTool` objects                                                                                                             |
 
 ### Install Pipeline (TypeScript SDK)
 

--- a/idd/modules/talk-to-skill/INTENT.md
+++ b/idd/modules/talk-to-skill/INTENT.md
@@ -1,0 +1,55 @@
+# Talk to this Skill
+
+## What
+
+Embedded AI chat on every skill detail page. Users can ask questions about a skill before installing — what it does, whether it's safe, how to use it. Powered by prompt2bot (bot creation) + alice-and-bot (chat UI).
+
+## Why
+
+- Skill discoverability: visitors can interrogate a skill interactively instead of just reading a README
+- Collaboration with prompt2bot (uriva, issue #292) — same integration as agentskills.co.il
+- Trust: talking to a skill-specific bot gives users a second channel to evaluate quality
+
+## Constraints
+
+### Feature gating
+
+- Button + bubble hidden when `PROMPT2BOT_API_TOKEN` env var is unset
+- Feature silently disabled — no error messages, no broken UI
+
+### Bot lifecycle
+
+- One bot per skill version (not per skill)
+- Bot created lazily on first user click, not at publish time
+- Bot never created for a skill version with status != 'published'
+- Bot creation is idempotent — if `prompt2botBotId` exists in DB for this version, reuse it
+- Bot creation failure is non-blocking — return error to client, skill page still works
+
+### Security
+
+- `prompt2botSecret` (Remote Tools Secret) stored in DB but NEVER included in any client-facing query result or API response
+- Only `chatLink` and `botPublicKey` are exposed to the browser
+
+### Attribution
+
+- "Powered by prompt2bot · alice&bot" visible whenever the chat widget is open
+- prompt2bot + alice-and-bot listed on the About page tech stack
+
+### UX
+
+- Desktop: "Talk to this skill" button in the skill header + floating bubble (bottom-right)
+- Mobile: button in the mobile action bar alongside Star + Download
+- Both open the same Dialog overlay with the alice-and-bot Chat component
+- Chat styled to match Tank dark theme (tank-green-ui primary, dark background)
+
+## Examples
+
+| Input                                                    | Expected Output                                                |
+| -------------------------------------------------------- | -------------------------------------------------------------- |
+| Visitor clicks "Talk to this skill" (no bot exists yet)  | API call creates bot → chat opens with bot that knows README   |
+| Visitor clicks "Talk to this skill" (bot already exists) | Chat opens immediately — no API call, no delay                 |
+| `PROMPT2BOT_API_TOKEN` is unset                          | No button, no bubble rendered anywhere                         |
+| Skill has no README, only description                    | Button still shows; bot uses description + metadata as context |
+| Skill page on mobile                                     | Button visible in mobile action bar                            |
+| Bot creation API fails                                   | Error shown to user; skill page continues to work normally     |
+| Attacker inspects network responses                      | `prompt2botSecret` never appears in any response body          |

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -22,6 +22,8 @@ export {
 } from './errors.js';
 
 export * from './install/index.js';
+export type { MCPToolDefinition, OpenAIFunctionTool, SkillTool, SkillToolInput, SkillToolResult } from './tools.js';
+export { createSkillTool, createSkillTools } from './tools.js';
 
 export type {
   DownloadOptions,

--- a/packages/sdk/src/tools.ts
+++ b/packages/sdk/src/tools.ts
@@ -1,0 +1,192 @@
+import type { TankClient } from './client.js';
+import { TankNotFoundError } from './errors.js';
+
+export interface SkillToolInput {
+  action: 'read' | 'list' | 'read_all';
+  path?: string;
+}
+
+export interface SkillToolResult {
+  success: boolean;
+  content?: string;
+  files?: string[];
+  skill?: {
+    content: string;
+    references: Record<string, string>;
+    scripts: Record<string, string>;
+    files: string[];
+  };
+  error?: string;
+}
+
+export interface OpenAIFunctionTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+export interface MCPToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface SkillTool {
+  name: string;
+  skillName: string;
+  version: string;
+  description: string;
+  files: string[];
+  execute(input: SkillToolInput): Promise<SkillToolResult>;
+  toOpenAI(): OpenAIFunctionTool;
+  toMCP(): MCPToolDefinition;
+}
+
+const MAX_TOOL_NAME_LENGTH = 64;
+const MAX_DESCRIPTION_LENGTH = 1024;
+const MAX_FILES_IN_DESCRIPTION = 30;
+const MAX_FILES_IN_ERROR = 10;
+
+function sanitizeToolName(skillName: string): string {
+  const raw = skillName
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .replace(/^_+/, '')
+    .replace(/_+/g, '_');
+  return raw.slice(0, MAX_TOOL_NAME_LENGTH) || 'skill_tool';
+}
+
+function buildParameterSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    required: ['action'],
+    additionalProperties: false,
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['read', 'list', 'read_all'],
+        description:
+          'read: read a single file (requires path). list: list all files. read_all: complete skill with references and scripts.'
+      },
+      path: {
+        type: 'string',
+        description: 'File path to read (required when action is "read"). Example: "SKILL.md", "references/guide.md"'
+      }
+    }
+  };
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 3)}...`;
+}
+
+function buildDescription(skillName: string, version: string, skillDescription: string, files: string[]): string {
+  const refFiles = files.filter((f) => f.startsWith('references/'));
+  const scriptFiles = files.filter((f) => f.startsWith('scripts/'));
+
+  const displayFiles =
+    files.length <= MAX_FILES_IN_DESCRIPTION
+      ? files.join(', ')
+      : `${files.slice(0, MAX_FILES_IN_DESCRIPTION).join(', ')} and ${files.length - MAX_FILES_IN_DESCRIPTION} more`;
+
+  const parts = [
+    `Access the "${skillName}" skill (v${version}).`,
+    truncate(skillDescription, 200),
+    '',
+    'Actions: read_all | list | read (with path)',
+    `Files (${files.length}): ${displayFiles}`
+  ];
+
+  if (refFiles.length > 0) {
+    parts.push(`References: ${refFiles.map((f) => f.replace('references/', '')).join(', ')}`);
+  }
+  if (scriptFiles.length > 0) {
+    parts.push(`Scripts: ${scriptFiles.map((f) => f.replace('scripts/', '')).join(', ')}`);
+  }
+
+  return truncate(parts.join('\n'), MAX_DESCRIPTION_LENGTH);
+}
+
+export async function createSkillTool(client: TankClient, skillName: string, version?: string): Promise<SkillTool> {
+  const info = await client.info(skillName);
+  const ver = version ?? info.latestVersion;
+  if (!ver) throw new TankNotFoundError(`No published versions for ${skillName}`, skillName);
+
+  const files = await client.listFiles(skillName, ver);
+  const filesSet = new Set(files);
+  const toolName = sanitizeToolName(skillName);
+  const description = buildDescription(skillName, ver, info.description ?? '', files);
+  const parameterSchema = buildParameterSchema();
+
+  async function execute(input: SkillToolInput): Promise<SkillToolResult> {
+    try {
+      switch (input.action) {
+        case 'list':
+          return { success: true, files };
+
+        case 'read': {
+          if (!input.path) {
+            return { success: false, error: 'path is required for action "read"' };
+          }
+          if (!filesSet.has(input.path)) {
+            const hint = files.slice(0, MAX_FILES_IN_ERROR).join(', ');
+            const suffix = files.length > MAX_FILES_IN_ERROR ? ` and ${files.length - MAX_FILES_IN_ERROR} more` : '';
+            return { success: false, error: `File not found: ${input.path}. Available: ${hint}${suffix}` };
+          }
+          const content = await client.readFile(skillName, ver, input.path);
+          return { success: true, content };
+        }
+
+        case 'read_all': {
+          const skill = await client.readSkill(skillName, ver);
+          return {
+            success: true,
+            skill: {
+              content: skill.content,
+              references: skill.references,
+              scripts: skill.scripts,
+              files: skill.files
+            }
+          };
+        }
+
+        default:
+          return { success: false, error: `Unknown action: ${String((input as { action: unknown }).action)}` };
+      }
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  return {
+    name: toolName,
+    skillName,
+    version: ver,
+    description,
+    files,
+    execute,
+
+    toOpenAI(): OpenAIFunctionTool {
+      return {
+        type: 'function',
+        function: { name: toolName, description, parameters: parameterSchema }
+      };
+    },
+
+    toMCP(): MCPToolDefinition {
+      return { name: toolName, description, inputSchema: parameterSchema };
+    }
+  };
+}
+
+export async function createSkillTools(client: TankClient, skillNames: string[]): Promise<SkillTool[]> {
+  const tools: SkillTool[] = [];
+  for (let i = 0; i < skillNames.length; i += 6) {
+    const batch = skillNames.slice(i, i + 6);
+    const batchTools = await Promise.all(batch.map((name) => createSkillTool(client, name)));
+    tools.push(...batchTools);
+  }
+  return tools;
+}


### PR DESCRIPTION
## Summary

Adds `createSkillTool()` to the SDK — generates framework-agnostic tool definitions from Tank skills, enabling AI agents to discover and read skills through standard tool interfaces.

### API

```typescript
import { TankClient, createSkillTool } from '@tankpkg/sdk';

const tool = await createSkillTool(client, '@tank/react');

// OpenAI function calling
const response = await openai.chat.completions.create({
  tools: [tool.toOpenAI()],
  messages: [{ role: 'user', content: 'Read the React skill.' }],
});

// Execute the model's tool call
const result = await tool.execute(JSON.parse(call.function.arguments));
// { success: true, skill: { content, references, scripts, files } }
```

### Formats
- `tool.toOpenAI()` — OpenAI/Anthropic/Vercel AI SDK function calling schema
- `tool.toMCP()` — MCP tool protocol schema
- `tool.execute()` — filesystem-like access: `read_all`, `list`, `read`

### Bulletproof
- INTENT.md: C44-C52 constraints, E44-E52 examples
- BDD: 13 Gherkin scenarios in `tool-generator.feature`
- Clean-code review: name validation, bounded descriptions, error normalization
- Demo: OpenAI autonomously calls `read_all`, returns full skill content