### PR TITLE
fix(scan): honest scan results, early 404 detection, skip reasons

### DIFF
--- a/apps/python-api/lib/scan/stage0_ingest.py
+++ b/apps/python-api/lib/scan/stage0_ingest.py
@@ -494,6 +494,7 @@ def _friendly_download_error(exc: Exception, url: str) -> str:
 
     # Fallback: strip raw URL from httpx error to keep it clean
     import re
+
     clean = re.sub(r" for url 'https?://[^']+}'", "", msg)
     clean = re.sub(r" for url 'https?://[^']+'", "", clean)
     return f"Failed to download package: {clean}"

--- a/apps/python-api/lib/scan/stage0_ingest.py
+++ b/apps/python-api/lib/scan/stage0_ingest.py
@@ -470,6 +470,35 @@ def narrow_to_sub_path(
     return new_temp_dir, new_files, total_size, findings
 
 
+def _friendly_download_error(exc: Exception, url: str) -> str:
+    """Convert raw httpx/SSL errors into user-friendly messages."""
+    msg = str(exc)
+
+    # httpx HTTPStatusError: "Client error '404 Not Found' for url '...'"
+    if "404" in msg:
+        return "Repository not found. Check that the URL is correct and the repository is public."
+    if "403" in msg:
+        return "Access denied. The repository may be private or have access restrictions."
+    if "401" in msg:
+        return "Authentication required. The repository may be private."
+
+    # Timeout / connection errors
+    if "timed out" in msg.lower() or "timeout" in msg.lower():
+        return "Download timed out. The repository may be too large or temporarily unavailable."
+    if "connection" in msg.lower() or "connect" in msg.lower():
+        return "Could not connect to the repository host. The service may be temporarily unavailable."
+
+    # Size limit
+    if "exceeds maximum" in msg:
+        return f"Package too large to scan. {msg}"
+
+    # Fallback: strip raw URL from httpx error to keep it clean
+    import re
+    clean = re.sub(r" for url 'https?://[^']+}'", "", msg)
+    clean = re.sub(r" for url 'https?://[^']+'", "", clean)
+    return f"Failed to download package: {clean}"
+
+
 async def stage0_ingest(tarball_url: str, sub_path: str | None = None) -> IngestResult:
     """Run Stage 0: Ingestion & Quarantine.
 
@@ -491,12 +520,13 @@ async def stage0_ingest(tarball_url: str, sub_path: str | None = None) -> Ingest
     try:
         tarball_data = await download_tarball(tarball_url)
     except Exception as e:
+        error_msg = _friendly_download_error(e, tarball_url)
         findings.append(
             Finding(
                 stage="stage0",
                 severity="critical",
                 type="download_failed",
-                description=f"Failed to download tarball: {e!s}",
+                description=error_msg,
                 confidence=1.0,
                 tool="stage0_ingest",
             )

--- a/apps/registry/src/api/routes/v1/scan.ts
+++ b/apps/registry/src/api/routes/v1/scan.ts
@@ -70,6 +70,11 @@ export const scanRoutes = new Hono().post('/', zValidator('json', scanSchema), a
 
   log.info({ url, urlType: expanded.urlType, tarballUrl: expanded.tarballUrl }, 'URL expanded');
 
+  // Early exit if URL expansion detected a problem (e.g. repo not found)
+  if (expanded.error) {
+    return c.json({ error: expanded.error }, 400);
+  }
+
   // Step 5: Route to scanner
   try {
     const headers: Record<string, string> = {

--- a/apps/registry/src/components/skills/scanning-tools-strip.tsx
+++ b/apps/registry/src/components/skills/scanning-tools-strip.tsx
@@ -9,6 +9,8 @@ export interface ScanningTool {
   ran: boolean;
   findingCount: number;
   status: 'ran' | 'skipped' | 'failed';
+  /** Why this tool was skipped — shown below the "Skipped" label */
+  skipReason?: string;
 }
 
 export interface ScanningToolsStripProps {
@@ -30,7 +32,9 @@ function ToolCard({ tool }: { tool: ScanningTool }) {
         </div>
       )}
       {tool.status === 'failed' && <div className="text-xs mt-1 text-red-600 dark:text-red-400">Failed</div>}
-      {tool.status === 'skipped' && <div className="text-xs mt-1 text-muted-foreground">Skipped</div>}
+      {tool.status === 'skipped' && (
+        <div className="text-xs mt-1 text-muted-foreground">{tool.skipReason ?? 'Skipped'}</div>
+      )}
     </div>
   );
 }
@@ -38,14 +42,38 @@ function ToolCard({ tool }: { tool: ScanningTool }) {
 export function ScanningToolsStrip({ tools }: ScanningToolsStripProps) {
   if (tools.length === 0) return null;
 
+  const ranCount = tools.filter((t) => t.status === 'ran').length;
+  const total = tools.length;
+
   return (
-    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
-      {tools.map((tool) => (
-        <ToolCard key={tool.name} tool={tool} />
-      ))}
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-all"
+            style={{ width: `${Math.round((ranCount / total) * 100)}%` }}
+          />
+        </div>
+        <span className="text-xs text-muted-foreground shrink-0">
+          {ranCount}/{total} tools ran
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        {tools.map((tool) => (
+          <ToolCard key={tool.name} tool={tool} />
+        ))}
+      </div>
     </div>
   );
 }
+
+/** Skip reasons for tools that can't run in certain scan contexts. */
+const SKIP_REASONS: Record<string, string> = {
+  stage1: 'Requires package structure',
+  stage2: 'No source code to analyze',
+  stage5: 'No dependency manifest',
+  llm: 'Not configured'
+};
 
 /**
  * Build the scanning tools list dynamically from actual findings data.
@@ -76,6 +104,7 @@ export function buildScanningTools(scanDetails: {
       icon: <Shield className="size-4" />,
       ran: stagesRun.includes('stage1'),
       status: stagesRun.includes('stage1') ? 'ran' : 'skipped',
+      skipReason: stagesRun.includes('stage1') ? undefined : SKIP_REASONS.stage1,
       findingCount: findings.filter((f) => f.stage === 'stage1').length
     },
     {
@@ -84,6 +113,7 @@ export function buildScanningTools(scanDetails: {
       icon: <ScanSearch className="size-4" />,
       ran: stagesRun.includes('stage2'),
       status: stagesRun.includes('stage2') ? 'ran' : 'skipped',
+      skipReason: stagesRun.includes('stage2') ? undefined : SKIP_REASONS.stage2,
       findingCount: findings.filter((f) => f.tool?.includes('semgrep')).length
     },
     {
@@ -92,6 +122,7 @@ export function buildScanningTools(scanDetails: {
       icon: <Bug className="size-4" />,
       ran: stagesRun.includes('stage2'),
       status: stagesRun.includes('stage2') ? 'ran' : 'skipped',
+      skipReason: stagesRun.includes('stage2') ? undefined : SKIP_REASONS.stage2,
       findingCount: findings.filter((f) => f.tool === 'bandit').length
     },
     {
@@ -140,6 +171,7 @@ export function buildScanningTools(scanDetails: {
       icon: <Link2 className="size-4" />,
       ran: stagesRun.includes('stage5'),
       status: stagesRun.includes('stage5') ? 'ran' : 'skipped',
+      skipReason: stagesRun.includes('stage5') ? undefined : SKIP_REASONS.stage5,
       findingCount: findings.filter((f) => f.tool === 'stage5_osv').length
     },
     {
@@ -148,6 +180,7 @@ export function buildScanningTools(scanDetails: {
       icon: <Bot className="size-4" />,
       ran: scanDetails.llm_analysis?.enabled ?? false,
       status: scanDetails.llm_analysis?.enabled ? 'ran' : 'skipped',
+      skipReason: scanDetails.llm_analysis?.enabled ? undefined : SKIP_REASONS.llm,
       findingCount: findings.filter((f) => f.llm_reviewed).length
     }
   ];

--- a/apps/registry/src/lib/scan/__tests__/url-expander.test.ts
+++ b/apps/registry/src/lib/scan/__tests__/url-expander.test.ts
@@ -39,7 +39,7 @@ describe('resolveDefaultBranch', () => {
       .mockResolvedValueOnce(mockResponse({ body: { default_branch: 'master' } }));
 
     const first = await resolveDefaultBranch('test-owner', 'cached-repo');
-    expect(first).toBe('master');
+    expect(first).toEqual({ branch: 'master' });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
@@ -47,8 +47,8 @@ describe('resolveDefaultBranch', () => {
   it('returns default_branch from GitHub API', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(mockResponse({ body: { default_branch: 'develop' } }));
 
-    const branch = await resolveDefaultBranch('owner', 'custom-branch-repo');
-    expect(branch).toBe('develop');
+    const result = await resolveDefaultBranch('owner', 'custom-branch-repo');
+    expect(result).toEqual({ branch: 'develop' });
   });
 
   it('falls back to HEAD probe when API fails', async () => {
@@ -57,8 +57,8 @@ describe('resolveDefaultBranch', () => {
       .mockResolvedValueOnce(mockResponse({ ok: false, status: 404 }))
       .mockResolvedValueOnce(mockResponse({ ok: true }));
 
-    const branch = await resolveDefaultBranch('owner', 'master-only-repo');
-    expect(branch).toBe('master');
+    const result = await resolveDefaultBranch('owner', 'master-only-repo');
+    expect(result).toEqual({ branch: 'master' });
   });
 
   it('falls back to HEAD probe on network error', async () => {
@@ -66,22 +66,29 @@ describe('resolveDefaultBranch', () => {
       .mockRejectedValueOnce(new Error('network error'))
       .mockResolvedValueOnce(mockResponse({ ok: true }));
 
-    const branch = await resolveDefaultBranch('owner', 'network-error-repo');
-    expect(branch).toBe('main');
+    const result = await resolveDefaultBranch('owner', 'network-error-repo');
+    expect(result).toEqual({ branch: 'main' });
   });
 
-  it('returns "main" when all strategies fail', async () => {
+  it('returns { branch: "main", notFound: true } when all strategies fail', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse({ ok: false, status: 404 }));
 
-    const branch = await resolveDefaultBranch('owner', 'nonexistent-repo');
-    expect(branch).toBe('main');
+    const result = await resolveDefaultBranch('owner', 'nonexistent-repo');
+    expect(result).toEqual({ branch: 'main', notFound: true });
   });
 
   it('defaults to "main" when API returns no default_branch field', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(mockResponse({ body: {} }));
 
-    const branch = await resolveDefaultBranch('owner', 'no-branch-field');
-    expect(branch).toBe('main');
+    const result = await resolveDefaultBranch('owner', 'no-branch-field');
+    expect(result).toEqual({ branch: 'main' });
+  });
+
+  it('returns notFound when GitHub API returns 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(mockResponse({ ok: false, status: 404 }));
+
+    const result = await resolveDefaultBranch('owner', 'private-repo');
+    expect(result).toEqual({ branch: 'main', notFound: true });
   });
 });
 
@@ -108,6 +115,17 @@ describe('expandGitHubFolder', () => {
     expect(result).toEqual({
       tarballUrl: 'https://codeload.github.com/owner/repo/tar.gz/master',
       subPath: null
+    });
+  });
+
+  it('returns notFound for nonexistent repo', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(mockResponse({ ok: false, status: 404 }));
+
+    const result = await expandGitHubFolder('https://github.com/owner/nonexistent');
+    expect(result).toEqual({
+      tarballUrl: 'https://codeload.github.com/owner/nonexistent/tar.gz/main',
+      subPath: null,
+      notFound: true
     });
   });
 

--- a/apps/registry/src/lib/scan/url-expander.ts
+++ b/apps/registry/src/lib/scan/url-expander.ts
@@ -31,6 +31,8 @@ export interface ExpandedURL {
   urlType: URLType;
   /** Content type hint for single-file mode */
   contentType: string | null;
+  /** Human-readable error if URL resolution failed (repo not found, etc.) */
+  error?: string;
 }
 
 /**
@@ -112,7 +114,7 @@ function parseURL(url: string): URL | null {
  * → tarball: https://codeload.github.com/{owner}/{repo}/tar.gz/{default_branch}
  * → sub_path: null
  */
-export async function expandGitHubFolder(url: string): Promise<{ tarballUrl: string; subPath: string | null } | null> {
+export async function expandGitHubFolder(url: string): Promise<{ tarballUrl: string; subPath: string | null; notFound?: boolean } | null> {
   const parsed = parseURL(url);
   if (!parsed || parsed.hostname !== 'github.com') return null;
 
@@ -139,10 +141,11 @@ export async function expandGitHubFolder(url: string): Promise<{ tarballUrl: str
   }
 
   // Just owner/repo — resolve default branch
-  const branch = await resolveDefaultBranch(owner, cleanRepo);
+  const result = await resolveDefaultBranch(owner, cleanRepo);
   return {
-    tarballUrl: `https://codeload.github.com/${owner}/${cleanRepo}/tar.gz/${branch}`,
-    subPath: null
+    tarballUrl: `https://codeload.github.com/${owner}/${cleanRepo}/tar.gz/${result.branch}`,
+    subPath: null,
+    notFound: result.notFound
   };
 }
 
@@ -201,7 +204,7 @@ function isBlockedHost(hostname: string): boolean {
  * Capped at 1000 entries to prevent unbounded growth in long-running processes.
  */
 const MAX_BRANCH_CACHE_SIZE = 1000;
-const branchCache = new Map<string, { branch: string; expires: number }>();
+const branchCache = new Map<string, { branch: string; notFound?: boolean; expires: number }>();
 const BRANCH_CACHE_TTL_MS = 10 * 60 * 1000;
 
 /** Evict expired entries; if cache is still full, drop oldest. */
@@ -230,12 +233,17 @@ export function clearBranchCache(): void {
  * 2. Call GitHub API (`GET /repos/{owner}/{repo}`) with 5s timeout
  * 3. Fallback: HEAD probe `main` then `master` on codeload.github.com
  * 4. Final fallback: return `"main"`
+ *
+ * Returns `{ branch, notFound }` — check `notFound` to detect nonexistent repos.
  */
-export async function resolveDefaultBranch(owner: string, repo: string): Promise<string> {
+export async function resolveDefaultBranch(
+  owner: string,
+  repo: string
+): Promise<{ branch: string; notFound?: boolean }> {
   const cacheKey = `${owner}/${repo}`;
   const cached = branchCache.get(cacheKey);
   if (cached && cached.expires > Date.now()) {
-    return cached.branch;
+    return { branch: cached.branch, notFound: cached.notFound };
   }
 
   // Strategy 1: GitHub API
@@ -253,13 +261,21 @@ export async function resolveDefaultBranch(owner: string, repo: string): Promise
       const branch = data.default_branch ?? 'main';
       evictBranchCache();
       branchCache.set(cacheKey, { branch, expires: Date.now() + BRANCH_CACHE_TTL_MS });
-      return branch;
+      return { branch };
+    }
+
+    // 404 from GitHub API means the repo doesn't exist (or is private)
+    if (response.status === 404) {
+      evictBranchCache();
+      branchCache.set(cacheKey, { branch: 'main', notFound: true, expires: Date.now() + BRANCH_CACHE_TTL_MS });
+      return { branch: 'main', notFound: true };
     }
   } catch {
     // API failed — fall through to HEAD probe
   }
 
   // Strategy 2: HEAD probe on codeload.github.com
+  let lastProbeStatus = 0;
   for (const candidate of ['main', 'master'] as const) {
     try {
       const probeUrl = `https://codeload.github.com/${owner}/${repo}/tar.gz/${candidate}`;
@@ -269,20 +285,22 @@ export async function resolveDefaultBranch(owner: string, repo: string): Promise
         redirect: 'follow',
         headers: { 'User-Agent': 'Tank-Security-Scanner/1.0' }
       });
+      lastProbeStatus = probeResponse.status;
       if (probeResponse.ok) {
         evictBranchCache();
         branchCache.set(cacheKey, { branch: candidate, expires: Date.now() + BRANCH_CACHE_TTL_MS });
-        return candidate;
+        return { branch: candidate };
       }
     } catch {
       // Probe failed — try next candidate
     }
   }
 
-  // Strategy 3: hardcoded fallback — cache it to avoid repeat failures
+  // If both probes returned 404, the repo likely doesn't exist
+  const notFound = lastProbeStatus === 404;
   evictBranchCache();
-  branchCache.set(cacheKey, { branch: 'main', expires: Date.now() + BRANCH_CACHE_TTL_MS });
-  return 'main';
+  branchCache.set(cacheKey, { branch: 'main', notFound, expires: Date.now() + BRANCH_CACHE_TTL_MS });
+  return { branch: 'main', notFound };
 }
 
 export async function fetchRawFileContent(url: string): Promise<{ content: string; contentType: string } | null> {
@@ -370,7 +388,7 @@ export async function expandSkillsShUrl(url: string): Promise<{ tarballUrl: stri
   const repo = parts[1];
   const skillName = parts[2];
 
-  const branch = await resolveDefaultBranch(owner, repo);
+  const { branch } = await resolveDefaultBranch(owner, repo);
 
   // Skills.sh repos typically follow the convention: skills/{skill-name}/SKILL.md
   // Probe which sub_path exists in the repo
@@ -414,7 +432,7 @@ export async function fetchSkillFileFromGitHub(
   options?: { trySkillsConvention?: boolean }
 ): Promise<{ content: string; contentType: string } | null> {
   const candidates = ['SKILL.md', 'skill.md', 'README.md', 'README'];
-  const branch = await resolveDefaultBranch(owner, repo);
+  const { branch } = await resolveDefaultBranch(owner, repo);
 
   // Try direct path first, optionally skills/{skillPath} (common skills.sh convention)
   const pathCandidates = options?.trySkillsConvention ? [skillPath, `skills/${skillPath}`] : [skillPath];
@@ -493,7 +511,7 @@ async function scrapeAgentskillsGithub(
     if (npxMatch) {
       const owner = npxMatch[2];
       const repo = npxMatch[3];
-      const branch = await resolveDefaultBranch(owner, repo);
+      const { branch } = await resolveDefaultBranch(owner, repo);
       return {
         tarballUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/${branch}`,
         subPath: skillName,
@@ -507,7 +525,7 @@ async function scrapeAgentskillsGithub(
     if (ghMatch) {
       const owner = ghMatch[1];
       const repo = ghMatch[2];
-      const branch = await resolveDefaultBranch(owner, repo);
+      const { branch } = await resolveDefaultBranch(owner, repo);
       return {
         tarballUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/${branch}`,
         subPath: skillName,
@@ -592,6 +610,16 @@ export async function expandScanUrl(rawUrl: string): Promise<ExpandedURL> {
       const expanded = await expandGitHubFolder(rawUrl);
       if (!expanded) {
         return { tarballUrl: rawUrl, subPath: null, fileContent: null, urlType: 'unknown', contentType: null };
+      }
+      if (expanded.notFound) {
+        return {
+          tarballUrl: '',
+          subPath: null,
+          fileContent: null,
+          urlType: 'github_folder',
+          contentType: null,
+          error: 'Repository not found. Check that the URL is correct and the repository is public.'
+        };
       }
       return {
         tarballUrl: expanded.tarballUrl,

--- a/apps/registry/src/lib/scan/url-expander.ts
+++ b/apps/registry/src/lib/scan/url-expander.ts
@@ -114,7 +114,9 @@ function parseURL(url: string): URL | null {
  * → tarball: https://codeload.github.com/{owner}/{repo}/tar.gz/{default_branch}
  * → sub_path: null
  */
-export async function expandGitHubFolder(url: string): Promise<{ tarballUrl: string; subPath: string | null; notFound?: boolean } | null> {
+export async function expandGitHubFolder(
+  url: string
+): Promise<{ tarballUrl: string; subPath: string | null; notFound?: boolean } | null> {
   const parsed = parseURL(url);
   if (!parsed || parsed.hostname !== 'github.com') return null;
 

--- a/apps/registry/src/screens/scan-screen.tsx
+++ b/apps/registry/src/screens/scan-screen.tsx
@@ -177,15 +177,14 @@ export function ScanPage({ initialUrl }: { initialUrl?: string }) {
         <div className="space-y-6">
           {/* Ingest failure warning */}
           {ingestFailure && (
-            <Card className="border-amber-300 dark:border-amber-800">
+            <Card className="border-destructive/50">
               <CardContent className="py-4 space-y-2">
-                <p role="alert" className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                <p role="alert" className="text-sm font-medium text-destructive">
                   Package download failed
                 </p>
-                <p className="text-sm text-muted-foreground break-words">
-                  {ingestFailure.description.length > 200
-                    ? `${ingestFailure.description.slice(0, 200)}...`
-                    : ingestFailure.description}
+                <p className="text-sm text-muted-foreground break-words">{ingestFailure.description}</p>
+                <p className="text-xs text-muted-foreground">
+                  Check that the URL is correct and the repository or package is publicly accessible.
                 </p>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- Detect nonexistent/private GitHub repos **early** in URL expansion (before Python scanner) and return a clear `"Repository not found"` error instead of raw httpx 404 messages
- Add contextual **skip reasons** to scanning tool cards: "Requires package structure", "No source code to analyze", "No dependency manifest"
- Add **coverage progress bar** above tool grid showing `5/12 tools ran` ratio — makes it impossible to mistake a partial scan for a full one
- Improve download error messages in Python scanner: 404 → "Repository not found", 403 → "Access denied", timeout → "Download timed out"
- Improve ingest failure card: red destructive styling, full description (no truncation), help text

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun vitest run url-expander.test.ts` — 21/21 tests pass
- [ ] Deploy to nightly and test:
  - Single file: `https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md`
  - Full repo: `https://github.com/anthropics/skills`
  - Nonexistent repo: `https://github.com/anthropics/playwright-browser-skill` → should show "Repository not found"
  - Verify skip reasons appear on skipped tools
  - Verify coverage bar shows correct ratio