### PR TITLE
fix(ci): build @internals/adapters before CLI in nightly and release pipelines

### DIFF
--- a/justfile
+++ b/justfile
@@ -66,6 +66,7 @@ scan:
 # just build mcp     - MCP server via tsdown
 # just build internals-schemas - shared contract schemas via tsdown
 # just build internals-helpers - shared helpers via tsdown
+# just build adapters - platform adapters via tsdown
 # just build binary  - standalone CLI executable (tsdown + esbuild + SEA)
 [group('build')]
 build target='all':
@@ -78,9 +79,10 @@ build target='all':
         sdk)     bun run --filter @tankpkg/sdk build ;;
         internals-schemas) bun run --filter @internals/schemas build ;;
         internals-helpers) bun run --filter @internals/helpers build ;;
+        adapters) bun run --filter @internals/adapters build ;;
         binary) bun run --filter @tankpkg/cli build:binary ;;
         all)    bun turbo build ;;
-        *) echo "Unknown target: {{target}}. Use: registry, cli, mcp, sdk, internals-schemas, internals-helpers, binary, all" && exit 1 ;;
+        *) echo "Unknown target: {{target}}. Use: registry, cli, mcp, sdk, internals-schemas, internals-helpers, adapters, binary, all" && exit 1 ;;
     esac
 
 # just fmt        - format all code (TypeScript + Python)
@@ -344,6 +346,7 @@ ci-build-cli VERSION:
     just bump {{VERSION}}
     just build internals-schemas
     just build internals-helpers
+    just build adapters
     just build sdk
     just build cli
     just build mcp
@@ -365,6 +368,7 @@ ci-publish-npm-nightly:
     just bump "${NIGHTLY_VERSION}"
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build internals-schemas
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build internals-helpers
+    TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build adapters
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build cli
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build mcp
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build sdk


### PR DESCRIPTION
## Summary

Fixes the broken `@tankpkg/cli` npm package that crashes with `ERR_MODULE_NOT_FOUND: Cannot find package '@internals/adapters'`.

## Root Cause

Both `ci-build-cli` (release) and `ci-publish-npm-nightly` recipes build `internals-schemas` and `internals-helpers` before the CLI, but **skip building `@internals/adapters`**. tsdown's `alwaysBundle` rule needs the compiled `dist/` to exist — without it, the import is left as an external reference in the published bundle.

**Before (broken):** Published dist has `import { ... } from "@internals/adapters"` on line 10 (4,254 lines)
**After (fixed):** All `@internals/*` code is inlined into the bundle (11,613 lines, zero external imports)

## Changes

- Added `adapters` build target to justfile `build` recipe
- Added `just build adapters` step in `ci-build-cli` and `ci-publish-npm-nightly`
- Updated help text to list the new target

## Verification

1. Cleaned `packages/cli/dist/` and `packages/adapters/dist/`
2. Rebuilt using the fixed pipeline order: schemas → helpers → adapters → cli
3. Confirmed zero `@internals/` references in output: `grep -n '@internals/' dist/bin/tank.js` returns nothing
4. Smoke test: `node dist/bin/tank.js --version` → `0.12.1` ✅