### PR TITLE
fix(scanner): install tokenomics in correct directory on Vercel

### DIFF
--- a/apps/python-api/vercel.json
+++ b/apps/python-api/vercel.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm install --production",
   "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
 }


### PR DESCRIPTION
## Summary
- Previous PR #388 ran `npm install` but it executed in the repo root instead of `apps/python-api/`, so `tokenomics` was never installed
- Removed the stale `buildCommand` from `vercel.json` — install is now handled entirely via Vercel project settings (set via API):
  - `installCommand`: `pip install -r requirements.txt && npm install --omit=dev`
- `rootDirectory` is already `apps/python-api` in Vercel project config, so `npm install` will now pick up `apps/python-api/package.json` which has `tokenomics`