### PR TITLE
fix: dark-mode prose code blocks and inline code styling

### DIFF
--- a/apps/registry/src/styles/global.css
+++ b/apps/registry/src/styles/global.css
@@ -500,7 +500,7 @@
 
   & pre {
     overflow-x: auto;
-    border-radius: 0.25rem;
+    border-radius: 0.5rem;
     padding: 0.875em 1.25em;
     font-size: 0.875em;
     line-height: 1.7;
@@ -508,12 +508,13 @@
     margin-bottom: 1.7em;
     background: oklch(0.968 0.007 155);
     color: oklch(0.208 0.042 155);
+    border: 1px solid oklch(0.9 0.02 155);
   }
 
   & :not(pre) > code {
     background: oklch(0.95 0.01 155);
     padding: 0.2em 0.4em;
-    border-radius: 0.25rem;
+    border-radius: 0.375rem;
     color: oklch(0.4 0.12 155);
     font-size: 0.85em;
     border: 1px solid oklch(0.9 0.02 155);
@@ -528,6 +529,8 @@
     background: transparent;
     padding: 0;
     border-radius: 0;
+    border: none;
+    color: inherit;
   }
 
   & pre code span {
@@ -629,9 +632,9 @@
 }
 
 /* ============================================================
-   DARK PROSE INVERT
+   DARK PROSE
    ============================================================ */
-.dark .prose.prose-invert {
+.dark .prose {
   & a {
     color: oklch(0.929 0.013 155);
   }
@@ -639,14 +642,16 @@
     background: oklch(0.22 0.03 155);
   }
   & pre {
-    background: oklch(0.08 0.008 155);
+    background: oklch(0.1 0.008 155);
     color: oklch(0.93 0.008 155);
+    border-color: oklch(0.18 0.014 155);
   }
   & :not(pre) > code {
-    background: oklch(0.14 0.008 155);
+    background: oklch(0.13 0.008 155);
     color: oklch(0.85 0.05 155);
-    padding: 0.15em 0.35em;
-    border-radius: 0.125rem;
+    border: 1px solid oklch(0.2 0.014 155);
+    padding: 0.2em 0.4em;
+    border-radius: 0.375rem;
   }
   & pre code,
   & pre code span {


### PR DESCRIPTION
## Summary
- Fix dark-mode code styling that was never applying to skill READMEs
- The selector `.dark .prose.prose-invert` never matched because `dark:prose-invert` is a no-op in Tailwind v4 without `@tailwindcss/typography` — changed to `.dark .prose`
- Improved code surface styling: darker backgrounds, visible borders, consistent border-radius for both inline code and code blocks