### PR TITLE
fix(ci): build SDK before CLI bundle in release pipeline

### DIFF
--- a/justfile
+++ b/justfile
@@ -344,6 +344,7 @@ ci-build-cli VERSION:
     just bump {{VERSION}}
     just build internals-schemas
     just build internals-helpers
+    just build sdk
     just build cli
     just build mcp
 


### PR DESCRIPTION
CLI imports @tankpkg/sdk but ci-build-cli never built it, causing release binary builds to fail.