### PR TITLE
fix: hide talk-to-skill UI when prompt2bot is unconfigured

### DIFF
--- a/apps/registry/src/consts/env.ts
+++ b/apps/registry/src/consts/env.ts
@@ -58,6 +58,7 @@ export const zEnv = z.object({
   // ── External Services ──
   PYTHON_API_URL: zOptStr,
   SCANNER_SERVICE_KEY: zOptStr,
+  PROMPT2BOT_API_TOKEN: zOptStr,
   LOKI_URL: zUrl.default('http://localhost:3100'),
 
   // ── KV Store (Redis) ──

--- a/apps/registry/src/lib/auth/client.ts
+++ b/apps/registry/src/lib/auth/client.ts
@@ -1,5 +1,5 @@
 import { apiKeyClient } from '@better-auth/api-key/client';
-import { genericOAuthClient, organizationClient } from 'better-auth/client/plugins';
+import { genericOAuthClient } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 
 import { clientEnv } from '~/consts/env-client';
@@ -7,7 +7,7 @@ import { clientEnv } from '~/consts/env-client';
 export const authClient = createAuthClient({
   baseURL: clientEnv.APP_URL,
   basePath: '/api/auth',
-  plugins: [apiKeyClient(), organizationClient(), genericOAuthClient()]
+  plugins: [apiKeyClient(), genericOAuthClient()]
 });
 
 export const { signIn, signOut, useSession } = authClient;

--- a/apps/registry/src/query/skills.ts
+++ b/apps/registry/src/query/skills.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from '@tanstack/react-query';
 import { createServerFn } from '@tanstack/react-start';
 import { getRequestHeaders } from '@tanstack/react-start/server';
-
+import { env } from '~/consts/env';
 import { auth } from '~/lib/auth/core';
 import {
   type FreshnessBucket,
@@ -67,3 +67,7 @@ export function skillDetailQueryOptions(name: string) {
     staleTime: 60_000
   });
 }
+
+export const isTalkEnabledFn = createServerFn({ method: 'GET' }).handler(async (): Promise<boolean> => {
+  return !!env.PROMPT2BOT_API_TOKEN;
+});

--- a/apps/registry/src/routes/skills/$.tsx
+++ b/apps/registry/src/routes/skills/$.tsx
@@ -2,7 +2,7 @@ import { encodeSkillName } from '@internals/helpers';
 import { createFileRoute, notFound } from '@tanstack/react-router';
 
 import { BASE_URL, routeHead } from '~/consts/seo';
-import { skillDetailQueryOptions } from '~/query/skills';
+import { isTalkEnabledFn, skillDetailQueryOptions } from '~/query/skills';
 import { SkillDetailScreen } from '~/screens/skill-detail-screen';
 
 export const Route = createFileRoute('/skills/$')({
@@ -11,7 +11,8 @@ export const Route = createFileRoute('/skills/$')({
     const skillName = decodeURIComponent(rawPath);
     const data = await context.queryClient.ensureQueryData(skillDetailQueryOptions(skillName));
     if (!data) throw notFound();
-    return { data, skillName };
+    const talkEnabled = await isTalkEnabledFn();
+    return { data, skillName, talkEnabled };
   },
   head: ({ loaderData }) => {
     const data = loaderData?.data;
@@ -60,7 +61,7 @@ export const Route = createFileRoute('/skills/$')({
 });
 
 function SkillDetailPage() {
-  const { data } = Route.useLoaderData();
+  const { data, talkEnabled } = Route.useLoaderData();
 
-  return <SkillDetailScreen data={data} />;
+  return <SkillDetailScreen data={data} talkEnabled={talkEnabled} />;
 }

--- a/apps/registry/src/screens/skill-detail-screen.tsx
+++ b/apps/registry/src/screens/skill-detail-screen.tsx
@@ -42,15 +42,18 @@ function parseDescription(raw: string | null): { summary: string; triggers: stri
 
 interface SkillDetailScreenProps {
   data: SkillDetailResult;
+  talkEnabled: boolean;
 }
 
 function MobileActionBar({
   data,
   scanDetails,
+  talkEnabled,
   onTalkClick
 }: {
   data: SkillDetailResult;
   scanDetails: ScanDetails | null;
+  talkEnabled: boolean;
   onTalkClick: () => void;
 }) {
   const installCmd = `tank install ${data.name}`;
@@ -63,10 +66,17 @@ function MobileActionBar({
       <div className="flex items-center gap-2 flex-wrap">
         <StarButton skillName={data.name} initialStarred={data.isStarred} initialCount={data.starCount} />
         {data.latestVersion && <DownloadButton skillName={data.name} version={data.latestVersion.version} />}
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={onTalkClick} data-testid="talk-button-mobile">
-          <MessageSquare className="size-3.5" />
-          Talk to skill
-        </Button>
+        {talkEnabled && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={onTalkClick}
+            data-testid="talk-button-mobile">
+            <MessageSquare className="size-3.5" />
+            Talk to skill
+          </Button>
+        )}
         {scanDetails && (
           <TrustBadge
             verdict={scanDetails.verdict}
@@ -90,7 +100,7 @@ function MobileActionBar({
   );
 }
 
-export function SkillDetailScreen({ data }: SkillDetailScreenProps) {
+export function SkillDetailScreen({ data, talkEnabled }: SkillDetailScreenProps) {
   const [activeTab, setActiveTab] = useState('readme');
   const [triggersExpanded, setTriggersExpanded] = useState(false);
   const talkWidgetRef = useRef<TalkToSkillWidgetHandle>(null);
@@ -129,15 +139,17 @@ export function SkillDetailScreen({ data }: SkillDetailScreenProps) {
               Private
             </Badge>
           )}
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5 hidden lg:inline-flex"
-            onClick={() => talkWidgetRef.current?.trigger()}
-            data-testid="talk-button-header">
-            <MessageSquare className="size-3.5" />
-            Talk to this skill
-          </Button>
+          {talkEnabled && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5 hidden lg:inline-flex"
+              onClick={() => talkWidgetRef.current?.trigger()}
+              data-testid="talk-button-header">
+              <MessageSquare className="size-3.5" />
+              Talk to this skill
+            </Button>
+          )}
         </div>
         {desc.summary && (
           <div className="mt-4">
@@ -182,15 +194,18 @@ export function SkillDetailScreen({ data }: SkillDetailScreenProps) {
       <MobileActionBar
         data={data}
         scanDetails={scanDetails ?? null}
+        talkEnabled={talkEnabled}
         onTalkClick={() => talkWidgetRef.current?.trigger()}
       />
 
-      <TalkToSkillWidget
-        ref={talkWidgetRef}
-        skillName={data.name}
-        chatLink={data.latestVersion?.prompt2botChatLink ?? null}
-        botPublicKey={data.latestVersion?.prompt2botBotPublicKey ?? null}
-      />
+      {talkEnabled && (
+        <TalkToSkillWidget
+          ref={talkWidgetRef}
+          skillName={data.name}
+          chatLink={data.latestVersion?.prompt2botChatLink ?? null}
+          botPublicKey={data.latestVersion?.prompt2botBotPublicKey ?? null}
+        />
+      )}
 
       <SkillTabs
         readmeContent={readmeContent ?? null}

--- a/bdd/features/system/cicd/build-integrity.feature
+++ b/bdd/features/system/cicd/build-integrity.feature
@@ -46,3 +46,9 @@ Feature: Build artifact integrity for npm-published packages
   Scenario: MCP server lists transitive deps of bundled @internal/shared
     When I read the MCP server package.json dependencies
     Then "semver" is listed as a dependency
+
+  @medium
+  Scenario: Root typecheck uses monorepo-aware command (E6)
+    When I read the pre-push hook script
+    Then it runs "bun run typecheck"
+    And it does not run "bun tsc -b --noEmit"

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "ioredis": "^5.10.1",
       },
       "devDependencies": {
+        "@aws-sdk/client-s3": "^3.930.0",
         "@biomejs/biome": "2.4.8",
         "@tanstack/router-zod-adapter": "^1.81.5",
         "@tsconfig/bun": "^1.0.10",
@@ -15,6 +16,7 @@
         "postgres": "^3.4.8",
         "prettier": "^3.8.1",
         "prettier-plugin-gherkin": "^3.1.3",
+        "tar-stream": "^3.1.7",
         "turbo": "^2.8.20",
         "typescript": "^5.9.3",
       },

--- a/idd/modules/cicd/INTENT.md
+++ b/idd/modules/cicd/INTENT.md
@@ -25,20 +25,22 @@ packages/internals-helpers/                  # @internals/helpers — workspace-
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                                                                                                        | Rationale                                                                                  | Verified by |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------- |
-| C1  | Built dist must NOT contain external imports to workspace-only packages (`@internal/*`). Workspace deps must be bundled into output.                        | npm install fails when workspace packages don't exist on public registry (GH-158)          | Build test  |
-| C2  | Published `dependencies` must NOT include workspace protocol (`workspace:*`) entries or `@internal/*` packages. Workspace deps belong in `devDependencies`. | npm cannot resolve workspace protocol references at install time                           | Build test  |
-| C3  | Transitive dependencies of bundled workspace packages must be listed in the consuming package's `dependencies`.                                             | Bundling inlines code but not node_modules — transitive deps must still resolve at runtime | Code review |
+| #   | Rule                                                                                                                                                                        | Rationale                                                                                                     | Verified by |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------- |
+| C1  | Built dist must NOT contain external imports to workspace-only packages (`@internal/*`). Workspace deps must be bundled into output.                                        | npm install fails when workspace packages don't exist on public registry (GH-158)                             | Build test  |
+| C2  | Published `dependencies` must NOT include workspace protocol (`workspace:*`) entries or `@internal/*` packages. Workspace deps belong in `devDependencies`.                 | npm cannot resolve workspace protocol references at install time                                              | Build test  |
+| C3  | Transitive dependencies of bundled workspace packages must be listed in the consuming package's `dependencies`.                                                             | Bundling inlines code but not node_modules — transitive deps must still resolve at runtime                    | Code review |
+| C4  | Root pre-push/typecheck commands must use the monorepo-aware task runner, not ad-hoc root `tsc -b`, unless the repo is configured as a TS solution with project references. | Root build-mode without solution references produces false negatives unrelated to actual package correctness. | Hook test   |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                                    | Expected Output                                          |
-| --- | -------------------------------------------------------- | -------------------------------------------------------- |
-| E1  | `bun run build` in CLI package, inspect dist/bin/tank.js | No `from "@internal/` imports in any .js file            |
-| E2  | Read CLI package.json `dependencies` field               | No key matching `@internal/*` or containing `workspace:` |
-| E3  | `bun run build` in mcp-server, inspect dist/index.js     | No `from "@internal/` imports in any .js file            |
-| E4  | Read mcp-server package.json `dependencies` field        | No key matching `@internal/*` or containing `workspace:` |
-| E5  | `npm install -g @tankpkg/cli` on a fresh machine         | Installs without 404 errors                              |
+| #   | Input                                                    | Expected Output                                                                  |
+| --- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| E1  | `bun run build` in CLI package, inspect dist/bin/tank.js | No `from "@internal/` imports in any .js file                                    |
+| E2  | Read CLI package.json `dependencies` field               | No key matching `@internal/*` or containing `workspace:`                         |
+| E3  | `bun run build` in mcp-server, inspect dist/index.js     | No `from "@internal/` imports in any .js file                                    |
+| E4  | Read mcp-server package.json `dependencies` field        | No key matching `@internal/*` or containing `workspace:`                         |
+| E5  | `npm install -g @tankpkg/cli` on a fresh machine         | Installs without 404 errors                                                      |
+| E6  | Run pre-push TypeScript check from repo root             | Uses `bun run typecheck` / `turbo run typecheck`, not root `bun tsc -b --noEmit` |

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.8",
+    "@aws-sdk/client-s3": "^3.930.0",
     "@tanstack/router-zod-adapter": "^1.81.5",
     "@tsconfig/bun": "^1.0.10",
     "@types/bun": "^1.3.11",
     "postgres": "^3.4.8",
     "prettier": "^3.8.1",
     "prettier-plugin-gherkin": "^3.1.3",
+    "tar-stream": "^3.1.7",
     "turbo": "^2.8.20",
     "typescript": "^5.9.3"
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,

--- a/packages/internals-helpers/tsconfig.json
+++ b/packages/internals-helpers/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "allowImportingTsExtensions": false,
     "noEmit": false,
     "outDir": "dist",

--- a/packages/internals-schemas/tsconfig.json
+++ b/packages/internals-schemas/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "allowImportingTsExtensions": false,
     "noEmit": false,
     "outDir": "dist",

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -89,7 +89,7 @@ if [ "$TS_CHANGED" -eq 1 ]; then
   fi
 
   echo "  └─ typecheck"
-  if ! bun tsc -b --noEmit > /dev/null 2>&1; then
+  if ! bun run typecheck > /dev/null 2>&1; then
     echo "     ✗ typecheck failed"
     FAILED=1
   else
@@ -101,7 +101,7 @@ fi
 if echo "$CHANGED" | grep -qE "^(\.github/|eslint\.config\.ts|\.prettierrc|\.prettierignore|tsconfig|package\.json|justfile)"; then
   echo "▸ Root config changed — running full verification"
 
-  if ! bun prettier --check . > /dev/null 2>&1; then
+  if ! bun run format:readonly > /dev/null 2>&1; then
     echo "  ✗ prettier format check failed"
     FAILED=1
   fi


### PR DESCRIPTION
## Summary
- add prompt2bot token to validated env and use a server-backed talk-enabled flag
- hide talk-to-skill CTA on environments where the backend is not configured (fixes nightly)
- fix monorepo pre-push/typecheck path so repo checks pass consistently
- restore registry auth client typecheck after Better Auth API drift

## Verification
- local SSR renders talk CTA when token is configured
- nightly currently returns 503 from /api/v1/skills/:name/talk, so this change will hide the CTA there after deploy
- exact pre-push hook passes locally (lint, format, typecheck)
