### PR TITLE
feat: agentic SDK demo examples

### DIFF
--- a/examples/sdk-demos/README.md
+++ b/examples/sdk-demos/README.md
@@ -1,0 +1,47 @@
+# Tank SDK — Agentic Framework Demos
+
+Each demo shows `createSkillTool()` working with a different AI framework.
+The agent autonomously discovers, reads, and uses Tank skills — zero hand-holding.
+
+## Setup
+
+```bash
+npm install
+```
+
+Requires a running Tank registry at `http://localhost:5555` with at least one published skill.
+
+## Demos
+
+| File | Framework | Loop | Run |
+|------|-----------|------|-----|
+| `demo-openai.mjs` | OpenAI | Manual agentic loop | `OPENAI_API_KEY=... node demo-openai.mjs` |
+| `demo-vercel-ai.mjs` | Vercel AI SDK | Auto (`maxSteps`) | `OPENAI_API_KEY=... node demo-vercel-ai.mjs` |
+| `demo-anthropic.mjs` | Anthropic Claude | Manual agentic loop | `ANTHROPIC_API_KEY=... node demo-anthropic.mjs` |
+| `demo-mcp-server.mjs` | MCP Server | N/A (server) | `node demo-mcp-server.mjs` |
+
+## MCP Server
+
+The MCP demo exposes Tank skills as MCP tools. Connect from any MCP client:
+
+```json
+{
+  "mcpServers": {
+    "tank-skills": {
+      "command": "node",
+      "args": ["/path/to/demo-mcp-server.mjs"],
+      "env": {
+        "TANK_REGISTRY_URL": "http://localhost:5555",
+        "TANK_SKILLS": "@tank/react,@tank/nextjs"
+      }
+    }
+  }
+}
+```
+
+## How It Works
+
+1. `createSkillTool(client, '@org/skill')` fetches skill metadata + file list
+2. Returns a `SkillTool` with `execute()`, `toOpenAI()`, `toMCP()`
+3. Register with any framework — the model autonomously calls the tool
+4. Tool provides filesystem-like access: `read_all`, `list`, `read`

--- a/examples/sdk-demos/demo-anthropic.mjs
+++ b/examples/sdk-demos/demo-anthropic.mjs
@@ -1,0 +1,68 @@
+/**
+ * Anthropic Claude — agentic tool_use loop
+ * Claude autonomously decides which tools to call and when to stop
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import { TankClient, createSkillTool } from '@tankpkg/sdk';
+
+const REGISTRY = 'http://localhost:5555';
+const SKILL = '@e2etest-019e8fc048/sdk-demo-skill';
+
+async function main() {
+  console.log('╔═══════════════════════════════════════════╗');
+  console.log('║  Anthropic Claude — Agentic Tool Use      ║');
+  console.log('╚═══════════════════════════════════════════╝\n');
+
+  const tank = new TankClient({ registryUrl: REGISTRY });
+  const claude = new Anthropic();
+  const skillTool = await createSkillTool(tank, SKILL);
+  const def = skillTool.toOpenAI();
+
+  // Anthropic uses input_schema (snake_case)
+  const tools = [{
+    name: def.function.name,
+    description: def.function.description,
+    input_schema: def.function.parameters,
+  }];
+
+  const messages = [
+    { role: 'user', content: 'Read the skill and tell me everything about it — content, references, scripts.' },
+  ];
+
+  let turn = 0;
+  while (true) {
+    turn++;
+    console.log(`── Turn ${turn} ──`);
+
+    const response = await claude.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 1024,
+      tools,
+      messages,
+    });
+
+    messages.push({ role: 'assistant', content: response.content });
+
+    if (response.stop_reason === 'end_turn') {
+      const text = response.content.find(b => b.type === 'text');
+      console.log(`\n── Final Answer ──\n${text?.text ?? '(no text)'}\n`);
+      break;
+    }
+
+    if (response.stop_reason !== 'tool_use') break;
+
+    const toolResults = [];
+    for (const block of response.content) {
+      if (block.type !== 'tool_use') continue;
+      console.log(`  🔧 ${block.name}(${JSON.stringify(block.input)})`);
+      const result = await skillTool.execute(block.input);
+      console.log(`  ✅ success=${result.success}`);
+      toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: JSON.stringify(result) });
+    }
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  console.log(`✅ Claude — ${turn} turn(s), fully autonomous`);
+}
+
+main().catch(err => { console.error('FATAL:', err.message); process.exit(1); });

--- a/examples/sdk-demos/demo-mcp-server.mjs
+++ b/examples/sdk-demos/demo-mcp-server.mjs
@@ -1,0 +1,54 @@
+/**
+ * MCP Server — exposes Tank skills as MCP tools
+ * Any MCP client (Claude Desktop, Cursor, OpenCode) can connect and use them
+ *
+ * Run: node demo-mcp-server.mjs
+ * Then connect from your MCP client via stdio
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { TankClient, createSkillTool } from '@tankpkg/sdk';
+
+const REGISTRY = process.env.TANK_REGISTRY_URL || 'http://localhost:5555';
+const SKILLS = (process.env.TANK_SKILLS || '@e2etest-019e8fc048/sdk-demo-skill').split(',');
+
+async function main() {
+  console.error('Tank MCP Server starting...');
+  console.error(`Registry: ${REGISTRY}`);
+  console.error(`Skills: ${SKILLS.join(', ')}`);
+
+  const tank = new TankClient({ registryUrl: REGISTRY });
+  const server = new McpServer({ name: 'tank-skills', version: '0.1.0' });
+
+  // Dynamically register each skill as an MCP tool
+  for (const skillName of SKILLS) {
+    console.error(`Loading skill: ${skillName}`);
+    const skillTool = await createSkillTool(tank, skillName.trim());
+
+    server.tool(
+      skillTool.name,
+      skillTool.description,
+      {
+        action: z.enum(['read', 'list', 'read_all']).describe('read: single file. list: all files. read_all: complete skill.'),
+        path: z.string().optional().describe('File path (required for read action)'),
+      },
+      async (args) => {
+        const result = await skillTool.execute(args);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+    );
+
+    console.error(`  ✅ Registered tool: ${skillTool.name} (${skillTool.files.length} files)`);
+  }
+
+  // Connect via stdio — MCP clients pipe JSON-RPC through stdin/stdout
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`\nMCP server running — ${SKILLS.length} skill tool(s) registered`);
+  console.error('Connect from Claude Desktop, Cursor, or OpenCode via stdio');
+}
+
+main().catch(err => { console.error('FATAL:', err.message); process.exit(1); });

--- a/examples/sdk-demos/demo-openai.mjs
+++ b/examples/sdk-demos/demo-openai.mjs
@@ -1,0 +1,56 @@
+/**
+ * OpenAI — agentic function calling loop
+ * Model autonomously calls tools until it has enough info
+ */
+import OpenAI from 'openai';
+import { TankClient, createSkillTool } from '@tankpkg/sdk';
+
+const REGISTRY = 'http://localhost:5555';
+const SKILL = '@e2etest-019e8fc048/sdk-demo-skill';
+
+async function main() {
+  console.log('╔═══════════════════════════════════════════╗');
+  console.log('║  OpenAI — Agentic Function Calling        ║');
+  console.log('╚═══════════════════════════════════════════╝\n');
+
+  const tank = new TankClient({ registryUrl: REGISTRY });
+  const openai = new OpenAI();
+  const skillTool = await createSkillTool(tank, SKILL);
+
+  const messages = [
+    { role: 'system', content: 'Use tools to read skills. Always read the full skill before answering.' },
+    { role: 'user', content: 'What does this skill do? Read everything and summarize.' },
+  ];
+
+  let turn = 0;
+  while (true) {
+    turn++;
+    console.log(`── Turn ${turn} ──`);
+
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      tools: [skillTool.toOpenAI()],
+      messages,
+    });
+
+    const choice = response.choices[0];
+
+    if (choice.finish_reason === 'tool_calls' && choice.message.tool_calls?.length) {
+      messages.push(choice.message);
+      for (const call of choice.message.tool_calls) {
+        console.log(`  🔧 ${call.function.name}(${call.function.arguments})`);
+        const result = await skillTool.execute(JSON.parse(call.function.arguments));
+        console.log(`  ✅ success=${result.success}`);
+        messages.push({ role: 'tool', tool_call_id: call.id, content: JSON.stringify(result) });
+      }
+      continue;
+    }
+
+    console.log(`\n── Final Answer ──\n${choice.message.content}\n`);
+    break;
+  }
+
+  console.log(`✅ OpenAI — ${turn} turn(s), fully autonomous`);
+}
+
+main().catch(err => { console.error('FATAL:', err.message); process.exit(1); });

--- a/examples/sdk-demos/demo-vercel-ai.mjs
+++ b/examples/sdk-demos/demo-vercel-ai.mjs
@@ -1,0 +1,55 @@
+import { generateText, tool, jsonSchema } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { TankClient, createSkillTool } from '@tankpkg/sdk';
+
+const REGISTRY = 'http://localhost:5555';
+const SKILL = '@e2etest-019e8fc048/sdk-demo-skill';
+
+async function main() {
+  console.log('╔═══════════════════════════════════════════╗');
+  console.log('║  Vercel AI SDK — Agentic Tool Use Demo   ║');
+  console.log('╚═══════════════════════════════════════════╝\n');
+
+  const client = new TankClient({ registryUrl: REGISTRY });
+  const openai = createOpenAI();
+  const skillTool = await createSkillTool(client, SKILL);
+
+  const tankTool = tool({
+    description: skillTool.description,
+    parameters: jsonSchema({
+      type: 'object',
+      required: ['action'],
+      additionalProperties: false,
+      properties: {
+        action: { type: 'string', enum: ['read', 'list', 'read_all'] },
+        path: { type: ['string', 'null'] },
+      },
+      strict: true,
+    }),
+    execute: async (args) => skillTool.execute(args),
+  });
+
+  const { text, steps } = await generateText({
+    model: openai.responses('gpt-4o-mini'),
+    tools: { [skillTool.name]: tankTool },
+    maxSteps: 5,
+    system: 'Use the available tool to read skills and answer questions.',
+    prompt: 'What does this skill do? Read everything and summarize.',
+  });
+
+  console.log(`Completed in ${steps.length} step(s):\n`);
+  for (const [i, step] of steps.entries()) {
+    console.log(`  Step ${i + 1}:`);
+    if (step.toolCalls?.length) {
+      for (const call of step.toolCalls) {
+        console.log(`    🔧 ${call.toolName}(${JSON.stringify(call.args)})`);
+      }
+    }
+    if (step.text) console.log(`    💬 ${step.text.slice(0, 80)}...`);
+  }
+
+  console.log(`\n── Final Answer ──\n${text}\n`);
+  console.log('✅ Vercel AI SDK — maxSteps handled the full agentic loop');
+}
+
+main().catch(err => { console.error('FATAL:', err.message); process.exit(1); });

--- a/packages/sdk/src/tools.ts
+++ b/packages/sdk/src/tools.ts
@@ -52,7 +52,7 @@ const MAX_FILES_IN_ERROR = 10;
 
 function sanitizeToolName(skillName: string): string {
   const raw = skillName
-    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .replace(/[^a-zA-Z0-9_]/g, '_')
     .replace(/^_+/, '')
     .replace(/_+/g, '_');
   return raw.slice(0, MAX_TOOL_NAME_LENGTH) || 'skill_tool';


### PR DESCRIPTION
## Summary

Adds working agentic demo examples for the SDK tool generator, plus a tool name sanitization fix.

### Demos (`examples/sdk-demos/`)

| File | Framework | Status |
|------|-----------|--------|
| `demo-openai.mjs` | OpenAI function calling | Proven — model autonomously calls `read_all`, synthesizes answer |
| `demo-anthropic.mjs` | Anthropic Claude tool_use | Ready — needs `ANTHROPIC_API_KEY` |
| `demo-mcp-server.mjs` | MCP Server (stdio) | Proven — registers skills as MCP tools |
| `demo-vercel-ai.mjs` | Vercel AI SDK | Blocked — AI SDK v3 Responses API schema compat issue |

### Fix

`sanitizeToolName` now strips hyphens — OpenAI function names require `^[a-zA-Z0-9_]+$`.