### PR TITLE
feat(registry): overhaul home page to showcase full product capabilities

### DIFF
--- a/apps/registry/src/components/home/cli-preview.tsx
+++ b/apps/registry/src/components/home/cli-preview.tsx
@@ -1,54 +1,63 @@
 import { Terminal } from 'lucide-react';
+import { motion } from 'motion/react';
 
 import { INSTALL_COMMAND } from '~/consts/brand';
 import { cliCommands } from '~/consts/homepage';
 
 export function CliPreview() {
   return (
-    <section className="relative py-16 md:py-24 overflow-hidden">
-      <div className="absolute inset-0 bg-linear-to-b from-transparent via-tank/5 to-transparent" />
+    <section className="relative z-[1] border-t border-border" aria-label="CLI preview">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-10"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-sm bg-tank/10 border border-tank/12 mb-4">
+            <Terminal className="w-5 h-5 text-tank" />
+          </div>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            Get started in <span className="text-tank">seconds</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px]">Everything you need, right from the terminal.</p>
+        </motion.div>
 
-      <div className="container mx-auto px-4 relative">
-        <div className="max-w-3xl mx-auto">
-          <div className="text-center mb-8">
-            <div className="inline-flex items-center justify-center w-12 h-12 rounded bg-tank/10 border border-tank/20 mb-4">
-              <Terminal className="w-6 h-6 text-tank" />
-            </div>
-            <h2 className="text-2xl md:text-3xl font-bold tracking-tight mb-3">
-              Get started in <span className="text-tank">seconds</span>
-            </h2>
-            <p className="text-muted-foreground">Everything you need, right from the terminal.</p>
+        <motion.div
+          className="tank-terminal tank-scanlines mx-auto max-w-[640px] rounded overflow-hidden"
+          initial={{ opacity: 0, scale: 0.97 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4 }}>
+          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
+            <span className="size-2.5 rounded-full bg-red-500/50" />
+            <span className="size-2.5 rounded-full bg-yellow-500/50" />
+            <span className="size-2.5 rounded-full bg-tank/50" />
+            <span className="ml-2 text-[11px] text-muted-foreground/50 font-mono">tank-cli</span>
           </div>
 
-          <div className="tank-terminal tank-scanlines rounded overflow-hidden">
-            <div className="flex items-center gap-2 px-4 py-2.5 border-b border-tank/20 bg-tank-midnight">
-              <span className="size-3 rounded-full bg-red-500/80" />
-              <span className="size-3 rounded-full bg-amber-500/80" />
-              <span className="size-3 rounded-full bg-tank/80" />
-              <span className="ml-3 text-xs text-tank/60 font-mono">tank-cli</span>
+          <div className="p-5 space-y-4">
+            <div className="group">
+              <p className="text-[11px] text-muted-foreground/40 mb-1 font-mono"># Install Tank CLI</p>
+              <p className="text-sm font-mono flex items-center gap-2">
+                <span className="text-tank select-none">$</span>
+                <span className="text-foreground/80 group-hover:text-foreground transition-colors">
+                  {INSTALL_COMMAND}
+                </span>
+              </p>
             </div>
-
-            <div className="p-4 md:p-6 space-y-4">
-              <div className="group">
-                <p className="text-xs text-slate-500 mb-1 font-mono"># Install Tank CLI</p>
-                <p className="text-sm md:text-base font-mono flex items-center gap-2">
+            <div className="border-t border-border/50" />
+            {cliCommands.map((item) => (
+              <div key={item.cmd} className="group">
+                <p className="text-[11px] text-muted-foreground/40 mb-1 font-mono"># {item.desc}</p>
+                <p className="text-sm font-mono flex items-center gap-2">
                   <span className="text-tank select-none">$</span>
-                  <span className="text-slate-200 group-hover:text-white transition-colors">{INSTALL_COMMAND}</span>
+                  <span className="text-foreground/80 group-hover:text-foreground transition-colors">{item.cmd}</span>
                 </p>
               </div>
-              <div className="border-t border-tank/10" />
-              {cliCommands.map((item) => (
-                <div key={item.cmd} className="group">
-                  <p className="text-xs text-slate-500 mb-1 font-mono"># {item.desc}</p>
-                  <p className="text-sm md:text-base font-mono flex items-center gap-2">
-                    <span className="text-tank select-none">$</span>
-                    <span className="text-slate-200 group-hover:text-white transition-colors">{item.cmd}</span>
-                  </p>
-                </div>
-              ))}
-            </div>
+            ))}
           </div>
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/apps/registry/src/components/home/comparison-table.tsx
+++ b/apps/registry/src/components/home/comparison-table.tsx
@@ -1,0 +1,179 @@
+import { Check, Minus, X } from 'lucide-react';
+import { motion } from 'motion/react';
+
+const ROWS: Array<{
+  feature: string;
+  npm: 'yes' | 'partial' | 'no';
+  registries: 'yes' | 'partial' | 'no';
+  tank: 'yes' | 'partial' | 'no';
+  npmNote?: string;
+  registriesNote?: string;
+  tankNote?: string;
+}> = [
+  {
+    feature: 'Versioning',
+    npm: 'yes',
+    npmNote: 'Semver',
+    registries: 'partial',
+    registriesNote: 'Git tags / none',
+    tank: 'yes',
+    tankNote: 'Semver + escalation detection'
+  },
+  {
+    feature: 'Lockfile',
+    npm: 'yes',
+    npmNote: 'package-lock.json',
+    registries: 'no',
+    registriesNote: 'None',
+    tank: 'yes',
+    tankNote: 'tank.lock with SHA-512'
+  },
+  {
+    feature: 'Permission model',
+    npm: 'no',
+    registries: 'no',
+    tank: 'yes',
+    tankNote: 'Network, filesystem, subprocess'
+  },
+  {
+    feature: 'Security scanning',
+    npm: 'partial',
+    npmNote: 'npm audit (deps only)',
+    registries: 'partial',
+    registriesNote: 'Basic / none',
+    tank: 'yes',
+    tankNote: '6-stage pipeline'
+  },
+  {
+    feature: 'Audit score',
+    npm: 'no',
+    registries: 'no',
+    tank: 'yes',
+    tankNote: 'Transparent 0\u201310'
+  },
+  {
+    feature: 'Escalation detection',
+    npm: 'no',
+    registries: 'no',
+    tank: 'yes',
+    tankNote: 'Auto-flagged at publish'
+  },
+  {
+    feature: 'Install from URL',
+    npm: 'partial',
+    npmNote: 'No scanning',
+    registries: 'no',
+    tank: 'yes',
+    tankNote: 'Scanned before install'
+  },
+  {
+    feature: 'Self-hosted',
+    npm: 'partial',
+    npmNote: 'Verdaccio etc.',
+    registries: 'no',
+    tank: 'yes',
+    tankNote: '7-step setup wizard'
+  },
+  {
+    feature: 'MCP server',
+    npm: 'no',
+    registries: 'no',
+    tank: 'yes',
+    tankNote: '17 tools, full CLI parity'
+  }
+];
+
+function StatusIcon({ status }: { status: 'yes' | 'partial' | 'no' }) {
+  if (status === 'yes')
+    return (
+      <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-tank/15">
+        <Check className="w-3 h-3 text-tank" />
+      </span>
+    );
+  if (status === 'partial')
+    return (
+      <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-500/15">
+        <Minus className="w-3 h-3 text-amber-500" />
+      </span>
+    );
+  return (
+    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-muted">
+      <X className="w-3 h-3 text-muted-foreground/40" />
+    </span>
+  );
+}
+
+export function ComparisonTable() {
+  return (
+    <section className="relative z-[1] border-t border-border" aria-label="Feature comparison">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            How Tank <span className="text-tank">compares</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px]">
+            Agent skills deserve the same security infrastructure as npm packages — and more.
+          </p>
+        </motion.div>
+
+        <motion.div
+          className="overflow-x-auto rounded border border-border"
+          initial={{ opacity: 0, y: 15 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3, delay: 0.1 }}>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border bg-card/50">
+                <th className="text-left px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60 w-[180px]">
+                  Feature
+                </th>
+                <th className="text-center px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                  npm
+                </th>
+                <th className="text-center px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                  Current Registries
+                </th>
+                <th className="text-center px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                  <span className="text-tank">Tank</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map((row, i) => (
+                <tr key={row.feature} className={`border-b border-border/50 ${i % 2 === 0 ? 'bg-card/20' : ''}`}>
+                  <td className="px-4 py-3 font-medium text-[13px]">{row.feature}</td>
+                  <td className="px-4 py-3 text-center">
+                    <div className="flex flex-col items-center gap-1">
+                      <StatusIcon status={row.npm} />
+                      {row.npmNote && <span className="text-[11px] text-muted-foreground/50">{row.npmNote}</span>}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <div className="flex flex-col items-center gap-1">
+                      <StatusIcon status={row.registries} />
+                      {row.registriesNote && (
+                        <span className="text-[11px] text-muted-foreground/50">{row.registriesNote}</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <div className="flex flex-col items-center gap-1">
+                      <StatusIcon status={row.tank} />
+                      {row.tankNote && <span className="text-[11px] text-tank/70">{row.tankNote}</span>}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/src/components/home/editor-integration.tsx
+++ b/apps/registry/src/components/home/editor-integration.tsx
@@ -1,0 +1,111 @@
+import { Blocks } from 'lucide-react';
+import { motion } from 'motion/react';
+
+const CAPABILITIES = [
+  { label: 'Install & update', desc: 'Install, update, and remove packages without leaving your editor' },
+  { label: 'Search & discover', desc: 'Search the registry and view package details inline' },
+  { label: 'Security scanning', desc: 'Scan packages and view audit results directly' },
+  { label: 'Publish', desc: 'Pack, scan, and publish — all from your IDE' },
+  { label: 'Permissions & verify', desc: 'Check permission budgets and verify lockfile integrity' },
+  { label: 'Diagnostics', desc: 'Run tank doctor to troubleshoot your setup' }
+];
+
+const EDITORS = ['Claude Code', 'Cursor', 'VS Code Copilot', 'OpenCode', 'Windsurf', 'Cline', 'Roo Code'];
+
+export function EditorIntegration() {
+  return (
+    <section className="relative z-[1] border-t border-border" aria-label="Editor integration">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-sm bg-tank/10 border border-tank/12 mb-4">
+            <Blocks className="w-5 h-5 text-tank" />
+          </div>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            Native in your <span className="text-tank">editor</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px] max-w-lg mx-auto">
+            The Tank MCP server gives your AI agent 17 tools — full CLI parity, right inside your IDE. No terminal
+            needed.
+          </p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+          {/* Left — capabilities */}
+          <motion.div
+            className="space-y-3"
+            initial={{ opacity: 0, x: -15 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.3 }}>
+            {CAPABILITIES.map((cap, i) => (
+              <motion.div
+                key={cap.label}
+                className="rounded border border-border bg-card/30 px-4 py-3"
+                initial={{ opacity: 0, y: 8 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: i * 0.05, duration: 0.2 }}>
+                <p className="text-[13px] font-semibold tracking-tight mb-0.5">{cap.label}</p>
+                <p className="text-[12px] text-muted-foreground">{cap.desc}</p>
+              </motion.div>
+            ))}
+          </motion.div>
+
+          {/* Right — terminal-style MCP config */}
+          <motion.div
+            className="tank-terminal tank-scanlines rounded overflow-hidden"
+            initial={{ opacity: 0, x: 15 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.3, delay: 0.1 }}>
+            <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
+              <span className="size-2.5 rounded-full bg-red-500/50" />
+              <span className="size-2.5 rounded-full bg-yellow-500/50" />
+              <span className="size-2.5 rounded-full bg-tank/50" />
+              <span className="ml-2 text-[11px] text-muted-foreground/50 font-mono">mcp config</span>
+            </div>
+            <pre className="p-5 text-[12px] leading-[1.8] overflow-x-auto font-mono">
+              <code>
+                <span className="text-muted-foreground/40">{'{'}</span>
+                {'\n'}
+                {'  '}
+                <span className="text-tank">"mcpServers"</span>
+                <span className="text-muted-foreground/40">: {'{'}</span>
+                {'\n'}
+                {'    '}
+                <span className="text-tank">"tank"</span>
+                <span className="text-muted-foreground/40">: {'{'}</span>
+                {'\n'}
+                {'      '}
+                <span className="text-tank">"command"</span>
+                <span className="text-muted-foreground/40">:</span> <span className="text-amber-400">"npx"</span>
+                <span className="text-muted-foreground/40">,</span>
+                {'\n'}
+                {'      '}
+                <span className="text-tank">"args"</span>
+                <span className="text-muted-foreground/40">:</span>{' '}
+                <span className="text-amber-400">["@tankpkg/mcp-server"]</span>
+                {'\n'}
+                {'    '}
+                <span className="text-muted-foreground/40">{'}'}</span>
+                {'\n'}
+                {'  '}
+                <span className="text-muted-foreground/40">{'}'}</span>
+                {'\n'}
+                <span className="text-muted-foreground/40">{'}'}</span>
+              </code>
+            </pre>
+            <div className="px-5 pb-4">
+              <p className="text-[11px] text-muted-foreground/40 font-mono"># Works with: {EDITORS.join(' · ')}</p>
+            </div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/src/components/home/enterprise-section.tsx
+++ b/apps/registry/src/components/home/enterprise-section.tsx
@@ -1,0 +1,101 @@
+import { Building2 } from 'lucide-react';
+import { motion } from 'motion/react';
+
+const CAPABILITIES = [
+  {
+    title: 'Setup wizard',
+    description:
+      '7-step guided deployment — database, storage, auth providers, scanner LLM, admin user. Production-ready in minutes.'
+  },
+  {
+    title: 'Admin panel',
+    description:
+      'Full moderation dashboard — manage users, packages, organizations. Quarantine, ban, rescan. Every action audit-logged.'
+  },
+  {
+    title: 'Flexible storage',
+    description:
+      'S3-compatible object storage (AWS, MinIO, Cloudflare R2) or local filesystem for single-instance deployments.'
+  },
+  {
+    title: 'SSO & OIDC',
+    description:
+      'Bring your own identity provider — GitHub OAuth, any OIDC-compliant IdP (Okta, Azure AD, Keycloak), or email/password.'
+  },
+  {
+    title: 'Organizations',
+    description:
+      'Teams with scoped publishing, member invitations, and role-based access. Service accounts for CI/CD pipelines.'
+  },
+  {
+    title: 'CLI from your instance',
+    description:
+      'Users install the Tank CLI directly from your instance — pre-configured with your registry URL. No npm required.'
+  }
+];
+
+export function EnterpriseSection() {
+  return (
+    <section className="relative z-[1] border-t border-border" aria-label="Self-hosted deployment">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-sm bg-tank/10 border border-tank/12 mb-4">
+            <Building2 className="w-5 h-5 text-tank" />
+          </div>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            Run it <span className="text-tank">on your infrastructure</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px] max-w-lg mx-auto">
+            One Docker image. Your database, your storage, your auth. Full control, no data leaves your network.
+          </p>
+        </motion.div>
+
+        <motion.div
+          className="tank-terminal tank-scanlines mx-auto max-w-[500px] rounded overflow-hidden mb-10"
+          initial={{ opacity: 0, scale: 0.97 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4 }}>
+          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
+            <span className="size-2.5 rounded-full bg-red-500/50" />
+            <span className="size-2.5 rounded-full bg-yellow-500/50" />
+            <span className="size-2.5 rounded-full bg-tank/50" />
+            <span className="ml-2 text-[11px] text-muted-foreground/50 font-mono">terminal</span>
+          </div>
+          <div className="p-5">
+            <p className="text-[11px] text-muted-foreground/40 mb-1 font-mono"># Deploy Tank in one command</p>
+            <p className="text-sm font-mono">
+              <span className="text-tank select-none">$ </span>
+              <span className="text-foreground/80">docker compose up -d</span>
+            </p>
+            <p className="text-[11px] text-muted-foreground/40 mt-3 mb-1 font-mono"># Open the setup wizard</p>
+            <p className="text-sm font-mono">
+              <span className="text-tank select-none">$ </span>
+              <span className="text-foreground/80">open https://tank.internal/setup</span>
+            </p>
+          </div>
+        </motion.div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {CAPABILITIES.map((cap, i) => (
+            <motion.div
+              key={cap.title}
+              className="rounded border border-border bg-card/30 p-5"
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.05, duration: 0.2 }}>
+              <h3 className="text-[14px] font-bold tracking-tight mb-1.5">{cap.title}</h3>
+              <p className="text-[12px] text-muted-foreground leading-relaxed">{cap.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/src/components/home/faq-section.tsx
+++ b/apps/registry/src/components/home/faq-section.tsx
@@ -1,25 +1,37 @@
 import { HelpCircle } from 'lucide-react';
+import { motion } from 'motion/react';
 
 import { faqItems } from '~/consts/homepage';
 
 export function FaqSection() {
   return (
-    <section className="container mx-auto px-4 py-16 md:py-24">
-      <div className="max-w-3xl mx-auto">
-        <div className="text-center mb-12">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded bg-tank/10 border border-tank/20 mb-4">
-            <HelpCircle className="w-6 h-6 text-tank" />
+    <section className="relative z-[1] border-t border-border" aria-label="FAQ">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-sm bg-tank/10 border border-tank/12 mb-4">
+            <HelpCircle className="w-5 h-5 text-tank" />
           </div>
-          <h2 className="text-2xl md:text-3xl font-bold tracking-tight mb-3">
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
             Frequently Asked <span className="text-tank">Questions</span>
           </h2>
-        </div>
-        <div className="space-y-6">
-          {faqItems.map((item) => (
-            <div key={item.question} className="border border-tank/10 rounded p-5 bg-card/30">
-              <h3 className="font-semibold text-base mb-2">{item.question}</h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">{item.answer}</p>
-            </div>
+        </motion.div>
+        <div className="max-w-[700px] mx-auto space-y-4">
+          {faqItems.map((item, i) => (
+            <motion.div
+              key={item.question}
+              className="rounded border border-border bg-card/30 p-5"
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.05, duration: 0.2 }}>
+              <h3 className="text-[15px] font-bold tracking-tight mb-2">{item.question}</h3>
+              <p className="text-[13px] text-muted-foreground leading-relaxed">{item.answer}</p>
+            </motion.div>
           ))}
         </div>
       </div>

--- a/apps/registry/src/components/home/features-grid.tsx
+++ b/apps/registry/src/components/home/features-grid.tsx
@@ -1,37 +1,52 @@
 import { Shield } from 'lucide-react';
+import { motion } from 'motion/react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { features } from '~/consts/homepage';
 
 export function FeaturesGrid() {
   return (
-    <section className="container mx-auto px-4 pb-16 md:pb-24">
-      <div className="text-center mb-12">
-        <div className="inline-flex items-center justify-center w-12 h-12 rounded bg-tank/10 border border-tank/20 mb-4">
-          <Shield className="w-6 h-6 text-tank" />
-        </div>
-        <h2 className="text-2xl md:text-3xl font-bold tracking-tight mb-3">
-          Security at <span className="text-tank">every layer</span>
-        </h2>
-        <p className="text-muted-foreground max-w-xl mx-auto">
-          From publish to install — every package is scanned, scored, and verified.
-        </p>
-      </div>
+    <section className="relative z-[1] border-t border-border" aria-label="Security features">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-sm bg-tank/10 border border-tank/12 mb-4">
+            <Shield className="w-5 h-5 text-tank" />
+          </div>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            Security at <span className="text-tank">every layer</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px]">
+            From publish to install — every package is scanned, scored, and verified.
+          </p>
+        </motion.div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 max-w-5xl mx-auto">
-        {features.map((feature) => (
-          <Card key={feature.title} className="tank-card bg-card/50 backdrop-blur-sm hover:bg-card/80 group">
-            <CardHeader>
-              <div className="inline-flex h-10 w-10 items-center justify-center rounded bg-tank/10 border border-tank/20 mb-3 group-hover:bg-tank/20 transition-colors">
-                <feature.icon className="h-5 w-5 text-tank" />
-              </div>
-              <CardTitle className="text-base">{feature.title}</CardTitle>
-            </CardHeader>
-            <CardContent className="-mt-2">
-              <p className="text-sm text-muted-foreground leading-relaxed">{feature.description}</p>
-            </CardContent>
-          </Card>
-        ))}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {features.map((feature, i) => (
+            <motion.div
+              key={feature.title}
+              initial={{ opacity: 0, y: 15 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.06, duration: 0.25 }}>
+              <Card className="bg-card/30 border-border hover:bg-card/50 transition-colors group h-full">
+                <CardHeader>
+                  <div className="inline-flex h-9 w-9 items-center justify-center rounded-sm bg-tank/10 border border-tank/12 mb-3 group-hover:bg-tank/15 transition-colors">
+                    <feature.icon className="h-4 w-4 text-tank" />
+                  </div>
+                  <CardTitle className="text-[15px] font-bold tracking-tight">{feature.title}</CardTitle>
+                </CardHeader>
+                <CardContent className="-mt-2">
+                  <p className="text-[13px] text-muted-foreground leading-relaxed">{feature.description}</p>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/apps/registry/src/components/home/hero-section.tsx
+++ b/apps/registry/src/components/home/hero-section.tsx
@@ -58,8 +58,9 @@ export function HeroSection({ starCount, selfhostedAppUrl }: HeroSectionProps) {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.2, delay: 0.1 }}>
-              Integrity verification, permission budgets, and 6-stage security scanning. What npm did for JavaScript,
-              Tank does for AI agents.
+              Install from registries or any URL — every package scanned through a 6-stage security pipeline. Permission
+              budgets, SHA-512 lockfiles, and escalation detection. What npm did for JavaScript, Tank does for AI
+              agents.
             </motion.p>
 
             {/* Install method selector — biggest CTA */}

--- a/apps/registry/src/components/home/how-it-works.tsx
+++ b/apps/registry/src/components/home/how-it-works.tsx
@@ -4,20 +4,39 @@ const STEPS = [
   {
     number: '1',
     title: 'Publish with scanning',
-    description:
-      'Every package passes through a 6-stage security pipeline. Malware, secrets, and permission escalation are caught at publish time.'
+    description: 'Every package passes through a 6-stage security pipeline before it reaches the registry.',
+    stages: [
+      'Ingestion & hashing',
+      'Structure validation',
+      'Static analysis (Semgrep + Bandit)',
+      'Injection detection',
+      'Secrets scanning (detect-secrets)',
+      'Dependency audit (OSV)'
+    ]
   },
   {
     number: '2',
     title: 'Install with integrity',
     description:
-      'Every package is pinned with SHA-512 hashes. If the content changes after install, the next install fails. No silent tampering.'
+      'Every package is pinned with SHA-512 hashes in a lockfile. If the content changes after install, the next verify fails.',
+    stages: [
+      'SHA-512 integrity hashing',
+      'Lockfile pinning (tank.lock)',
+      'Tamper detection on verify',
+      'Install from URL — scanned first'
+    ]
   },
   {
     number: '3',
     title: 'Run with permissions',
     description:
-      'Declare what your agent can do — network, filesystem, subprocess. Packages exceeding the budget are rejected before they run.'
+      'Declare what your agent can do. Packages exceeding the permission budget are rejected before they run.',
+    stages: [
+      'Network outbound allowlists',
+      'Filesystem read/write scopes',
+      'Subprocess enable/disable',
+      'Escalation detection on update'
+    ]
   }
 ];
 
@@ -32,7 +51,7 @@ export function HowItWorks() {
           viewport={{ once: true }}
           transition={{ duration: 0.3 }}>
           <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">How Tank Works</h2>
-          <p className="text-muted-foreground text-[15px]">Three steps from install to verified.</p>
+          <p className="text-muted-foreground text-[15px]">Three steps from publish to verified.</p>
         </motion.div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -48,7 +67,15 @@ export function HowItWorks() {
                 {step.number}
               </span>
               <h3 className="text-[15px] font-bold tracking-tight mb-2">{step.title}</h3>
-              <p className="text-[13px] text-muted-foreground leading-relaxed">{step.description}</p>
+              <p className="text-[13px] text-muted-foreground leading-relaxed mb-4">{step.description}</p>
+              <ul className="space-y-1.5">
+                {step.stages.map((stage) => (
+                  <li key={stage} className="flex items-start gap-2 text-[12px] text-muted-foreground/70">
+                    <span className="text-tank mt-0.5 text-[10px]">▸</span>
+                    <span>{stage}</span>
+                  </li>
+                ))}
+              </ul>
             </motion.div>
           ))}
         </div>

--- a/apps/registry/src/components/home/works-with.tsx
+++ b/apps/registry/src/components/home/works-with.tsx
@@ -5,7 +5,10 @@ const TOOLS = [
   { name: 'Cursor', icon: '⊞' },
   { name: 'GitHub Copilot', icon: '◆' },
   { name: 'Codex', icon: '▸' },
-  { name: 'Windsurf', icon: '◇' }
+  { name: 'Windsurf', icon: '◇' },
+  { name: 'OpenCode', icon: '⌘' },
+  { name: 'Cline', icon: '▹' },
+  { name: 'Roo Code', icon: '◈' }
 ];
 
 export function WorksWith() {

--- a/apps/registry/src/consts/homepage.ts
+++ b/apps/registry/src/consts/homepage.ts
@@ -38,10 +38,12 @@ export const features: Array<{ icon: LucideIcon; title: string; description: str
 ];
 
 export const cliCommands = [
-  { cmd: 'tank install @vercel/next-skill', desc: 'Install with integrity verification' },
-  { cmd: 'tank permissions', desc: 'See what your agent can do' },
-  { cmd: 'tank audit', desc: 'Check security scan results' },
-  { cmd: 'tank publish', desc: 'Publish with 6-stage analysis' }
+  { cmd: 'tank install @vercel/next-skill', desc: 'Install from registry with integrity verification' },
+  { cmd: 'tank install https://github.com/org/skill', desc: 'Install from any URL — scanned before install' },
+  { cmd: 'tank permissions', desc: 'See what your agent is allowed to do' },
+  { cmd: 'tank audit', desc: 'View 6-stage security scan results' },
+  { cmd: 'tank build', desc: 'Compile for Claude Code, Cursor, OpenCode, and more' },
+  { cmd: 'tank doctor', desc: 'Diagnose your setup in one command' }
 ];
 
 export const faqItems = [

--- a/apps/registry/src/screens/home-screen.tsx
+++ b/apps/registry/src/screens/home-screen.tsx
@@ -3,6 +3,12 @@ import { ArrowRight, Users } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useMemo } from 'react';
 
+import { CliPreview } from '~/components/home/cli-preview';
+import { ComparisonTable } from '~/components/home/comparison-table';
+import { EditorIntegration } from '~/components/home/editor-integration';
+import { EnterpriseSection } from '~/components/home/enterprise-section';
+import { FaqSection } from '~/components/home/faq-section';
+import { FeaturesGrid } from '~/components/home/features-grid';
 import { HeroSection } from '~/components/home/hero-section';
 import { HowItWorks } from '~/components/home/how-it-works';
 import { WhyTankExists } from '~/components/home/why-tank-exists';
@@ -70,13 +76,25 @@ export function HomeScreen({ publicSkillCount, starCount, selfhostedAppUrl }: Ho
 
       <WorksWith />
 
+      <ComparisonTable />
+
       <WhyTankExists />
 
       <HowItWorks />
 
+      <FeaturesGrid />
+
       <TankJsonExample />
 
+      <CliPreview />
+
+      <EditorIntegration />
+
+      <EnterpriseSection />
+
       <ContributorsSection />
+
+      <FaqSection />
 
       <BottomCta starCount={starCount} />
     </>
@@ -233,7 +251,6 @@ function ContributorsSection() {
 function BottomCta({ starCount }: { starCount: number | null }) {
   return (
     <section className="relative z-[1] border-t border-border overflow-hidden" aria-label="Call to action">
-      {/* Radial glow */}
       <div
         className="pointer-events-none absolute bottom-0 left-1/2 -translate-x-1/2 w-[500px] h-[300px]"
         style={{ background: 'radial-gradient(ellipse, rgba(0,255,65,0.04) 0%, transparent 60%)' }}


### PR DESCRIPTION
## Summary

- Activates 3 orphaned components (FeaturesGrid, CliPreview, FaqSection) that were coded but never imported
- Adds 3 new sections: Comparison Table, Editor/MCP Integration, Enterprise/Self-Hosted
- Expands Works With from 5 → 8 tools (OpenCode, Cline, Roo Code)
- Updates hero subtitle, How It Works scanner stages, CLI preview commands
- Section count: 7 → 14

## New Sections

| Section | Description |
|---|---|
| **Comparison Table** | npm vs registries vs Tank across 9 feature dimensions |
| **Editor Integration** | MCP server with 17 tools, opencode.json config example |
| **Enterprise / Self-Hosted** | 6 capability cards + docker-compose snippet |

## Verification

- [x] TypeScript typecheck clean
- [x] Biome lint clean (zero new warnings)
- [x] Production build passes (1.22s)
- [x] Pre-push hooks pass (lint + format + typecheck)