### PR TITLE
fix(scanner): vendor tokenomics for Vercel Python runtime

### DIFF
--- a/apps/python-api/.gitignore
+++ b/apps/python-api/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+vendor/
+__pycache__/
+.venv/
+*.pyc

--- a/apps/python-api/lib/scan/stage_token.py
+++ b/apps/python-api/lib/scan/stage_token.py
@@ -53,18 +53,17 @@ def stage_token_analyze(ingest_result: IngestResult) -> StageResult:
     # Try: global binary → node <local_module> → npx → bunx
     tokenomics_bin = shutil.which("tokenomics")
 
-    # Find the tokenomics JS module (installed via package.json)
+    # Find the tokenomics JS module (installed via package.json or vendored at build)
     tokenomics_module: str | None = None
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     if not tokenomics_bin:
         candidates = [
+            # Vendored copy (copied during Vercel build step)
+            os.path.join(project_root, "vendor", "tokenomics", "analyze.js"),
+            # Standard node_modules from project root
+            os.path.join(project_root, "node_modules", "tokenomics", "dist", "analyze.js"),
+            # CWD-relative node_modules
             os.path.join(os.getcwd(), "node_modules", "tokenomics", "dist", "analyze.js"),
-            os.path.join(
-                os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-                "node_modules",
-                "tokenomics",
-                "dist",
-                "analyze.js",
-            ),
         ]
         for candidate in candidates:
             if os.path.isfile(candidate):

--- a/apps/python-api/vercel.json.md
+++ b/apps/python-api/vercel.json.md
@@ -1,1 +1,0 @@
-# tokenomics deps diagnostic


### PR DESCRIPTION
## Problem
Stage T (token usage analysis) always `skipped` on Vercel because:
1. `tokenomics` is a Node.js CLI in `package.json`
2. Vercel Python runtime installs Python deps only
3. Even when `npm install` runs during build, `node_modules` isn't bundled into the serverless function

## Solution
Vendor the tokenomics JS file into the function source at build time:
- **Vercel installCommand** (set via API): `pip install && npm install && cp tokenomics to vendor/`
- **stage_token.py**: Added `vendor/tokenomics/analyze.js` as first candidate path
- The vendored file gets bundled into the serverless function alongside the Python code

## Changes
- `apps/python-api/lib/scan/stage_token.py` — Added vendor path as first candidate
- `apps/python-api/.gitignore` — Ignore node_modules, vendor, __pycache__
- Removed diagnostic `vercel.json.md` from previous PR