### PR TITLE
fix(scanner): install tokenomics Node deps on Vercel build

### DIFF
--- a/apps/python-api/vercel.json
+++ b/apps/python-api/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm install",
+  "buildCommand": "npm install --production",
   "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
 }


### PR DESCRIPTION
## Summary
- Stage T (token usage analysis) was always `skipped` on Vercel because `tokenomics` (Node.js CLI) was never installed — Vercel's Python runtime only runs `pip install`
- Updated Vercel project settings via API to chain `pip install` + `npm install --production` so `node_modules/tokenomics` is available at runtime
- Updated `vercel.json` buildCommand to stay consistent with project settings

## Root Cause
`apps/python-api/package.json` declares `tokenomics` as a dependency, but Vercel's FastAPI framework detection only installs Python deps. The scanner code gracefully skips Stage T when tokenomics isn't found, so no `stageT` findings → no Tokens tab in UI.

## What Changed
- `apps/python-api/vercel.json`: `buildCommand` updated to `npm install --production`  
- Vercel project settings (already applied via API): `installCommand = pip install -r requirements.txt && npm install --production`