### PR TITLE
fix(cli): handle undefined audit_score/duration_ms from scan API

### DIFF
--- a/packages/cli/src/lib/scan-gate.ts
+++ b/packages/cli/src/lib/scan-gate.ts
@@ -181,9 +181,9 @@ export async function scanUrl(url: string, options?: { token?: string; registryU
   return {
     success: true,
     verdict: data.verdict,
-    auditScore: data.audit_score,
+    auditScore: data.audit_score ?? null,
     findings,
-    durationMs: data.duration_ms
+    durationMs: data.duration_ms ?? null
   };
 }
 


### PR DESCRIPTION
## Summary

- Coalesce `undefined` API response fields (`audit_score`, `duration_ms`) to `null` so existing null guards in `displayScanResults` work correctly
- Without this fix, `toFixed()` crashes on `undefined` when the scan API omits these fields

## Root Cause

`scanUrl()` mapped API fields directly without null coalescing. `displayScanResults` checks `!== null` but `undefined` passes that check, causing a runtime crash.

## Testing

Discovered during live local demo of `tank install <url>`. The scan API for some repos omits `audit_score` and `duration_ms`.