### PR TITLE
fix(scan): external skill URLs, detect-secrets evidence, and findings display

### DIFF
--- a/apps/python-api/lib/scan/stage4_secrets.py
+++ b/apps/python-api/lib/scan/stage4_secrets.py
@@ -128,7 +128,13 @@ def run_detect_secrets(temp_dir: str) -> list[Finding]:
     try:
         import detect_secrets
 
-        logger.info("detect-secrets version: %s", getattr(detect_secrets, "__version__", "unknown"))
+        try:
+            from importlib.metadata import version as pkg_version
+
+            ds_version = pkg_version("detect-secrets")
+        except Exception:
+            ds_version = getattr(detect_secrets, "__version__", "unknown")
+        logger.info("detect-secrets version: %s", ds_version)
 
         from detect_secrets.core.scan import get_files_to_scan, scan_file
         from detect_secrets.settings import transient_settings
@@ -162,17 +168,33 @@ def run_detect_secrets(temp_dir: str) -> list[Finding]:
                 try:
                     for secret in scan_file(abs_path):
                         rel_path = file_path
-                        findings.append(
-                            Finding(
-                                stage="stage4",
-                                severity="critical",
-                                type=f"secret_{secret.type}",
-                                description=f"Secret detected: {secret.type}",
-                                location=f"{rel_path}:{secret.line_number}",
-                                confidence=0.9,
-                                tool="detect-secrets",
-                            )
+
+                        # Read the matched line for evidence
+                        evidence_text = ""
+                        try:
+                            with open(abs_path, encoding="utf-8", errors="replace") as f:
+                                lines = f.readlines()
+                                if 0 < secret.line_number <= len(lines):
+                                    evidence_text = lines[secret.line_number - 1].strip()[:200]
+                        except Exception:
+                            pass
+
+                        finding = Finding(
+                            stage="stage4",
+                            severity="critical",
+                            type=f"secret_{secret.type}",
+                            description=f"Secret detected: {secret.type}",
+                            location=f"{rel_path}:{secret.line_number}",
+                            confidence=0.9,
+                            tool="detect-secrets",
+                            evidence=evidence_text or None,
                         )
+
+                        # Downgrade severity for files in example/doc paths
+                        if _is_example_path(rel_path):
+                            finding.severity = "info"
+
+                        findings.append(finding)
                 except Exception as file_error:
                     logger.warning("detect-secrets file scan error: %s", file_error)
 

--- a/apps/registry/src/components/skills/findings-table.test.tsx
+++ b/apps/registry/src/components/skills/findings-table.test.tsx
@@ -29,16 +29,16 @@ describe('resolveExpandable', () => {
     expect(result.expandedText).toBe(evidence);
   });
 
-  it('long description (>100 chars) without evidence → expandable with frontend truncation', () => {
-    const desc = 'A'.repeat(150);
+  it('long description (>150 chars) without evidence → expandable with frontend truncation', () => {
+    const desc = 'A'.repeat(200);
     const result = resolveExpandable(desc, null);
     expect(result.expandable).toBe(true);
-    expect(result.collapsedText).toBe(`${'A'.repeat(100)}…`);
+    expect(result.collapsedText).toBe(`${'A'.repeat(150)}…`);
     expect(result.expandedText).toBe(desc);
   });
 
   it('long description with shorter evidence → expands to full description, not evidence', () => {
-    const desc = 'A'.repeat(150);
+    const desc = 'A'.repeat(200);
     const result = resolveExpandable(desc, 'short');
     expect(result.expandable).toBe(true);
     expect(result.expandedText).toBe(desc);
@@ -127,12 +127,12 @@ describe('FindingsTable', () => {
     expect(screen.getByText('Matched injection pattern: You must always follow t...')).toBeTruthy();
   });
 
-  it('shows expand button for long descriptions and truncates at 100 chars', () => {
-    const longDesc = 'A'.repeat(150);
+  it('shows expand button for long descriptions and truncates at 150 chars', () => {
+    const longDesc = 'A'.repeat(200);
     const findings = [makeFinding({ description: longDesc, evidence: null })];
     render(<FindingsTable findings={findings} />);
 
-    expect(screen.getByText(`${'A'.repeat(100)}…`)).toBeTruthy();
+    expect(screen.getByText(`${'A'.repeat(150)}…`)).toBeTruthy();
     const btn = screen.getByText('Show more');
 
     fireEvent.click(btn);

--- a/apps/registry/src/components/skills/findings-table.tsx
+++ b/apps/registry/src/components/skills/findings-table.tsx
@@ -25,7 +25,7 @@ const severityDot: Record<string, string> = {
   info: 'bg-muted-foreground'
 };
 
-const TRUNCATE_LENGTH = 100;
+const TRUNCATE_LENGTH = 150;
 
 const LLM_VERDICT_STYLES: Record<string, { label: string; className: string }> = {
   confirmed_threat: { label: 'Confirmed', className: 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400' },

--- a/apps/registry/src/lib/db/index.ts
+++ b/apps/registry/src/lib/db/index.ts
@@ -27,6 +27,7 @@ export const sql = new Proxy({} as ReturnType<typeof postgres>, {
   },
   apply(_, _thisArg, args) {
     ensureInitialized();
+    // biome-ignore lint/complexity/noBannedTypes: proxy requires Function type for dynamic dispatch
     return (_sql as Function).apply(_sql, args);
   }
 }) as ReturnType<typeof postgres>;

--- a/apps/registry/src/lib/scan/url-expander.ts
+++ b/apps/registry/src/lib/scan/url-expander.ts
@@ -371,9 +371,33 @@ export async function expandSkillsShUrl(url: string): Promise<{ tarballUrl: stri
   const skillName = parts[2];
 
   const branch = await resolveDefaultBranch(owner, repo);
+
+  // Skills.sh repos typically follow the convention: skills/{skill-name}/SKILL.md
+  // Probe which sub_path exists in the repo
+  let subPath = skillName;
+  for (const candidate of [`skills/${skillName}`, skillName]) {
+    try {
+      const probeUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${candidate}`;
+      const probeResp = await fetch(probeUrl, {
+        method: 'HEAD',
+        signal: AbortSignal.timeout(3_000),
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'Tank-Security-Scanner/1.0'
+        }
+      });
+      if (probeResp.ok) {
+        subPath = candidate;
+        break;
+      }
+    } catch {
+      // Probe failed — try next candidate
+    }
+  }
+
   return {
     tarballUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/${branch}`,
-    subPath: skillName
+    subPath
   };
 }
 
@@ -386,31 +410,39 @@ export async function expandSkillsShUrl(url: string): Promise<{ tarballUrl: stri
 export async function fetchSkillFileFromGitHub(
   owner: string,
   repo: string,
-  skillPath: string
+  skillPath: string,
+  options?: { trySkillsConvention?: boolean }
 ): Promise<{ content: string; contentType: string } | null> {
   const candidates = ['SKILL.md', 'skill.md', 'README.md', 'README'];
   const branch = await resolveDefaultBranch(owner, repo);
 
-  for (const filename of candidates) {
-    const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${skillPath}/${filename}`;
-    try {
-      const response = await fetch(rawUrl, {
-        signal: AbortSignal.timeout(10_000),
-        redirect: 'follow',
-        headers: { 'User-Agent': 'Tank-Security-Scanner/1.0' }
-      });
+  // Try direct path first, optionally skills/{skillPath} (common skills.sh convention)
+  const pathCandidates = options?.trySkillsConvention
+    ? [skillPath, `skills/${skillPath}`]
+    : [skillPath];
 
-      if (!response.ok) continue;
+  for (const path of pathCandidates) {
+    for (const filename of candidates) {
+      const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}/${filename}`;
+      try {
+        const response = await fetch(rawUrl, {
+          signal: AbortSignal.timeout(10_000),
+          redirect: 'follow',
+          headers: { 'User-Agent': 'Tank-Security-Scanner/1.0' }
+        });
 
-      // Validate redirect stayed on allowed host
-      const finalUrl = new URL(response.url);
-      if (isBlockedHost(finalUrl.hostname)) continue;
-      if (!ALLOWED_FETCH_HOSTS.some((h) => finalUrl.hostname === h || finalUrl.hostname.endsWith(`.${h}`))) continue;
+        if (!response.ok) continue;
 
-      const content = await response.text();
-      return { content, contentType: 'text/markdown' };
-    } catch {
-      // File not found, try next candidate
+        // Validate redirect stayed on allowed host
+        const finalUrl = new URL(response.url);
+        if (isBlockedHost(finalUrl.hostname)) continue;
+        if (!ALLOWED_FETCH_HOSTS.some((h) => finalUrl.hostname === h || finalUrl.hostname.endsWith(`.${h}`))) continue;
+
+        const content = await response.text();
+        return { content, contentType: 'text/markdown' };
+      } catch {
+        // File not found, try next candidate
+      }
     }
   }
 
@@ -510,13 +542,13 @@ async function resolveAgentskillsContent(url: string): Promise<{ content: string
   const skillName = parts[skillsIdx + 2];
 
   // Strategy 1: Try skills-il org directly (covers majority of skills)
-  const directResult = await fetchSkillFileFromGitHub('skills-il', category, skillName);
+  const directResult = await fetchSkillFileFromGitHub('skills-il', category, skillName, { trySkillsConvention: true });
   if (directResult) return directResult;
 
   // Strategy 2: Scrape page to find GitHub owner/repo, then fetch file
   const scraped = await scrapeAgentskillsGithub(url, category, skillName);
   if (scraped) {
-    const fileResult = await fetchSkillFileFromGitHub(scraped.owner, scraped.repo, skillName);
+    const fileResult = await fetchSkillFileFromGitHub(scraped.owner, scraped.repo, skillName, { trySkillsConvention: true });
     if (fileResult) return fileResult;
 
     // Return tarball info for fallback

--- a/apps/registry/src/lib/scan/url-expander.ts
+++ b/apps/registry/src/lib/scan/url-expander.ts
@@ -417,9 +417,7 @@ export async function fetchSkillFileFromGitHub(
   const branch = await resolveDefaultBranch(owner, repo);
 
   // Try direct path first, optionally skills/{skillPath} (common skills.sh convention)
-  const pathCandidates = options?.trySkillsConvention
-    ? [skillPath, `skills/${skillPath}`]
-    : [skillPath];
+  const pathCandidates = options?.trySkillsConvention ? [skillPath, `skills/${skillPath}`] : [skillPath];
 
   for (const path of pathCandidates) {
     for (const filename of candidates) {
@@ -548,7 +546,9 @@ async function resolveAgentskillsContent(url: string): Promise<{ content: string
   // Strategy 2: Scrape page to find GitHub owner/repo, then fetch file
   const scraped = await scrapeAgentskillsGithub(url, category, skillName);
   if (scraped) {
-    const fileResult = await fetchSkillFileFromGitHub(scraped.owner, scraped.repo, skillName, { trySkillsConvention: true });
+    const fileResult = await fetchSkillFileFromGitHub(scraped.owner, scraped.repo, skillName, {
+      trySkillsConvention: true
+    });
     if (fileResult) return fileResult;
 
     // Return tarball info for fallback

--- a/apps/registry/src/services/external-skills.ts
+++ b/apps/registry/src/services/external-skills.ts
@@ -73,87 +73,87 @@ const SEED_SKILLS: Array<{
   installCount: number;
 }> = [
   {
-    name: 'context7-docs',
-    url: 'https://github.com/contextLabs/context7-docs',
-    description: 'Fetch up-to-date documentation for any library or framework via Context7 MCP.',
-    author: 'contextLabs',
+    name: 'soultrace',
+    url: 'https://skills.sh/soultrace-ai/soultrace-skill/soultrace',
+    description: 'AI-powered end-to-end testing and trace analysis for web applications.',
+    author: 'soultrace-ai',
     installCount: 45000
   },
   {
-    name: 'playwright-browser',
-    url: 'https://github.com/anthropics/playwright-browser-skill',
-    description: 'Browser automation via Playwright — navigate, click, fill forms, extract data.',
-    author: 'anthropics',
+    name: 'find-skills',
+    url: 'https://skills.sh/vercel-labs/skills/find-skills',
+    description: 'Discover and search for AI agent skills across registries.',
+    author: 'vercel-labs',
     installCount: 38000
   },
   {
-    name: 'sequential-thinking',
-    url: 'https://github.com/modelcontextprotocol/sequential-thinking',
-    description: 'Structured chain-of-thought reasoning with backtracking and revision.',
-    author: 'modelcontextprotocol',
+    name: 'microsoft-foundry',
+    url: 'https://skills.sh/microsoft/azure-skills/microsoft-foundry',
+    description: 'Azure AI Foundry integration for model deployment and management.',
+    author: 'microsoft',
     installCount: 32000
   },
   {
-    name: 'memory-bank',
-    url: 'https://github.com/anthropics/memory-bank',
-    description: 'Persistent memory management for AI agents across sessions.',
+    name: 'frontend-design',
+    url: 'https://skills.sh/anthropics/skills/frontend-design',
+    description: 'High-quality frontend UI generation with design best practices.',
     author: 'anthropics',
     installCount: 28000
   },
   {
-    name: 'filesystem-server',
-    url: 'https://github.com/modelcontextprotocol/filesystem-server',
-    description: 'Secure file system access with configurable root directories.',
-    author: 'modelcontextprotocol',
+    name: 'vercel-react-best-practices',
+    url: 'https://skills.sh/vercel-labs/agent-skills/vercel-react-best-practices',
+    description: 'React and Next.js best practices for production applications.',
+    author: 'vercel-labs',
     installCount: 25000
   },
   {
-    name: 'github-skills',
-    url: 'https://github.com/github/github-mcp-tools',
-    description: 'GitHub API integration — repos, issues, PRs, actions.',
-    author: 'github',
+    name: 'remotion-best-practices',
+    url: 'https://skills.sh/remotion-dev/skills/remotion-best-practices',
+    description: 'Programmatic video creation with Remotion framework best practices.',
+    author: 'remotion-dev',
     installCount: 22000
   },
   {
-    name: 'brave-search',
-    url: 'https://github.com/brave-com/brave-search-mcp',
-    description: 'Web search via Brave Search API with privacy-first approach.',
-    author: 'brave-com',
+    name: 'agent-browser',
+    url: 'https://skills.sh/vercel-labs/agent-browser/agent-browser',
+    description: 'Browser automation for AI agents — navigate, interact, extract data.',
+    author: 'vercel-labs',
     installCount: 19000
   },
   {
-    name: 'sqlite-explorer',
-    url: 'https://github.com/modelcontextprotocol/sqlite-explorer',
-    description: 'Read-only SQLite database exploration and query tool.',
-    author: 'modelcontextprotocol',
+    name: 'supabase-postgres-best-practices',
+    url: 'https://skills.sh/supabase/agent-skills/supabase-postgres-best-practices',
+    description: 'PostgreSQL performance optimization and best practices from Supabase.',
+    author: 'supabase',
     installCount: 16000
   },
   {
-    name: 'fetch-web',
-    url: 'https://github.com/modelcontextprotocol/fetch-web',
-    description: 'HTTP client for fetching web content with HTML-to-markdown conversion.',
-    author: 'modelcontextprotocol',
+    name: 'skill-creator',
+    url: 'https://skills.sh/anthropics/skills/skill-creator',
+    description: 'Create and publish AI agent skills with scaffolding and validation.',
+    author: 'anthropics',
     installCount: 14000
   },
   {
-    name: 'puppeteer-crawl',
-    url: 'https://github.com/anthropics/puppeteer-crawl-skill',
-    description: 'Web crawling and scraping via headless Chrome/Puppeteer.',
-    author: 'anthropics',
+    name: 'shadcn',
+    url: 'https://skills.sh/shadcn/ui/shadcn',
+    description: 'Build UIs with shadcn/ui components and design system patterns.',
+    author: 'shadcn',
     installCount: 12000
   },
   {
-    name: 'slack-integration',
-    url: 'https://github.com/slackapi/slack-mcp-server',
-    description: 'Slack workspace integration — send messages, read channels, manage threads.',
-    author: 'slackapi',
+    name: 'impeccable-frontend-design',
+    url: 'https://skills.sh/pbakaus/impeccable/frontend-design',
+    description: 'Production-grade frontend design with accessibility and performance focus.',
+    author: 'pbakaus',
     installCount: 11000
   },
   {
-    name: 'postgres-query',
-    url: 'https://github.com/modelcontextprotocol/postgres-query',
-    description: 'Execute SQL queries against PostgreSQL databases with safety checks.',
-    author: 'modelcontextprotocol',
+    name: 'lark-base',
+    url: 'https://skills.sh/larksuite/cli/lark-base',
+    description: 'Lark Base integration for spreadsheet and database operations.',
+    author: 'larksuite',
     installCount: 9500
   }
 ];

--- a/packages/vault/src/__tests__/full-flow.test.ts
+++ b/packages/vault/src/__tests__/full-flow.test.ts
@@ -88,7 +88,7 @@ describe('full E2E — credential vault lifecycle', () => {
     expect(vault.size).toBe(2);
 
     // Phase 3: verify provider NEVER saw real credentials
-    const providerBody1 = providerLog[providerLog.length - 1]!;
+    const providerBody1 = providerLog[providerLog.length - 1];
     expect(providerBody1).not.toContain(REAL_STRIPE);
     expect(providerBody1).not.toContain(REAL_AWS);
 

--- a/packages/vault/src/__tests__/proxy.test.ts
+++ b/packages/vault/src/__tests__/proxy.test.ts
@@ -166,7 +166,7 @@ describe('proxy server — real HTTP', () => {
   it('restores fake credentials in response', async () => {
     vault.store(REAL_STRIPE_KEY, 'sk_live_FAKEFORTEST00000000000', 'stripe_secret');
 
-    const providerPort = mockProvider.port;
+    const _providerPort = mockProvider.port;
     const responseServer = createServer((req, res) => {
       let reqBody = '';
       req.on('data', (c: Buffer) => {
@@ -203,8 +203,8 @@ describe('proxy server — real HTTP', () => {
     });
 
     const resBody = (await res.json()) as { choices: Array<{ message: { content: string } }> };
-    expect(resBody.choices[0]!.message.content).toContain(REAL_STRIPE_KEY);
-    expect(resBody.choices[0]!.message.content).not.toContain('sk_live_FAKEFORTEST00000000000');
+    expect(resBody.choices[0]?.message.content).toContain(REAL_STRIPE_KEY);
+    expect(resBody.choices[0]?.message.content).not.toContain('sk_live_FAKEFORTEST00000000000');
 
     responseServer.close();
   });


### PR DESCRIPTION
## Summary
- Replace all 12 broken seed data URLs with verified skills.sh URLs from the live trending page
- Fix skills.sh URL expansion to probe GitHub API for correct sub_path (`skills/{name}` convention)
- Fix detect-secrets version logging using `importlib.metadata` instead of missing `__version__`
- Add evidence (matched line content) to detect-secrets findings so "Show more" appears
- Apply example/doc path severity downgrade to detect-secrets findings (reduces false positives)
- Increase findings description truncation from 100 to 150 chars

## Test plan
- [ ] Verify external skills showcase on `/scan/top-skills` shows real, clickable skill links
- [ ] Scan a skills.sh URL like `https://skills.sh/anthropics/skills/frontend-design` — should resolve correctly
- [ ] Scan `@tank/flight-search` — detect-secrets findings should have "Show more" with evidence
- [ ] Check Vercel logs for detect-secrets version — should show actual version, not "unknown"
- [ ] Verify findings in example/doc paths get severity "info" instead of "critical"