### PR TITLE
fix(cli): skip symlinks gracefully instead of throwing

### DIFF
--- a/packages/cli/src/lib/packer.ts
+++ b/packages/cli/src/lib/packer.ts
@@ -282,17 +282,18 @@ function collectFiles(baseDir: string, currentDir: string, ig: ReturnType<typeof
       throw new Error(`Absolute path detected: "${relativePath}"`);
     }
 
-    // Security: check for symlinks using lstat (not stat which follows symlinks)
     const lstatResult = fs.lstatSync(fullPath);
-    if (lstatResult.isSymbolicLink()) {
-      throw new Error(`Symlink detected: "${relativePath}" — symlinks are not allowed in skill packages`);
-    }
 
-    // Check if this path should be ignored
-    // For directories, append '/' so ignore patterns like 'dir/' work correctly
-    const pathForIgnore = lstatResult.isDirectory() ? `${relativePath}/` : relativePath;
+    // Check ignore BEFORE symlink check — ignored files should not block packing
+    const isDir = lstatResult.isDirectory() || (lstatResult.isSymbolicLink() && fs.statSync(fullPath).isDirectory());
+    const pathForIgnore = isDir ? `${relativePath}/` : relativePath;
 
     if (ig.ignores(pathForIgnore)) {
+      continue;
+    }
+
+    if (lstatResult.isSymbolicLink()) {
+      console.warn(`⚠ Skipping symlink: ${relativePath}`);
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Symlinks now **warn and skip** instead of fatally aborting the pack
- Ignore filter runs **before** symlink detection — ignored symlinks are completely silent
- Fixes publishing for repos with convenience symlinks (e.g., `CLAUDE.md → AGENTS.md`)

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Symlink in `.gitignore` | ❌ Fatal throw | ✅ Silently skipped |
| Symlink NOT in ignore | ❌ Fatal throw | ✅ Warning + skipped |
| Normal files | ✅ Packed | ✅ Packed (no change) |

## Testing

```
$ tank publish --dry-run  # in repo with CLAUDE.md → AGENTS.md symlink
⚠ Skipping symlink: CLAUDE.md
⚠ Skipping symlink: GEMINI.md
ℹ name:    @elad12390/notification-mcp
✓ Dry run complete
```