### PR TITLE
fix(scanner): enable tokenomics on Vercel via npx fallback

### DIFF
--- a/apps/python-api/lib/scan/stage_token.py
+++ b/apps/python-api/lib/scan/stage_token.py
@@ -50,32 +50,45 @@ def stage_token_analyze(ingest_result: IngestResult) -> StageResult:
         )
 
     # Check if tokenomics CLI is available
-    tokenomics_path = shutil.which("tokenomics")
-    if not tokenomics_path:
+    # Try: global binary → npx (local node_modules) → bunx
+    tokenomics_bin = shutil.which("tokenomics")
+    run_cmd: list[str] | None = None
+    if tokenomics_bin:
+        run_cmd = [tokenomics_bin]
+    elif shutil.which("npx"):
+        run_cmd = ["npx", "--yes", "tokenomics"]
+    elif shutil.which("bunx"):
+        run_cmd = ["bunx", "tokenomics"]
+
+    if not run_cmd:
         return StageResult(
             stage="stageT", status="skipped", findings=[], duration_ms=int((time.monotonic() - start) * 1000)
         )
 
+    # For npx/bunx invocations, skip version check (npx handles it)
+    needs_version_check = bool(tokenomics_bin)
+
     # Check tokenomics version supports --analyze-skill (>=2.3.0)
-    try:
-        ver_result = subprocess.run([tokenomics_path, "--version"], capture_output=True, text=True, timeout=5)
-        version_str = (ver_result.stdout or ver_result.stderr or "").strip()
-        # Parse version from output like "tokenomics v2.3.0" or just "2.3.0"
-        version_str = version_str.lower().replace("tokenomics", "").replace("v", "").strip()
-        installed_parts = [int(p) for p in version_str.split(".") if p.isdigit()]
-        min_parts = [int(p) for p in MIN_TOKENOMICS_VERSION.split(".")]
-        if installed_parts < min_parts:
-            return StageResult(
-                stage="stageT", status="skipped", findings=[], duration_ms=int((time.monotonic() - start) * 1000)
-            )
-    except Exception:
-        # If version check fails, try running anyway — worst case it exits non-zero
-        pass
+    if needs_version_check:
+        try:
+            ver_result = subprocess.run([tokenomics_bin, "--version"], capture_output=True, text=True, timeout=5)
+            version_str = (ver_result.stdout or ver_result.stderr or "").strip()
+            # Parse version from output like "tokenomics v2.3.0" or just "2.3.0"
+            version_str = version_str.lower().replace("tokenomics", "").replace("v", "").strip()
+            installed_parts = [int(p) for p in version_str.split(".") if p.isdigit()]
+            min_parts = [int(p) for p in MIN_TOKENOMICS_VERSION.split(".")]
+            if installed_parts < min_parts:
+                return StageResult(
+                    stage="stageT", status="skipped", findings=[], duration_ms=int((time.monotonic() - start) * 1000)
+                )
+        except Exception:
+            # If version check fails, try running anyway — worst case it exits non-zero
+            pass
 
     # Run tokenomics CLI
     try:
         result = subprocess.run(
-            [tokenomics_path, "--analyze-skill", temp_dir, "--json"],
+            [*run_cmd, "--analyze-skill", temp_dir, "--json"],
             capture_output=True,
             text=True,
             timeout=TOKENOMICS_TIMEOUT,

--- a/apps/python-api/lib/scan/test_stage_token.py
+++ b/apps/python-api/lib/scan/test_stage_token.py
@@ -91,6 +91,28 @@ class TestCLINotInstalled:
         assert result.duration_ms >= 0
 
 
+class TestNpxFallback:
+    """Scenario: no global tokenomics, but npx is available."""
+
+    def test_uses_npx_when_global_not_found(self):
+        """When tokenomics is not global but npx is, should use npx --yes tokenomics."""
+        which_calls = {"tokenomics": None, "npx": "/usr/bin/npx", "bunx": None}
+
+        def mock_which(cmd):
+            return which_calls.get(cmd)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("lib.scan.stage_token.shutil.which", side_effect=mock_which):
+                with patch(
+                    "lib.scan.stage_token.subprocess.run",
+                    side_effect=_mock_subprocess_run(json.dumps(VALID_TOKENOMICS_JSON)),
+                ):
+                    result = stage_token_analyze(make_ingest(tmpdir))
+        assert result.stage == "stageT"
+        assert result.status == "passed"
+        assert len(result.findings) > 0
+
+
 class TestVersionTooOld:
     """Scenario: tokenomics installed but version < 2.3.1."""
 

--- a/apps/python-api/package.json
+++ b/apps/python-api/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tank-scanner-deps",
+  "private": true,
+  "dependencies": {
+    "tokenomics": "^2.3.1"
+  }
+}

--- a/apps/python-api/vercel.json
+++ b/apps/python-api/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "",
+  "buildCommand": "npm install",
   "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
 }

--- a/apps/registry/Dockerfile
+++ b/apps/registry/Dockerfile
@@ -12,6 +12,7 @@ COPY apps/registry/package.json ./apps/registry/
 COPY packages/cli/package.json ./packages/cli/
 COPY packages/mcp-server/package.json ./packages/mcp-server/
 COPY packages/sdk/package.json ./packages/sdk/
+COPY packages/adapters/package.json ./packages/adapters/
 COPY packages/vault/package.json ./packages/vault/
 COPY bdd/package.json ./bdd/
 COPY e2e/package.json ./e2e/
@@ -27,6 +28,7 @@ COPY packages/internals-schemas ./packages/internals-schemas
 COPY packages/internals-helpers ./packages/internals-helpers
 COPY apps/registry ./apps/registry
 COPY packages/sdk ./packages/sdk
+COPY packages/adapters ./packages/adapters
 COPY packages/cli ./packages/cli
 COPY packages/mcp-server ./packages/mcp-server
 
@@ -34,12 +36,14 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages/internals-schemas/node_modules ./packages/internals-schemas/node_modules
 COPY --from=deps /app/packages/internals-helpers/node_modules ./packages/internals-helpers/node_modules
 COPY --from=deps /app/packages/sdk/node_modules ./packages/sdk/node_modules
+COPY --from=deps /app/packages/adapters/node_modules ./packages/adapters/node_modules
 COPY --from=deps /app/apps/registry/node_modules ./apps/registry/node_modules
 COPY --from=deps /app/packages/cli/node_modules ./packages/cli/node_modules
 COPY --from=deps /app/packages/mcp-server/node_modules ./packages/mcp-server/node_modules
 
 RUN bun run --filter=@internals/schemas build && \
     bun run --filter=@internals/helpers build && \
+    bun run --filter=@internals/adapters build && \
     bun run --filter=@tankpkg/sdk build && \
     rm -rf apps/registry/.output && \
     bun run --filter=registry build && \


### PR DESCRIPTION
## Summary
- The nightly/stable scanner runs on Vercel (serverless Python), which has no Node.js global packages — tokenomics was silently skipping stageT
- Add `package.json` with `tokenomics@^2.3.1` so Vercel's build installs it into `node_modules`
- Set `vercel.json` buildCommand to `npm install` 
- Fall back to `npx --yes tokenomics` when the global binary isn't found (Vercel case)
- Add test for the npx fallback path

## Test plan
- [x] All 16 stage_token tests pass including new npx fallback test
- [x] ruff format + lint clean
- [x] biome check clean (0 errors)
- [ ] Merge → Vercel deploys scanner → rescan `@tank/resource-creator` → Tokens tab appears