### PR TITLE
feat(atoms): add runtime/entry fields to tool atom MCP config

### DIFF
--- a/packages/adapters/src/compile.ts
+++ b/packages/adapters/src/compile.ts
@@ -180,6 +180,16 @@ export function compilePackage(
 
   const allAtoms = collectAtoms(pkg, options?.resolver);
 
+  if (options?.sourceDir) {
+    for (const atom of allAtoms) {
+      if (atom.kind === 'tool' && atom.mcp?.entry && atom.mcp?.runtime) {
+        const absoluteEntry = path.resolve(options.sourceDir, atom.mcp.entry);
+        atom.mcp.command = atom.mcp.runtime;
+        atom.mcp.args = [absoluteEntry, ...(atom.mcp.args ?? [])];
+      }
+    }
+  }
+
   for (const atom of allAtoms) {
     const capability = adapter.capabilities[atom.kind as keyof AdapterCapabilities];
 

--- a/packages/internals-schemas/src/schemas/atoms/tool.ts
+++ b/packages/internals-schemas/src/schemas/atoms/tool.ts
@@ -4,11 +4,17 @@ import { extensionBagSchema } from './base.js';
 
 export const mcpServerConfigSchema = z
   .object({
-    command: z.string().min(1),
+    command: z.string().min(1).optional(),
     args: z.array(z.string()).optional(),
-    env: z.record(z.string(), z.string()).optional()
+    env: z.record(z.string(), z.string()).optional(),
+    runtime: z.string().min(1).optional(),
+    entry: z.string().min(1).optional()
   })
-  .strict();
+  .strict()
+  .refine(
+    (data) => data.command || (data.runtime && data.entry),
+    'MCP config must have either "command" or both "runtime" and "entry"'
+  );
 
 export const toolIRSchema = z
   .object({


### PR DESCRIPTION
## Summary

Tool atoms can now declare `runtime` + `entry` instead of hardcoding `command`/`args` with npm references. Tank resolves the entry point to an absolute `.tank/skills/` path at compile time.

## Why

Previously, tool atoms pointed to npm (`npx -y @org/pkg`) — Tank distributed config, npm distributed the binary. This defeated Tank's version locking, integrity hashing, and security scanning. Now Tank is the full distribution layer.

## Schema Change

```jsonc
// Before (legacy — still works)
{ "mcp": { "command": "npx", "args": ["-y", "@org/pkg"] } }

// After (new)
{ "mcp": { "runtime": "node", "entry": "dist/index.js" } }
```

`runtime` is any executable: `node`, `bun`, `uv`, `python`, `deno`, etc.
`entry` is a relative path within the package.

## How It Works

`compilePackage()` in compile.ts resolves `runtime`/`entry` into `command`/`args` with an absolute path before passing to adapters. All 6 adapters work unchanged.

## Backward Compatible

- `command`/`args` without `entry` still works (legacy)
- Zod refine ensures either `command` OR `runtime`+`entry` is present