### PR TITLE
fix(scanner): invoke tokenomics via node directly on Vercel

### DIFF
--- a/apps/python-api/lib/scan/stage_token.py
+++ b/apps/python-api/lib/scan/stage_token.py
@@ -50,42 +50,53 @@ def stage_token_analyze(ingest_result: IngestResult) -> StageResult:
         )
 
     # Check if tokenomics CLI is available
-    # Try: global binary → local node_modules/.bin → npx → bunx
+    # Try: global binary → node <local_module> → npx → bunx
     tokenomics_bin = shutil.which("tokenomics")
+
+    # Find the tokenomics JS module (installed via package.json)
+    tokenomics_module: str | None = None
     if not tokenomics_bin:
-        # Vercel installs package.json deps but doesn't put node_modules/.bin on PATH
-        # Check common locations relative to this file
         candidates = [
-            os.path.join(os.getcwd(), "node_modules", ".bin", "tokenomics"),
+            os.path.join(os.getcwd(), "node_modules", "tokenomics", "dist", "analyze.js"),
             os.path.join(
-                os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "node_modules", ".bin", "tokenomics"
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+                "node_modules",
+                "tokenomics",
+                "dist",
+                "analyze.js",
             ),
         ]
         for candidate in candidates:
             if os.path.isfile(candidate):
-                tokenomics_bin = candidate
+                tokenomics_module = candidate
                 break
 
-    if not tokenomics_bin and shutil.which("npx"):
-        tokenomics_bin = "npx"
-        run_via_npx = True
-    elif tokenomics_bin:
-        run_via_npx = tokenomics_bin == "npx"
-    else:
-        run_via_npx = False
+    # Find node binary — needed for local module invocation on Vercel
+    node_bin = shutil.which("node")
+    if not node_bin:
+        for candidate in ["/vercel/node-wrapper/node", "/usr/local/bin/node", "/opt/node/bin/node"]:
+            if os.path.isfile(candidate):
+                node_bin = candidate
+                break
 
-    if not tokenomics_bin:
+    # Build the run command
+    run_cmd: list[str] | None = None
+    needs_version_check = False
+
+    if tokenomics_bin:
+        run_cmd = [tokenomics_bin, "--analyze-skill", temp_dir, "--json"]
+        needs_version_check = True
+    elif tokenomics_module and node_bin:
+        run_cmd = [node_bin, tokenomics_module, "--analyze-skill", temp_dir, "--json"]
+    elif shutil.which("npx"):
+        run_cmd = ["npx", "--yes", "tokenomics", "--analyze-skill", temp_dir, "--json"]
+    elif shutil.which("bunx"):
+        run_cmd = ["bunx", "tokenomics", "--analyze-skill", temp_dir, "--json"]
+
+    if not run_cmd:
         return StageResult(
             stage="stageT", status="skipped", findings=[], duration_ms=int((time.monotonic() - start) * 1000)
         )
-
-    # Build the command
-    if run_via_npx:
-        run_cmd: list[str] = ["npx", "--yes", "tokenomics", "--analyze-skill", temp_dir, "--json"]
-    else:
-        run_cmd = [tokenomics_bin, "--analyze-skill", temp_dir, "--json"]
-
-    needs_version_check = not run_via_npx
 
     # Check tokenomics version supports --analyze-skill (>=2.3.0)
     if needs_version_check:

--- a/apps/python-api/lib/scan/test_stage_token.py
+++ b/apps/python-api/lib/scan/test_stage_token.py
@@ -1,7 +1,6 @@
 """Tests for Stage T: Token Usage Analysis."""
 
 import json
-import os
 import subprocess
 import tempfile
 from unittest.mock import MagicMock, patch
@@ -115,39 +114,33 @@ class TestNpxFallback:
 
 
 class TestLocalNodeModules:
-    """Scenario: tokenomics in local node_modules/.bin (Vercel)."""
+    """Scenario: tokenomics installed via package.json, invoked with node (Vercel)."""
 
-    def test_finds_local_binary(self, tmp_path):
-        """When global not on PATH but node_modules/.bin/tokenomics exists, use it."""
-        bin_dir = tmp_path / "node_modules" / ".bin"
-        bin_dir.mkdir(parents=True)
-        (bin_dir / "tokenomics").write_text("#!/bin/sh\necho test\n")
-        os.chmod(bin_dir / "tokenomics", 0o755)
+    def test_uses_node_with_local_module(self, tmp_path):
+        """When global not on PATH but node_modules/tokenomics exists and node is available."""
+        dist_dir = tmp_path / "node_modules" / "tokenomics" / "dist"
+        dist_dir.mkdir(parents=True)
+        (dist_dir / "analyze.js").write_text("// mock")
 
         mock_proc = MagicMock()
         mock_proc.stdout = json.dumps(VALID_TOKENOMICS_JSON)
         mock_proc.stderr = ""
         mock_proc.returncode = 0
 
-        ver_proc = MagicMock()
-        ver_proc.stdout = "tokenomics v2.3.1\n"
-        ver_proc.stderr = ""
-        ver_proc.returncode = 0
-
         skill_dir = tmp_path / "skill"
         skill_dir.mkdir()
 
-        def run_side_effect(cmd, **kwargs):
-            if "--version" in cmd:
-                return ver_proc
-            return mock_proc
+        def which_side_effect(cmd):
+            if cmd == "node":
+                return "/usr/local/bin/node"
+            return None
 
         import lib.scan.stage_token as mod
 
         with patch.object(mod, "__file__", str(tmp_path / "lib" / "scan" / "stage_token.py")):
-            with patch("lib.scan.stage_token.shutil.which", return_value=None):
-                with patch("os.path.isfile", side_effect=lambda p: "node_modules" in p or os.path.isfile(p)):
-                    with patch("lib.scan.stage_token.subprocess.run", side_effect=run_side_effect):
+            with patch("lib.scan.stage_token.shutil.which", side_effect=which_side_effect):
+                with patch("os.path.isfile", side_effect=lambda p: p.endswith("analyze.js")):
+                    with patch("lib.scan.stage_token.subprocess.run", return_value=mock_proc):
                         result = stage_token_analyze(make_ingest(str(skill_dir)))
         assert result.status == "passed"
         assert len(result.findings) > 0


### PR DESCRIPTION
## Summary
- `node_modules/.bin/tokenomics` is a shell wrapper that calls `node`, but Vercel's Python runtime doesn't have `node` on PATH — it silently fails
- Fix: resolve the JS module at `node_modules/tokenomics/dist/analyze.js` and find `node` at Vercel-specific paths (`/vercel/node-wrapper/node`), then invoke as `node analyze.js --analyze-skill <dir> --json`

## Test plan
- [x] All 17 tests pass (including new `node <module>` invocation test)
- [x] ruff format + lint clean
- [ ] Merge → Vercel redeploys → rescan → Tokens tab appears with tokenomics data