### PR TITLE
fix(install): one-command install — merge MCP configs + auto-install deps

### DIFF
--- a/e2e/atom-architecture/build-merge.e2e.test.ts
+++ b/e2e/atom-architecture/build-merge.e2e.test.ts
@@ -1,0 +1,80 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const TANK_BIN = path.resolve(__dirname, '../../packages/cli/dist/bin/tank.js');
+
+function run(args: string, opts?: { cwd?: string }): string {
+  return execSync(`node ${TANK_BIN} ${args} 2>&1`, {
+    cwd: opts?.cwd ?? process.cwd(),
+    encoding: 'utf-8',
+    timeout: 30000,
+    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' }
+  });
+}
+
+function createToolFixture(baseDir: string, name: string, entryFile: string): string {
+  const dir = path.join(baseDir, name);
+  fs.mkdirSync(path.join(dir, 'dist'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'tank.json'),
+    JSON.stringify({
+      name: `@test/${name}`,
+      version: '1.0.0',
+      description: `Test tool ${name}`,
+      permissions: { network: { outbound: [] }, filesystem: { read: ['**/*'], write: [] }, subprocess: true },
+      atoms: [{ kind: 'tool', name, mcp: { runtime: 'node', entry: entryFile } }]
+    })
+  );
+  fs.writeFileSync(path.join(dir, entryFile), '// placeholder entry\n');
+  return dir;
+}
+
+describe('E2E: `tank build` merges .mcp.json across multiple tool packages', () => {
+  const dirs: string[] = [];
+
+  afterAll(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function tmpDir(prefix: string): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), `tank-merge-e2e-${prefix}-`));
+    dirs.push(d);
+    return d;
+  }
+
+  it('second build overwrites first — only last MCP server survives (current broken behavior)', () => {
+    const fixtures = tmpDir('fixtures');
+    const out = tmpDir('out');
+    const toolA = createToolFixture(fixtures, 'tool-alpha', 'dist/index.js');
+    const toolB = createToolFixture(fixtures, 'tool-beta', 'dist/index.js');
+
+    run(`build ${toolA} --platform claude-code --out ${out}`);
+    run(`build ${toolB} --platform claude-code --out ${out}`);
+
+    const mcpJson = JSON.parse(fs.readFileSync(path.join(out, '.mcp.json'), 'utf-8'));
+
+    expect(mcpJson.mcpServers['tool-alpha']).toBeDefined();
+    expect(mcpJson.mcpServers['tool-beta']).toBeDefined();
+    expect(Object.keys(mcpJson.mcpServers)).toHaveLength(2);
+  });
+
+  it('second build overwrites first — only last MCP server survives (cursor)', () => {
+    const fixtures = tmpDir('fixtures-cursor');
+    const out = tmpDir('out-cursor');
+    const toolA = createToolFixture(fixtures, 'tool-alpha', 'dist/index.js');
+    const toolB = createToolFixture(fixtures, 'tool-beta', 'dist/index.js');
+
+    run(`build ${toolA} --platform cursor --out ${out}`);
+    run(`build ${toolB} --platform cursor --out ${out}`);
+
+    const mcpJson = JSON.parse(fs.readFileSync(path.join(out, '.cursor/mcp.json'), 'utf-8'));
+
+    expect(mcpJson.mcpServers['tool-alpha']).toBeDefined();
+    expect(mcpJson.mcpServers['tool-beta']).toBeDefined();
+    expect(Object.keys(mcpJson.mcpServers)).toHaveLength(2);
+  });
+});

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -45,10 +45,43 @@ function loadManifest(skillDir: string) {
   return result.data;
 }
 
+function deepMerge(a: Record<string, unknown>, b: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...a };
+  for (const [key, val] of Object.entries(b)) {
+    const existing = result[key];
+    if (
+      val !== null &&
+      typeof val === 'object' &&
+      !Array.isArray(val) &&
+      existing !== null &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing)
+    ) {
+      result[key] = deepMerge(existing as Record<string, unknown>, val as Record<string, unknown>);
+    } else {
+      result[key] = val;
+    }
+  }
+  return result;
+}
+
 function writeFiles(targetDir: string, compiled: CompileResult): number {
   for (const f of compiled.files) {
     const fullPath = path.join(targetDir, f.path);
     fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+
+    if (f.path.endsWith('.json') && fs.existsSync(fullPath)) {
+      try {
+        const existing = JSON.parse(fs.readFileSync(fullPath, 'utf-8'));
+        const incoming = JSON.parse(f.content);
+        const merged = deepMerge(existing, incoming);
+        fs.writeFileSync(fullPath, JSON.stringify(merged, null, 2));
+        continue;
+      } catch {
+        // parse failure — fall through to overwrite
+      }
+    }
+
     fs.writeFileSync(fullPath, f.content);
   }
   return compiled.files.length;

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -272,6 +273,27 @@ async function runLegacyFallback(options: {
   }
 }
 
+function installToolDependencies(extractDir: string, skillName: string): void {
+  const packageJsonPath = path.join(extractDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) return;
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    const hasDeps =
+      (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) ||
+      (pkg.peerDependencies && Object.keys(pkg.peerDependencies).length > 0);
+    if (!hasDeps) return;
+
+    execSync('npm install --production --ignore-scripts --no-audit --no-fund', {
+      cwd: extractDir,
+      stdio: 'pipe',
+      timeout: 60_000
+    });
+  } catch {
+    logger.warn(`Dependency install skipped for ${skillName} (non-fatal)`);
+  }
+}
+
 async function linkInstalledRoots(options: {
   rootSkillNames: string[];
   resolvedNodeByName: Map<string, ResolvedNode>;
@@ -331,6 +353,15 @@ async function linkInstalledRoots(options: {
     logger.warn('No agents detected for linking');
   }
 
+  const agentToPlatform: Record<string, string> = {
+    claude: 'claude-code',
+    opencode: 'opencode',
+    cursor: 'cursor',
+    codex: 'claude-code',
+    openclaw: 'opencode'
+  };
+  const platforms = new Set(detectedAgents.map((a) => agentToPlatform[a.id]).filter(Boolean));
+
   for (const skillName of rootSkillNames) {
     const node = resolvedNodeByName.get(skillName);
     if (!node) continue;
@@ -341,7 +372,9 @@ async function linkInstalledRoots(options: {
       const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
       if (!manifest.atoms || !Array.isArray(manifest.atoms) || manifest.atoms.length === 0) continue;
       const { buildCommand: runBuild } = await import('~/commands/build.js');
-      await runBuild({ skill: skillDir, target: directory });
+      for (const platform of platforms) {
+        await runBuild({ skill: skillDir, target: directory, platform });
+      }
     } catch {
       logger.warn(`Auto-build skipped for ${skillName} (non-fatal)`);
     }
@@ -386,6 +419,9 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     fs.mkdirSync(extractDir, { recursive: true });
     await extractSafely(payload.buffer, extractDir);
     verifyExtractedDependencies(extractDir, node);
+
+    spinner.text = `Installing dependencies for ${node.name}...`;
+    installToolDependencies(extractDir, node.name);
   }
 
   lock.lockfileVersion = LOCKFILE_VERSION;


### PR DESCRIPTION
## Summary

`tank install @org/tool` now just works — the MCP server is immediately usable by Claude Code, Cursor, and OpenCode without any manual steps.

## What changed

- **`writeFiles` deep-merges JSON files** instead of overwriting. Installing multiple tool packages now accumulates all MCP servers in `.mcp.json` / `.cursor/mcp.json` instead of the last one winning.
- **Post-extract `npm install`** — after extracting a tool package, if it has a `package.json` with dependencies, `npm install --production --ignore-scripts` runs automatically so the entry point can resolve its imports.
- **Auto-build targets all detected agents** — instead of relying on `detectPlatform()` (which checks `process.cwd()` and fails in clean directories), the install step builds for every agent detected on the system (Claude Code, OpenCode, Cursor, etc.).

## Before → After

| Step | Before | After |
|------|--------|-------|
| Install | `tank install @elad12390/notification-mcp` ✅ | Same ✅ |
| Build config | Manual `tank build ... --platform claude-code` ❌ | Automatic ✅ |
| Merge configs | Only last MCP survives ❌ | All MCPs accumulate ✅ |
| Install deps | Manual `npm install` in extracted dir ❌ | Automatic ✅ |
| MCP server starts | Crashes on missing deps ❌ | Works immediately ✅ |

## E2E test

New `build-merge.e2e.test.ts` creates two minimal tool fixtures, builds both to the same output dir, and asserts `.mcp.json` contains both MCP servers (Claude Code + Cursor).

## Files changed

- `packages/cli/src/commands/build.ts` — `writeFiles` deep-merges JSON
- `packages/cli/src/commands/install.ts` — `installToolDependencies` + auto-build for all detected platforms
- `e2e/atom-architecture/build-merge.e2e.test.ts` — new test