### PR TITLE
fix: auto-run DB migrations on every deploy (Vercel + Docker)

### DIFF
--- a/infra/docker-compose.onprem.yml
+++ b/infra/docker-compose.onprem.yml
@@ -91,6 +91,7 @@ services:
       S3_REGION: ${S3_REGION:-us-east-1}
       PYTHON_API_URL: http://scanner:8000
       TANK_MODE: selfhosted
+      AUTO_MIGRATE: "true"
       FIRST_ADMIN_EMAIL: ${FIRST_ADMIN_EMAIL:-}
       FIRST_ADMIN_PASSWORD: ${FIRST_ADMIN_PASSWORD:-}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}

--- a/infra/docker-compose.production.yml
+++ b/infra/docker-compose.production.yml
@@ -114,6 +114,7 @@ services:
       EMAIL_FROM: ${EMAIL_FROM:-no-reply@tank.local}
       FIRST_ADMIN_EMAIL: ${FIRST_ADMIN_EMAIL:-}
       TANK_MODE: selfhosted
+      AUTO_MIGRATE: "true"
     depends_on:
       postgres:
         condition: service_healthy

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "buildCommand": "NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
+  "buildCommand": "cd apps/registry && bunx drizzle-kit push --force && cd ../.. && NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
   "installCommand": "bun install",
   "devCommand": "bun --filter registry run dev"
 }


### PR DESCRIPTION
## Summary

- **Vercel**: add `drizzle-kit push --force` to `buildCommand` in `vercel.json` — runs before every build
- **Docker production**: enable `AUTO_MIGRATE=true` in `docker-compose.production.yml`
- **Docker on-prem**: enable `AUTO_MIGRATE=true` in `docker-compose.onprem.yml`

## Problem

DB migrations were **never triggered** during deployments. Schema changes in `schema.ts` (new tables, new columns) were not applied to the production database, causing:

- `dep_audit_results` table missing → skill detail page 500 error
- `system_config` table missing
- `prompt2bot_*` columns missing on `skill_versions`

Only CI tests ran migrations (against a throwaway test DB). Production, nightly, and on-prem deploys had zero migration steps.

## How it works

- **Vercel**: `drizzle-kit push --force` runs during `buildCommand`, before the app compiles. `DATABASE_URL` is already available in Vercel env vars.
- **Docker**: `entrypoint.sh` already checks `AUTO_MIGRATE=true` and runs `drizzle-kit push --force` on container startup. The compose files just weren't enabling it.
- `drizzle-kit push --force` is idempotent — safe to run on every deploy even when schema hasn't changed.