### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/infra/helm/tank/Chart.yaml
+++ b/infra/helm/tank/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   PostgreSQL, Redis, and MinIO for on-premises installations.
 type: application
 version: 0.1.0
-appVersion: "0.12.1"
+appVersion: "0.13.0"
 home: https://github.com/tankpkg/tank
 sources:
   - https://github.com/tankpkg/tank

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/cli",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
   "bin": {

--- a/packages/internals-helpers/package.json
+++ b/packages/internals-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internals/helpers",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/internals-schemas/package.json
+++ b/packages/internals-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internals/schemas",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/mcp-server",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "MCP server for Tank - scan and publish AI agent skills from your editor",
   "type": "module",
   "bin": {

--- a/packages/sdk-core/crates/python/pyproject.toml
+++ b/packages/sdk-core/crates/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tankpkg"
-version = "0.12.1"
+version = "0.13.0"
 requires-python = ">=3.9"
 description = "Tank SDK core — Python bindings for the security-first AI skill package manager"
 license = {text = "MIT"}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tankpkg/sdk",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Official TypeScript SDK for the Tank registry — search, download, install, and audit AI agent skills programmatically",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bumps version from 0.12.1 → 0.13.0 across all 8 workspace packages

## What's in 0.13.0

- **feat(atoms)**: `runtime`/`entry` fields on tool atom MCP config (#378) — publishers declare runtime (node, bun, uv, python, deno) and entry point; Tank resolves to absolute path at compile time
- **fix(cli)**: SKILL.md optional for multi-atom packages; `publishManifestSchema` used in `pack()` (#376)
- **fix(cli)**: symlinks skipped gracefully during packing instead of throwing (#377)

## Changed files

8 `package.json` / `pyproject.toml` / `Chart.yaml` files — version string only.