### PR TITLE
feat(registry): add Credential Vault, Atoms, and expanded features to home page

### DIFF
--- a/apps/registry/src/components/home/atoms-section.tsx
+++ b/apps/registry/src/components/home/atoms-section.tsx
@@ -1,0 +1,157 @@
+import { Atom } from 'lucide-react';
+import { motion } from 'motion/react';
+
+const ATOM_TYPES = [
+  { emoji: '📜', kind: 'instruction', desc: 'System prompts & behavioral rules' },
+  { emoji: '🪝', kind: 'hook', desc: 'Lifecycle events (pre-file-write, pre-command, ...)' },
+  { emoji: '🔧', kind: 'tool', desc: 'MCP tools agents can invoke' },
+  { emoji: '🤖', kind: 'agent', desc: 'Autonomous sub-agents with scoped roles' },
+  { emoji: '🛡', kind: 'rule', desc: 'Guardrails & constraints that override instructions' },
+  { emoji: '📡', kind: 'resource', desc: 'External data sources (APIs, databases, files)' },
+  { emoji: '💬', kind: 'prompt', desc: 'Reusable prompt templates with variables' }
+];
+
+const PLATFORMS = ['Claude Code', 'Cursor', 'OpenCode', 'Windsurf', 'Cline', 'Roo Code'];
+
+export function AtomsSection() {
+  return (
+    <section className="relative z-[1] border-t border-border" aria-label="Atoms architecture">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-sm bg-tank/10 border border-tank/12 mb-4">
+            <Atom className="w-5 h-5 text-tank" />
+          </div>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            7 primitives. <span className="text-tank">Every platform.</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px] max-w-lg mx-auto">
+            Atoms are the building blocks of AI agent skills. Write once in{' '}
+            <code className="text-sm bg-muted px-1.5 py-0.5 rounded font-mono">tank.json</code>, compile to native
+            configs for every editor.
+          </p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-10">
+          {ATOM_TYPES.map((atom, i) => (
+            <motion.div
+              key={atom.kind}
+              className="rounded border border-border bg-card/30 hover:bg-card/50 transition-colors px-4 py-3"
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.04, duration: 0.2 }}>
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-base" aria-hidden="true">
+                  {atom.emoji}
+                </span>
+                <span className="text-[13px] font-bold tracking-tight font-mono">{atom.kind}</span>
+              </div>
+              <p className="text-[11px] text-muted-foreground leading-relaxed">{atom.desc}</p>
+            </motion.div>
+          ))}
+
+          <motion.div
+            className="rounded border border-dashed border-border bg-card/20 px-4 py-3 flex items-center"
+            initial={{ opacity: 0, y: 10 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.3, duration: 0.2 }}>
+            <div>
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-base" aria-hidden="true">
+                  📦
+                </span>
+                <span className="text-[13px] font-bold tracking-tight font-mono">bundle</span>
+              </div>
+              <p className="text-[11px] text-muted-foreground leading-relaxed">
+                Combine 2+ atoms into a single installable skill
+              </p>
+            </div>
+          </motion.div>
+        </div>
+
+        <motion.div
+          className="tank-terminal tank-scanlines mx-auto max-w-[640px] rounded overflow-hidden"
+          initial={{ opacity: 0, scale: 0.97 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4 }}>
+          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
+            <span className="size-2.5 rounded-full bg-red-500/50" />
+            <span className="size-2.5 rounded-full bg-yellow-500/50" />
+            <span className="size-2.5 rounded-full bg-tank/50" />
+            <span className="ml-2 text-[11px] text-muted-foreground/50 font-mono">cross-platform build</span>
+          </div>
+          <div className="p-5 space-y-4">
+            <div>
+              <p className="text-[11px] text-muted-foreground/40 mb-1 font-mono">
+                # One command compiles for every editor
+              </p>
+              <p className="text-sm font-mono">
+                <span className="text-tank select-none">$ </span>
+                <span className="text-foreground/80">tank build</span>
+              </p>
+            </div>
+            <div className="border-t border-border/50" />
+            <div className="space-y-1.5">
+              <p className="text-[12px] font-mono text-tank">build</p>
+              <p className="text-[12px] font-mono text-muted-foreground/70">
+                {'  '}Reading <span className="text-amber-400">tank.json</span> → 3 instructions, 2 hooks, 1 tool
+              </p>
+              <p className="text-[12px] font-mono text-muted-foreground/70">
+                {'  '}
+                <span className="text-muted-foreground/40">├</span> .claude/commands/ {'  '}
+                <span className="text-tank">✓</span>
+              </p>
+              <p className="text-[12px] font-mono text-muted-foreground/70">
+                {'  '}
+                <span className="text-muted-foreground/40">├</span> .cursor/rules/ {'     '}
+                <span className="text-tank">✓</span>
+              </p>
+              <p className="text-[12px] font-mono text-muted-foreground/70">
+                {'  '}
+                <span className="text-muted-foreground/40">├</span> .opencode/ {'         '}
+                <span className="text-tank">✓</span>
+              </p>
+              <p className="text-[12px] font-mono text-muted-foreground/70">
+                {'  '}
+                <span className="text-muted-foreground/40">├</span> .windsurf/rules/ {'  '}
+                <span className="text-tank">✓</span>
+              </p>
+              <p className="text-[12px] font-mono text-muted-foreground/70">
+                {'  '}
+                <span className="text-muted-foreground/40">└</span> .clinerules/ {'      '}
+                <span className="text-tank">✓</span>
+              </p>
+            </div>
+            <div className="border-t border-border/50" />
+            <p className="text-[12px] font-mono text-tank">
+              compiled <span className="text-amber-400">6 atoms</span> for{' '}
+              <span className="text-amber-400">5 platforms</span>
+            </p>
+          </div>
+        </motion.div>
+
+        <motion.div
+          className="flex flex-wrap justify-center gap-2 mt-8"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.2, duration: 0.3 }}>
+          {PLATFORMS.map((platform) => (
+            <span
+              key={platform}
+              className="inline-flex items-center rounded-full border border-border bg-card/30 px-3 py-1 text-[12px] font-medium text-muted-foreground">
+              {platform}
+            </span>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/src/components/home/features-grid.tsx
+++ b/apps/registry/src/components/home/features-grid.tsx
@@ -25,7 +25,7 @@ export function FeaturesGrid() {
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           {features.map((feature, i) => (
             <motion.div
               key={feature.title}

--- a/apps/registry/src/components/home/vault-section.tsx
+++ b/apps/registry/src/components/home/vault-section.tsx
@@ -1,0 +1,152 @@
+import { KeyRound, ShieldCheck } from 'lucide-react';
+import { motion } from 'motion/react';
+
+const CREDENTIAL_TYPES = [
+  { prefix: 'sk_live_', label: 'Stripe' },
+  { prefix: 'AKIA', label: 'AWS' },
+  { prefix: 'ghp_', label: 'GitHub' },
+  { prefix: 'sk-proj-', label: 'OpenAI' },
+  { prefix: 'eyJ...', label: 'JWT' },
+  { prefix: 'postgresql://', label: 'Database URLs' },
+  { prefix: 'elvn_', label: 'ElevenLabs' },
+  { prefix: 'hooks.slack.com', label: 'Slack Webhooks' }
+];
+
+const VAULT_LAYERS = [
+  { step: '1', label: 'Detect', desc: '10 credential patterns matched via regex' },
+  { step: '2', label: 'Tokenize', desc: 'CSPRNG format-preserving fakes generated' },
+  { step: '3', label: 'Proxy', desc: 'HTTP intercept swaps fakes before LLM sees them' },
+  { step: '4', label: 'Restore', desc: 'Real credentials restored in agent output' }
+];
+
+export function VaultSection() {
+  return (
+    <section className="relative z-[1] border-t border-border" aria-label="Credential Vault">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <div className="inline-flex items-center justify-center w-10 h-10 rounded-sm bg-tank/10 border border-tank/12 mb-4">
+            <KeyRound className="w-5 h-5 text-tank" />
+          </div>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            Your secrets <span className="text-tank">never leave your machine</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px] max-w-lg mx-auto">
+            The Credential Vault intercepts API keys before they reach any LLM provider. Format-preserving tokenization
+            means agents work normally — but real credentials stay local.
+          </p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+          <motion.div
+            className="tank-terminal tank-scanlines rounded overflow-hidden"
+            initial={{ opacity: 0, x: -15 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.3 }}>
+            <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
+              <span className="size-2.5 rounded-full bg-red-500/50" />
+              <span className="size-2.5 rounded-full bg-yellow-500/50" />
+              <span className="size-2.5 rounded-full bg-tank/50" />
+              <span className="ml-2 text-[11px] text-muted-foreground/50 font-mono">credential vault</span>
+              <span className="ml-auto flex items-center gap-1.5">
+                <ShieldCheck className="w-3 h-3 text-tank" />
+                <span className="text-[11px] text-tank font-mono">protected</span>
+              </span>
+            </div>
+            <div className="p-5 space-y-4">
+              <div>
+                <p className="text-[11px] text-muted-foreground/40 mb-1 font-mono">
+                  # Launch agent with vault protection
+                </p>
+                <p className="text-sm font-mono">
+                  <span className="text-tank select-none">$ </span>
+                  <span className="text-foreground/80">tank run claude</span>
+                </p>
+              </div>
+              <div className="border-t border-border/50" />
+              <div className="space-y-1.5">
+                <p className="text-[12px] font-mono text-tank">vault</p>
+                <p className="text-[12px] font-mono text-muted-foreground/70">
+                  {'  '}Detected <span className="text-amber-400">3 credentials</span> in environment
+                </p>
+                <p className="text-[12px] font-mono text-muted-foreground/70">
+                  {'  '}
+                  <span className="text-muted-foreground/40">├</span> sk_live_4eC39H → sk_live_
+                  <span className="text-tank">fK9mR2vL8nP3</span>
+                </p>
+                <p className="text-[12px] font-mono text-muted-foreground/70">
+                  {'  '}
+                  <span className="text-muted-foreground/40">├</span> AKIAIOSFODNN → AKIA
+                  <span className="text-tank">XQMR7NWG5BPT</span>
+                </p>
+                <p className="text-[12px] font-mono text-muted-foreground/70">
+                  {'  '}
+                  <span className="text-muted-foreground/40">└</span> ghp_xxMJsa91 → ghp_
+                  <span className="text-tank">kL4nR8vP2mQ6wX</span>
+                </p>
+              </div>
+              <div className="border-t border-border/50" />
+              <p className="text-[12px] font-mono text-tank">
+                proxy listening on 127.0.0.1:9384
+                <br />
+                <span className="text-muted-foreground/70">launching claude with vault protection...</span>
+              </p>
+            </div>
+          </motion.div>
+
+          <motion.div
+            className="space-y-5"
+            initial={{ opacity: 0, x: 15 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.3, delay: 0.1 }}>
+            <div className="space-y-2.5">
+              {VAULT_LAYERS.map((layer, i) => (
+                <motion.div
+                  key={layer.label}
+                  className="rounded border border-border bg-card/30 px-4 py-3 flex items-start gap-3"
+                  initial={{ opacity: 0, y: 8 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: i * 0.06, duration: 0.2 }}>
+                  <span className="flex-none mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-tank/10 text-[11px] font-bold text-tank border border-tank/20">
+                    {layer.step}
+                  </span>
+                  <div>
+                    <p className="text-[13px] font-semibold tracking-tight">{layer.label}</p>
+                    <p className="text-[12px] text-muted-foreground">{layer.desc}</p>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+
+            <div className="rounded border border-border bg-card/30 p-4">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground mb-3">
+                Detected credential types
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {CREDENTIAL_TYPES.map((cred) => (
+                  <span
+                    key={cred.label}
+                    className="inline-flex items-center rounded border border-border bg-muted/50 px-2 py-0.5 text-[11px] font-mono text-muted-foreground">
+                    {cred.label}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <p className="text-[12px] text-muted-foreground text-center">
+              Works with{' '}
+              <span className="font-medium text-foreground">Claude Code, Cursor, OpenCode, Codex, and any agent</span>
+            </p>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/src/consts/homepage.ts
+++ b/apps/registry/src/consts/homepage.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import { Eye, GitBranch, Globe, Lock, Shield, Terminal } from 'lucide-react';
+import { Bot, Eye, GitBranch, Globe, Key, Lock, ScanSearch, Search, Shield, Terminal, Users } from 'lucide-react';
 
 export const features: Array<{ icon: LucideIcon; title: string; description: string }> = [
   {
@@ -26,9 +26,44 @@ export const features: Array<{ icon: LucideIcon; title: string; description: str
       'Not a social contract. A patch that adds network access? Detected and flagged. Permission escalation requires a major bump.'
   },
   {
+    icon: Key,
+    title: 'API Tokens & Keys',
+    description:
+      'Scoped API tokens for CI/CD — read-only, publish-only, or full access. Revoke instantly from the dashboard.'
+  },
+  {
+    icon: Users,
+    title: 'Orgs & Teams',
+    description: 'Create organizations, invite members, assign roles (owner/admin/member). Scoped publishing per team.'
+  },
+  {
+    icon: ScanSearch,
+    title: 'On-Demand Scanner',
+    description:
+      'Scan any package URL from the web UI. Full 6-stage pipeline with Semgrep, Bandit, secrets detection, and LLM analysis.'
+  },
+  {
+    icon: Search,
+    title: 'Advanced Discovery',
+    description:
+      'Filter by verdict, freshness, atom type, popularity. Star packages. Browse trending skills and top publishers.'
+  },
+  {
+    icon: Bot,
+    title: 'Service Accounts',
+    description:
+      'Machine identities for CI/CD pipelines. Scoped permissions, no human credentials needed. Full audit trail.'
+  },
+  {
     icon: Terminal,
     title: 'CLI-First Workflow',
-    description: 'Install, publish, audit, manage permissions from terminal. Designed for developers, not dashboards.'
+    description: '20+ commands — install, publish, audit, build, search, verify, permissions. Designed for developers.'
+  },
+  {
+    icon: Eye,
+    title: 'Audit Trail',
+    description:
+      'Every action logged — publishes, installs, permission changes, moderation decisions. Filter by action, user, or date.'
   },
   {
     icon: Globe,
@@ -38,11 +73,12 @@ export const features: Array<{ icon: LucideIcon; title: string; description: str
 ];
 
 export const cliCommands = [
-  { cmd: 'tank install @vercel/next-skill', desc: 'Install from registry with integrity verification' },
-  { cmd: 'tank install https://github.com/org/skill', desc: 'Install from any URL — scanned before install' },
-  { cmd: 'tank permissions', desc: 'See what your agent is allowed to do' },
+  { cmd: 'tank install @vercel/next-skill', desc: 'Install with integrity verification' },
+  { cmd: 'tank run claude', desc: 'Launch agent with Credential Vault protection' },
+  { cmd: 'tank build', desc: 'Compile atoms for Claude Code, Cursor, OpenCode, and more' },
+  { cmd: 'tank search "react hooks"', desc: 'Search the registry' },
   { cmd: 'tank audit', desc: 'View 6-stage security scan results' },
-  { cmd: 'tank build', desc: 'Compile for Claude Code, Cursor, OpenCode, and more' },
+  { cmd: 'tank verify', desc: 'Verify lockfile integrity (SHA-512)' },
   { cmd: 'tank doctor', desc: 'Diagnose your setup in one command' }
 ];
 

--- a/apps/registry/src/screens/home-screen.tsx
+++ b/apps/registry/src/screens/home-screen.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Users } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useMemo } from 'react';
 
+import { AtomsSection } from '~/components/home/atoms-section';
 import { CliPreview } from '~/components/home/cli-preview';
 import { ComparisonTable } from '~/components/home/comparison-table';
 import { EditorIntegration } from '~/components/home/editor-integration';
@@ -11,6 +12,7 @@ import { FaqSection } from '~/components/home/faq-section';
 import { FeaturesGrid } from '~/components/home/features-grid';
 import { HeroSection } from '~/components/home/hero-section';
 import { HowItWorks } from '~/components/home/how-it-works';
+import { VaultSection } from '~/components/home/vault-section';
 import { WhyTankExists } from '~/components/home/why-tank-exists';
 import { WorksWith } from '~/components/home/works-with';
 import { Button } from '~/components/ui/button';
@@ -84,7 +86,11 @@ export function HomeScreen({ publicSkillCount, starCount, selfhostedAppUrl }: Ho
 
       <FeaturesGrid />
 
+      <AtomsSection />
+
       <TankJsonExample />
+
+      <VaultSection />
 
       <CliPreview />
 


### PR DESCRIPTION
## Summary

- **Credential Vault section** — showcases `tank run claude` with terminal mockup showing the 4-layer pipeline (Detect → Tokenize → Proxy → Restore), 8 credential types, and multi-agent support
- **Atoms section** — explains the 7 canonical primitives (📜 instruction, 🪝 hook, 🔧 tool, 🤖 agent, 🛡 rule, 📡 resource, 💬 prompt) with cross-platform `tank build` compilation visual
- **Features grid expanded** from 6 → 12 cards: adds API Tokens, Orgs & Teams, On-Demand Scanner, Advanced Discovery, Service Accounts, Audit Trail
- **CLI preview updated** with `tank run claude`, `tank search`, `tank verify`

## New sections added

| Section | Position | Content |
|---------|----------|---------|
| Atoms Architecture | After Features Grid | 7 atom types + bundle card, `tank build` terminal showing compilation to 5 platforms |
| Credential Vault | After tank.json Example | `tank run claude` terminal, 4-step pipeline, 8 credential types, agent support badges |

## Changes

- `apps/registry/src/components/home/vault-section.tsx` — NEW
- `apps/registry/src/components/home/atoms-section.tsx` — NEW  
- `apps/registry/src/consts/homepage.ts` — 6 new feature cards + updated CLI commands
- `apps/registry/src/components/home/features-grid.tsx` — 4-column grid for 12 cards
- `apps/registry/src/screens/home-screen.tsx` — Wire new sections

## Verification

- [x] Zero LSP diagnostics on all changed files
- [x] `tsc --noEmit` clean
- [x] Biome lint + format clean
- [x] Build succeeds
- [x] Pre-push hooks pass (lint ✓, format ✓, typecheck ✓)
- [x] No hardcoded hex colors — all design system tokens (dark/light safe)