### PR TITLE
fix: switch DB migrations from push to migrate (no TTY required)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Ensure pg_trgm extension
         run: bun scripts/ensure-pg-trgm.mjs
 
-      - name: Push DB schema
-        run: cd apps/registry && bunx drizzle-kit push --force
+      - name: Run DB migrations
+        run: cd apps/registry && bunx drizzle-kit migrate

--- a/apps/registry/drizzle/0014_add_prompt2bot_depaudit_sysconfig.sql
+++ b/apps/registry/drizzle/0014_add_prompt2bot_depaudit_sysconfig.sql
@@ -1,0 +1,54 @@
+-- prompt2bot columns on skill_versions
+ALTER TABLE "skill_versions" ADD COLUMN IF NOT EXISTS "prompt2bot_bot_id" text;
+ALTER TABLE "skill_versions" ADD COLUMN IF NOT EXISTS "prompt2bot_chat_link" text;
+ALTER TABLE "skill_versions" ADD COLUMN IF NOT EXISTS "prompt2bot_bot_public_key" text;
+ALTER TABLE "skill_versions" ADD COLUMN IF NOT EXISTS "prompt2bot_secret" text;
+
+-- dep_audit_results table
+CREATE TABLE IF NOT EXISTS "dep_audit_results" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "version_id" uuid NOT NULL REFERENCES "skill_versions"("id"),
+  "ecosystem" text NOT NULL,
+  "package_count" integer NOT NULL DEFAULT 0,
+  "vulnerable_count" integer NOT NULL DEFAULT 0,
+  "vuln_summary" jsonb,
+  "packages" jsonb,
+  "tldr" text,
+  "health_score" real,
+  "sources_queried" jsonb,
+  "status" text NOT NULL DEFAULT 'pending',
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "dep_audit_results_version_id_created_at_idx" ON "dep_audit_results" ("version_id", "created_at");
+
+-- system_config table (on-prem setup wizard)
+CREATE TABLE IF NOT EXISTS "system_config" (
+  "id" integer PRIMARY KEY DEFAULT 1,
+  "setup_completed" boolean NOT NULL DEFAULT false,
+  "instance_url" text,
+  "auth_secret" text,
+  "storage_backend" text DEFAULT 's3',
+  "storage_endpoint" text,
+  "storage_region" text,
+  "storage_bucket" text,
+  "storage_access_key" text,
+  "storage_secret_key_enc" text,
+  "storage_public_endpoint" text,
+  "supabase_url" text,
+  "supabase_service_key_enc" text,
+  "scanner_provider" text DEFAULT 'disabled',
+  "scanner_api_key_enc" text,
+  "scanner_base_url" text,
+  "scanner_model" text,
+  "scanner_litellm_url" text,
+  "github_enabled" boolean NOT NULL DEFAULT false,
+  "github_client_id" text,
+  "github_client_secret_enc" text,
+  "oidc_enabled" boolean NOT NULL DEFAULT false,
+  "oidc_discovery_url" text,
+  "oidc_client_id" text,
+  "oidc_client_secret_enc" text,
+  "oidc_provider_id" text DEFAULT 'enterprise-oidc',
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/registry/drizzle/meta/_journal.json
+++ b/apps/registry/drizzle/meta/_journal.json
@@ -92,6 +92,20 @@
       "when": 1774000000000,
       "tag": "0012_add_apikey_reference_config",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1774100000000,
+      "tag": "0013_scan_schema_columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1774200000000,
+      "tag": "0014_add_prompt2bot_depaudit_sysconfig",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/registry/scripts/entrypoint.sh
+++ b/apps/registry/scripts/entrypoint.sh
@@ -16,9 +16,9 @@ fi
 if [ "$AUTO_MIGRATE" = "true" ]; then
   echo "[Tank] AUTO_MIGRATE=true — running headless setup..."
 
-  echo "[Tank] Pushing database schema..."
-  bun ./node_modules/drizzle-kit/bin.cjs push --force --config=drizzle.config.js 2>&1 || {
-    echo "[Tank] ERROR: Schema push failed. Is DATABASE_URL correct?"
+  echo "[Tank] Running database migrations..."
+  bun ./node_modules/drizzle-kit/bin.cjs migrate --config=drizzle.config.js 2>&1 || {
+    echo "[Tank] ERROR: Migration failed. Is DATABASE_URL correct?"
     exit 1
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "buildCommand": "cd apps/registry && bunx drizzle-kit push --force && cd ../.. && NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
+  "buildCommand": "cd apps/registry && bunx drizzle-kit migrate && cd ../.. && NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
   "installCommand": "bun install",
   "devCommand": "bun --filter registry run dev"
 }


### PR DESCRIPTION
## Summary

- Switch all 3 migration callsites from `drizzle-kit push --force` to `drizzle-kit migrate`
- Add migration `0014` with missing schema (prompt2bot columns, dep_audit_results, system_config)
- Register migrations 0013 + 0014 in the drizzle journal

## Root cause

`drizzle-kit push --force` still calls `promptNamedWithSchemasConflict` when it detects ambiguous schema changes (table/column renames vs additions). This prompt requires an interactive TTY, which silently fails in:
- **Vercel builds** → migration never ran, app deployed with stale schema
- **GitHub Actions** → `ECONNREFUSED` (separate issue) but would also hit TTY error
- **Docker entrypoint** → same TTY failure in non-interactive containers

## Fix

`drizzle-kit migrate` runs committed SQL files sequentially without any interactive prompts. It tracks applied migrations in a `__drizzle_migrations` journal table. All SQL uses `IF NOT EXISTS` / `IF NOT EXISTS` so it's idempotent against databases where the schema was already applied manually.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/db-migrate.yml` | `push --force` → `migrate` |
| `vercel.json` | `push --force` → `migrate` |
| `apps/registry/scripts/entrypoint.sh` | `push --force` → `migrate` |
| `apps/registry/drizzle/0014_*.sql` | New migration: prompt2bot, dep_audit_results, system_config |
| `apps/registry/drizzle/meta/_journal.json` | Register entries 13 + 14 |