### PR TITLE
fix(ci): make drizzle-kit push non-blocking in Vercel build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "buildCommand": "cd apps/registry && bunx drizzle-kit push --force && cd ../.. && NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
+  "buildCommand": "cd apps/registry && (bunx drizzle-kit push --force || echo 'drizzle-kit push failed (likely schema prompt in CI), skipping') && cd ../.. && NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
   "installCommand": "bun install",
   "devCommand": "bun --filter registry run dev"
 }


### PR DESCRIPTION
## Summary
- drizzle-kit 0.31.x prompts interactively on schema name conflicts (`promptNamedWithSchemasConflict`), which kills CI builds (no TTY)
- Since nightly shares the same DB as production, schema is already synced — safe to skip on failure
- Makes `drizzle-kit push` non-blocking: logs warning and continues with build