### PR TITLE
fix(scan): external skills scanning, tarball size limits, URL probing

### DIFF
--- a/apps/python-api/lib/scan/stage0_ingest.py
+++ b/apps/python-api/lib/scan/stage0_ingest.py
@@ -18,7 +18,7 @@ import httpx
 from lib.scan.models import Finding, IngestResult, StageResult
 
 # Configuration
-MAX_TARBALL_SIZE = 50 * 1024 * 1024  # 50MB
+MAX_TARBALL_SIZE = 100 * 1024 * 1024  # 100MB
 MAX_EXTRACTED_SIZE = 50 * 1024 * 1024  # 50MB
 MAX_COMPRESSION_RATIO = 100  # decompressed/compressed
 DOWNLOAD_TIMEOUT = 30.0  # seconds
@@ -583,23 +583,11 @@ async def stage0_ingest(tarball_url: str, sub_path: str | None = None) -> Ingest
     extract_findings, extracted_files, total_size = safe_extract(tar_path, temp_dir)
     findings.extend(extract_findings)
 
-    # Check total extracted size
-    if total_size > MAX_EXTRACTED_SIZE:
-        findings.append(
-            Finding(
-                stage="stage0",
-                severity="critical",
-                type="size_exceeded",
-                description=f"Total extracted size {total_size} exceeds maximum {MAX_EXTRACTED_SIZE}",
-                confidence=1.0,
-                tool="stage0_ingest",
-            )
-        )
-
     # Remove the tarball (we don't need it anymore)
     os.remove(tar_path)
 
     # Narrow to sub_path if specified (monorepo support)
+    # MUST happen before size check so the limit applies to the narrowed subdir, not the full repo
     if sub_path:
         try:
             temp_dir, extracted_files, narrowed_size, sub_path_findings = narrow_to_sub_path(
@@ -611,6 +599,19 @@ async def stage0_ingest(tarball_url: str, sub_path: str | None = None) -> Ingest
         if narrowed_size is not None:
             total_size = narrowed_size
         findings.extend(sub_path_findings)
+
+    # Check total extracted size (after narrowing, so this applies to the actual scanned content)
+    if total_size > MAX_EXTRACTED_SIZE:
+        findings.append(
+            Finding(
+                stage="stage0",
+                severity="critical",
+                type="size_exceeded",
+                description=f"Total extracted size {total_size} exceeds maximum {MAX_EXTRACTED_SIZE}",
+                confidence=1.0,
+                tool="stage0_ingest",
+            )
+        )
 
     # Compute file hashes
     file_hashes = compute_file_hashes(temp_dir, extracted_files)

--- a/apps/python-api/tests/test_stage0_ingest_ordering.py
+++ b/apps/python-api/tests/test_stage0_ingest_ordering.py
@@ -1,0 +1,65 @@
+"""Regression test for stage0_ingest size check ordering.
+
+Bug: Large monorepos (e.g. shadcn-ui/ui, microsoft/azure-skills) exceeded the
+     50MB extracted size limit BEFORE sub_path narrowing ran, causing scan failures.
+     The sub_path mechanism narrows extraction to a small subdirectory, but the size
+     check ran on the full repo.
+
+Fix: narrow_to_sub_path() now runs BEFORE the extracted size check, so the limit
+     applies to the narrowed subdirectory, not the full repo.
+"""
+
+
+class TestStage0IngestOrdering:
+    """Verify that sub_path narrowing happens before the size check."""
+
+    def test_narrow_before_size_check(self):
+        """Verify narrow_to_sub_path is called before size_exceeded check."""
+        import ast
+        import inspect
+
+        from lib.scan.stage0_ingest import stage0_ingest
+
+        source = inspect.getsource(stage0_ingest)
+        tree = ast.parse(source)
+
+        # Find all function calls and their line numbers
+        call_positions = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                name = None
+                if isinstance(node.func, ast.Name):
+                    name = node.func.id
+                elif isinstance(node.func, ast.Attribute):
+                    name = node.func.attr
+                if name:
+                    if name not in call_positions:
+                        call_positions[name] = []
+                    call_positions[name].append(node.lineno)
+
+        # Verify narrow_to_sub_path exists in the source
+        assert "narrow_to_sub_path" in call_positions, "narrow_to_sub_path not found in stage0_ingest"
+
+        # Find the size_exceeded finding (the string literal in the size check)
+        size_exceeded_line = None
+        narrow_line = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if "exceeds maximum" in node.value:
+                    size_exceeded_line = node.lineno
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name) and node.func.id == "narrow_to_sub_path":
+                    narrow_line = node.lineno
+
+        assert narrow_line is not None, "narrow_to_sub_path call not found"
+        assert size_exceeded_line is not None, "size_exceeded check not found"
+        assert narrow_line < size_exceeded_line, (
+            f"narrow_to_sub_path (line {narrow_line}) must come before "
+            f"size check (line {size_exceeded_line})"
+        )
+
+    def test_max_tarball_size_is_100mb(self):
+        """Verify MAX_TARBALL_SIZE was raised to 100MB."""
+        from lib.scan.stage0_ingest import MAX_TARBALL_SIZE
+
+        assert MAX_TARBALL_SIZE == 100 * 1024 * 1024

--- a/apps/python-api/tests/test_stage0_ingest_ordering.py
+++ b/apps/python-api/tests/test_stage0_ingest_ordering.py
@@ -44,12 +44,10 @@ class TestStage0IngestOrdering:
         size_exceeded_line = None
         narrow_line = None
         for node in ast.walk(tree):
-            if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                if "exceeds maximum" in node.value:
-                    size_exceeded_line = node.lineno
-            if isinstance(node, ast.Call):
-                if isinstance(node.func, ast.Name) and node.func.id == "narrow_to_sub_path":
-                    narrow_line = node.lineno
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) and "exceeds maximum" in node.value:
+                size_exceeded_line = node.lineno
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "narrow_to_sub_path":
+                narrow_line = node.lineno
 
         assert narrow_line is not None, "narrow_to_sub_path call not found"
         assert size_exceeded_line is not None, "size_exceeded check not found"

--- a/apps/python-api/tests/test_stage0_ingest_ordering.py
+++ b/apps/python-api/tests/test_stage0_ingest_ordering.py
@@ -52,8 +52,7 @@ class TestStage0IngestOrdering:
         assert narrow_line is not None, "narrow_to_sub_path call not found"
         assert size_exceeded_line is not None, "size_exceeded check not found"
         assert narrow_line < size_exceeded_line, (
-            f"narrow_to_sub_path (line {narrow_line}) must come before "
-            f"size check (line {size_exceeded_line})"
+            f"narrow_to_sub_path (line {narrow_line}) must come before size check (line {size_exceeded_line})"
         )
 
     def test_max_tarball_size_is_100mb(self):

--- a/apps/registry/src/api/routes/v1/scan.ts
+++ b/apps/registry/src/api/routes/v1/scan.ts
@@ -22,6 +22,7 @@ import { env } from '~/consts/env';
 import { resolveRequestUserId } from '~/lib/auth/authz';
 import { type ExpandedURL, expandScanUrl } from '~/lib/scan/url-expander';
 import { validateScanUrl } from '~/lib/scan/url-validator';
+import { updateExternalSkillScanResult } from '~/services/external-skills';
 import { log as baseLog } from '~/services/logger';
 import { anonymousLimiter, authFreeLimiter } from '../../middleware/rate-limit';
 
@@ -108,6 +109,7 @@ export const scanRoutes = new Hono().post('/', zValidator('json', scanSchema), a
       }
 
       const scanResult = await scanResponse.json();
+      writebackExternalSkill(url, scanResult);
       return c.json(scanResult);
     }
 
@@ -131,6 +133,7 @@ export const scanRoutes = new Hono().post('/', zValidator('json', scanSchema), a
     }
 
     const scanResult = await scanResponse.json();
+    writebackExternalSkill(url, scanResult);
     return c.json(scanResult);
   } catch (err) {
     if (err instanceof DOMException && err.name === 'TimeoutError') {
@@ -141,6 +144,32 @@ export const scanRoutes = new Hono().post('/', zValidator('json', scanSchema), a
     return c.json({ error: 'Scanner unavailable' }, 502);
   }
 });
+
+/**
+ * Write scan result back to external_skills if the URL matches a known external skill.
+ * Non-blocking: errors are caught and logged, never failing the scan response.
+ */
+function writebackExternalSkill(
+  sourceUrl: string,
+  scanResult: {
+    verdict: string;
+    findings: Array<{
+      stage: string;
+      severity: string;
+      type: string;
+      description: string;
+      location: string | null;
+      tool: string | null;
+    }>;
+    duration_ms: number;
+    [key: string]: unknown;
+  }
+): void {
+  const verdict = typeof scanResult.verdict === 'string' ? scanResult.verdict : 'unknown';
+  updateExternalSkillScanResult(sourceUrl, verdict, scanResult, new Date()).catch((err) => {
+    log.warn({ url: sourceUrl, error: String(err) }, 'Failed to write back scan result to external_skills');
+  });
+}
 
 /**
  * Extract filename from URL for single-file scan mode.

--- a/apps/registry/src/lib/scan/__tests__/url-expander.test.ts
+++ b/apps/registry/src/lib/scan/__tests__/url-expander.test.ts
@@ -166,6 +166,23 @@ describe('expandSkillsShUrl', () => {
     const result = await expandSkillsShUrl('https://skills.sh/owner/repo');
     expect(result).toBeNull();
   });
+
+  it('probes skills/ then src/skills/ then direct for sub_path', async () => {
+    // Mock resolveDefaultBranch (GitHub API call)
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+    fetchMock.mockResolvedValueOnce(mockResponse({ body: { default_branch: 'main' } }));
+
+    // Probe 1: skills/frontend-design → 404
+    fetchMock.mockResolvedValueOnce(mockResponse({ ok: false, status: 404 }));
+    // Probe 2: src/skills/frontend-design → 200
+    fetchMock.mockResolvedValueOnce(mockResponse({ ok: true, status: 200 }));
+
+    const result = await expandSkillsShUrl('https://skills.sh/pbakaus/impeccable/frontend-design');
+    expect(result).toEqual({
+      tarballUrl: 'https://codeload.github.com/pbakaus/impeccable/tar.gz/main',
+      subPath: 'src/skills/frontend-design'
+    });
+  });
 });
 
 // ── detectURLType ─────────────────────────────────────────────

--- a/apps/registry/src/lib/scan/url-expander.ts
+++ b/apps/registry/src/lib/scan/url-expander.ts
@@ -395,7 +395,7 @@ export async function expandSkillsShUrl(url: string): Promise<{ tarballUrl: stri
   // Skills.sh repos typically follow the convention: skills/{skill-name}/SKILL.md
   // Probe which sub_path exists in the repo
   let subPath = skillName;
-  for (const candidate of [`skills/${skillName}`, skillName]) {
+  for (const candidate of [`skills/${skillName}`, `src/skills/${skillName}`, skillName]) {
     try {
       const probeUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${candidate}`;
       const probeResp = await fetch(probeUrl, {
@@ -437,7 +437,7 @@ export async function fetchSkillFileFromGitHub(
   const { branch } = await resolveDefaultBranch(owner, repo);
 
   // Try direct path first, optionally skills/{skillPath} (common skills.sh convention)
-  const pathCandidates = options?.trySkillsConvention ? [skillPath, `skills/${skillPath}`] : [skillPath];
+  const pathCandidates = options?.trySkillsConvention ? [skillPath, `skills/${skillPath}`, `src/skills/${skillPath}`] : [skillPath];
 
   for (const path of pathCandidates) {
     for (const filename of candidates) {

--- a/apps/registry/src/lib/scan/url-expander.ts
+++ b/apps/registry/src/lib/scan/url-expander.ts
@@ -437,7 +437,9 @@ export async function fetchSkillFileFromGitHub(
   const { branch } = await resolveDefaultBranch(owner, repo);
 
   // Try direct path first, optionally skills/{skillPath} (common skills.sh convention)
-  const pathCandidates = options?.trySkillsConvention ? [skillPath, `skills/${skillPath}`, `src/skills/${skillPath}`] : [skillPath];
+  const pathCandidates = options?.trySkillsConvention
+    ? [skillPath, `skills/${skillPath}`, `src/skills/${skillPath}`]
+    : [skillPath];
 
   for (const path of pathCandidates) {
     for (const filename of candidates) {

--- a/apps/registry/src/services/__tests__/external-skills-scan.test.ts
+++ b/apps/registry/src/services/__tests__/external-skills-scan.test.ts
@@ -50,8 +50,8 @@ vi.mock('~/lib/scan/url-expander', () => ({
   expandScanUrl: vi.fn()
 }));
 
-import { scanExternalSkills, updateExternalSkillScanResult } from '../external-skills';
 import { expandScanUrl } from '~/lib/scan/url-expander';
+import { scanExternalSkills, updateExternalSkillScanResult } from '../external-skills';
 
 describe('scanExternalSkills', () => {
   afterEach(() => {
@@ -68,9 +68,7 @@ describe('scanExternalSkills', () => {
   });
 
   it('scans skills with null verdict via tarball mode', async () => {
-    mockStore.selectResult = [
-      { id: '1', url: 'https://skills.sh/owner/repo/skill1' }
-    ];
+    mockStore.selectResult = [{ id: '1', url: 'https://skills.sh/owner/repo/skill1' }];
 
     vi.mocked(expandScanUrl).mockResolvedValueOnce({
       tarballUrl: 'https://codeload.github.com/owner/repo/tar.gz/main',
@@ -94,9 +92,7 @@ describe('scanExternalSkills', () => {
   });
 
   it('handles scan errors gracefully', async () => {
-    mockStore.selectResult = [
-      { id: '2', url: 'https://skills.sh/owner/repo/broken' }
-    ];
+    mockStore.selectResult = [{ id: '2', url: 'https://skills.sh/owner/repo/broken' }];
 
     vi.mocked(expandScanUrl).mockResolvedValueOnce({
       tarballUrl: '',
@@ -114,9 +110,7 @@ describe('scanExternalSkills', () => {
   });
 
   it('scans skills via single-file mode when fileContent is present', async () => {
-    mockStore.selectResult = [
-      { id: '3', url: 'https://skills.sh/owner/repo/skill2' }
-    ];
+    mockStore.selectResult = [{ id: '3', url: 'https://skills.sh/owner/repo/skill2' }];
 
     vi.mocked(expandScanUrl).mockResolvedValueOnce({
       tarballUrl: '',

--- a/apps/registry/src/services/__tests__/external-skills-scan.test.ts
+++ b/apps/registry/src/services/__tests__/external-skills-scan.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock logger
+vi.mock('~/services/logger', () => ({
+  log: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }
+}));
+
+// Mock env
+vi.mock('~/consts/env', () => ({
+  env: {
+    PYTHON_API_URL: 'http://localhost:8000',
+    SCANNER_SERVICE_KEY: 'test-key'
+  }
+}));
+
+// Mock schemas with plain string column names (Drizzle columns used as identifiers)
+vi.mock('~/lib/db/schema', () => ({
+  externalSkills: {
+    url: 'url',
+    scanVerdict: 'scanVerdict',
+    scanResult: 'scanResult',
+    scannedAt: 'scannedAt',
+    updatedAt: 'updatedAt'
+  }
+}));
+
+// Helpers to set mock return values (declared before mock factories that reference them)
+const mockStore = { selectResult: [] as unknown[] };
+
+vi.mock('~/lib/db', () => {
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => mockStore.selectResult
+        })
+      })
+    }),
+    update: () => ({
+      set: () => ({
+        where: async () => {}
+      })
+    })
+  };
+  return { db };
+});
+
+// Mock url-expander
+vi.mock('~/lib/scan/url-expander', () => ({
+  expandScanUrl: vi.fn()
+}));
+
+import { scanExternalSkills, updateExternalSkillScanResult } from '../external-skills';
+import { expandScanUrl } from '~/lib/scan/url-expander';
+
+describe('scanExternalSkills', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockStore.selectResult = [];
+  });
+
+  it('does nothing when no unscanned skills exist', async () => {
+    mockStore.selectResult = [];
+
+    await scanExternalSkills();
+
+    expect(expandScanUrl).not.toHaveBeenCalled();
+  });
+
+  it('scans skills with null verdict via tarball mode', async () => {
+    mockStore.selectResult = [
+      { id: '1', url: 'https://skills.sh/owner/repo/skill1' }
+    ];
+
+    vi.mocked(expandScanUrl).mockResolvedValueOnce({
+      tarballUrl: 'https://codeload.github.com/owner/repo/tar.gz/main',
+      subPath: 'skill1',
+      fileContent: null,
+      urlType: 'skills_sh',
+      contentType: null
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ verdict: 'safe', findings: [], duration_ms: 100 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    await scanExternalSkills();
+
+    expect(expandScanUrl).toHaveBeenCalledWith('https://skills.sh/owner/repo/skill1');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles scan errors gracefully', async () => {
+    mockStore.selectResult = [
+      { id: '2', url: 'https://skills.sh/owner/repo/broken' }
+    ];
+
+    vi.mocked(expandScanUrl).mockResolvedValueOnce({
+      tarballUrl: '',
+      subPath: null,
+      fileContent: null,
+      urlType: 'unknown',
+      contentType: null,
+      error: 'Repository not found'
+    });
+
+    // Should not throw — error verdict is written
+    await scanExternalSkills();
+
+    expect(expandScanUrl).toHaveBeenCalledWith('https://skills.sh/owner/repo/broken');
+  });
+
+  it('scans skills via single-file mode when fileContent is present', async () => {
+    mockStore.selectResult = [
+      { id: '3', url: 'https://skills.sh/owner/repo/skill2' }
+    ];
+
+    vi.mocked(expandScanUrl).mockResolvedValueOnce({
+      tarballUrl: '',
+      subPath: null,
+      fileContent: '# Skill\nContent here',
+      urlType: 'skills_sh',
+      contentType: 'text/markdown'
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ verdict: 'safe', findings: [], duration_ms: 50 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    await scanExternalSkills();
+
+    // Verify scanner was called with single_file_content
+    const requestInit = fetchSpy.mock.calls[0][1] as RequestInit;
+    const callBody = JSON.parse(requestInit.body as string);
+    expect(callBody.single_file_content).toBe('# Skill\nContent here');
+    expect(callBody.single_file_name).toBe('SKILL.md');
+  });
+});
+
+describe('updateExternalSkillScanResult', () => {
+  it('updates external_skills row by URL without throwing', async () => {
+    await expect(
+      updateExternalSkillScanResult(
+        'https://skills.sh/owner/repo/skill1',
+        'safe',
+        { verdict: 'safe', findings: [], duration_ms: 100 },
+        new Date('2026-01-01')
+      )
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/registry/src/services/external-skills.ts
+++ b/apps/registry/src/services/external-skills.ts
@@ -12,8 +12,8 @@ import { z } from 'zod';
 import { env } from '~/consts/env';
 import { db } from '~/lib/db';
 import { externalSkills } from '~/lib/db/schema';
-import { escapeLike } from '~/lib/skills/data';
 import { expandScanUrl } from '~/lib/scan/url-expander';
+import { escapeLike } from '~/lib/skills/data';
 import { log as baseLog } from '~/services/logger';
 
 const log = baseLog.child({ module: 'external-skills' });
@@ -390,16 +390,15 @@ export async function scanExternalSkills(): Promise<void> {
   if (scanInProgress) return;
   scanInProgress = true;
   try {
+    const oneHourAgo = new Date(Date.now() - 3_600_000);
 
-  const oneHourAgo = new Date(Date.now() - 3_600_000);
+    const unscanned = await db
+      .select({ id: externalSkills.id, url: externalSkills.url })
+      .from(externalSkills)
+      .where(or(isNull(externalSkills.scanVerdict), sql`${externalSkills.scannedAt} < ${oneHourAgo}`))
+      .limit(20);
 
-  const unscanned = await db
-    .select({ id: externalSkills.id, url: externalSkills.url })
-    .from(externalSkills)
-    .where(or(isNull(externalSkills.scanVerdict), sql`${externalSkills.scannedAt} < ${oneHourAgo}`))
-    .limit(20);
-
-  if (unscanned.length === 0) return;
+    if (unscanned.length === 0) return;
 
     log.info({ count: unscanned.length }, 'Starting background scan for external skills');
 
@@ -408,7 +407,12 @@ export async function scanExternalSkills(): Promise<void> {
         const expanded = await expandScanUrl(skill.url);
 
         if (expanded.error) {
-          await updateExternalSkillScanResult(skill.url, 'error', { verdict: 'error', findings: [], duration_ms: 0 }, new Date());
+          await updateExternalSkillScanResult(
+            skill.url,
+            'error',
+            { verdict: 'error', findings: [], duration_ms: 0 },
+            new Date()
+          );
           continue;
         }
 

--- a/apps/registry/src/services/external-skills.ts
+++ b/apps/registry/src/services/external-skills.ts
@@ -6,12 +6,14 @@
  * API is unreachable.
  */
 
-import { sql } from 'drizzle-orm';
+import { eq, isNull, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
+import { env } from '~/consts/env';
 import { db } from '~/lib/db';
 import { externalSkills } from '~/lib/db/schema';
 import { escapeLike } from '~/lib/skills/data';
+import { expandScanUrl } from '~/lib/scan/url-expander';
 import { log as baseLog } from '~/services/logger';
 
 const log = baseLog.child({ module: 'external-skills' });
@@ -137,9 +139,9 @@ const SEED_SKILLS: Array<{
   },
   {
     name: 'shadcn',
-    url: 'https://skills.sh/shadcn/ui/shadcn',
+    url: 'https://skills.sh/shadcn-ui/ui/shadcn',
     description: 'Build UIs with shadcn/ui components and design system patterns.',
-    author: 'shadcn',
+    author: 'shadcn-ui',
     installCount: 12000
   },
   {
@@ -343,6 +345,120 @@ export async function fetchAndCacheExternalSkills(): Promise<void> {
         }
       }
     }
+  }
+
+  // Fire background scan for skills that need it (non-blocking)
+  scanExternalSkills().catch((err) => {
+    log.warn({ error: String(err) }, 'Background scan failed');
+  });
+}
+
+/**
+ * Update scan result for an external skill by URL.
+ */
+export async function updateExternalSkillScanResult(
+  sourceUrl: string,
+  verdict: string,
+  scanResult: {
+    verdict: string;
+    findings: Array<{
+      stage: string;
+      severity: string;
+      type: string;
+      description: string;
+      location: string | null;
+      tool: string | null;
+    }>;
+    duration_ms: number;
+  },
+  scannedAt: Date
+): Promise<void> {
+  await db
+    .update(externalSkills)
+    .set({ scanVerdict: verdict, scanResult, scannedAt, updatedAt: new Date() })
+    .where(eq(externalSkills.url, sourceUrl));
+}
+
+/**
+ * Scan external skills that don't have a scan verdict yet.
+ * Runs sequentially with rate-limit delay to avoid hammering GitHub/Python API.
+ */
+let scanInProgress = false;
+
+export async function scanExternalSkills(): Promise<void> {
+  if (!env.PYTHON_API_URL) return;
+  if (scanInProgress) return;
+  scanInProgress = true;
+  try {
+
+  const oneHourAgo = new Date(Date.now() - 3_600_000);
+
+  const unscanned = await db
+    .select({ id: externalSkills.id, url: externalSkills.url })
+    .from(externalSkills)
+    .where(or(isNull(externalSkills.scanVerdict), sql`${externalSkills.scannedAt} < ${oneHourAgo}`))
+    .limit(20);
+
+  if (unscanned.length === 0) return;
+
+    log.info({ count: unscanned.length }, 'Starting background scan for external skills');
+
+    for (const skill of unscanned) {
+      try {
+        const expanded = await expandScanUrl(skill.url);
+
+        if (expanded.error) {
+          await updateExternalSkillScanResult(skill.url, 'error', { verdict: 'error', findings: [], duration_ms: 0 }, new Date());
+          continue;
+        }
+
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (env.SCANNER_SERVICE_KEY) headers['X-Scanner-Key'] = env.SCANNER_SERVICE_KEY;
+
+        const body = expanded.fileContent
+          ? {
+              tarball_url: '',
+              version_id: `bg-scan-${crypto.randomUUID()}`,
+              manifest: {},
+              permissions: {},
+              single_file_content: expanded.fileContent,
+              single_file_name: 'SKILL.md',
+              single_file_content_type: expanded.contentType ?? 'text/markdown'
+            }
+          : {
+              tarball_url: expanded.tarballUrl,
+              version_id: `bg-scan-${crypto.randomUUID()}`,
+              manifest: {},
+              permissions: {},
+              sub_path: expanded.subPath ?? undefined
+            };
+
+        const scanResponse = await fetch(`${env.PYTHON_API_URL}/api/analyze/scan`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(55_000)
+        });
+
+        if (!scanResponse.ok) {
+          log.warn({ url: skill.url, status: scanResponse.status }, 'Background scan failed');
+          continue;
+        }
+
+        const scanResult = await scanResponse.json();
+        const verdict = scanResult.verdict ?? 'unknown';
+        await updateExternalSkillScanResult(skill.url, verdict, scanResult, new Date());
+
+        log.info({ url: skill.url, verdict }, 'Background scan completed');
+
+        // Rate limit: 3s delay between scans
+        await new Promise((resolve) => setTimeout(resolve, 3_000));
+      } catch (err) {
+        log.warn({ url: skill.url, error: String(err) }, 'Background scan error for skill');
+      }
+    }
+  } finally {
+    scanInProgress = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix external skills on top-skills page never being scanned (5 root causes, 6 acceptance criteria)
- Fix shadcn seed URL (`shadcn/ui` → `shadcn-ui/ui`, renamed repo)
- Add `src/skills/` probing path for non-standard repo structures (e.g. `pbakaus/impeccable`)
- Raise tarball download limit 50MB→100MB and move sub_path narrowing before extracted size check (monorepo support)
- Add `scanExternalSkills()` background scan with concurrency guard + scan result writeback from `/api/v1/scan`

## Changes
- `apps/registry/src/services/external-skills.ts` — seed URL fix, `scanExternalSkills()`, `updateExternalSkillScanResult()`, concurrency guard
- `apps/registry/src/lib/scan/url-expander.ts` — added `src/skills/` to probing candidates
- `apps/python-api/lib/scan/stage0_ingest.py` — MAX_TARBALL_SIZE 100MB, reordered narrow before size check
- `apps/registry/src/api/routes/v1/scan.ts` — writeback scan results to `external_skills` table
- `apps/registry/src/services/__tests__/external-skills-scan.test.ts` — new: 5 tests
- `apps/registry/src/lib/scan/__tests__/url-expander.test.ts` — new probing test
- `apps/python-api/tests/test_stage0_ingest_ordering.py` — new: AST ordering assertions

## Test plan
- [x] 22 url-expander tests pass (vitest)
- [x] 5 external-skills-scan tests pass (vitest)
- [x] Python AST assertions pass (100MB limit + correct ordering)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Lint clean on changed files (Biome)
- [ ] Verify top-skills page shows scan verdicts after deploy
- [ ] Verify shadcn skill resolves correctly on nightly

Co-Authored-By: Claude <noreply@anthropic.com>