### PR TITLE
fix(registry): show error feedback when talk-to-skill fails

### DIFF
--- a/apps/registry/src/components/skills/talk-to-skill-widget.tsx
+++ b/apps/registry/src/components/skills/talk-to-skill-widget.tsx
@@ -1,4 +1,4 @@
-import { Loader2, MessageCircle } from 'lucide-react';
+import { Loader2, MessageCircle, X } from 'lucide-react';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 const WIDGET_SCRIPT_URL = 'https://storage.googleapis.com/alice-and-bot/widget/dist/widget.iife.js';
@@ -335,21 +335,30 @@ export const TalkToSkillWidget = forwardRef<TalkToSkillWidgetHandle, TalkToSkill
     })();
   }, [skillName, resolvedBotKey]);
 
+  const [error, setError] = useState<string | null>(null);
+
   const handleClick = useCallback(async () => {
     if (toggleWidgetOpen()) return;
 
+    setError(null);
     setLoading(true);
     try {
       let key = resolvedBotKey;
       if (!key) {
         const encoded = encodeURIComponent(skillName);
         const res = await fetch(`/api/v1/skills/${encoded}/talk`, { method: 'POST' });
-        if (!res.ok) return;
+        if (!res.ok) {
+          setError('Unable to start chat. Please try again later.');
+          return;
+        }
         const data = (await res.json()) as { chatLink: string; botPublicKey: string | null };
         key = data.botPublicKey;
         if (key) setResolvedBotKey(key);
       }
-      if (!key) return;
+      if (!key) {
+        setError('Chat service is temporarily unavailable.');
+        return;
+      }
 
       if (!localStorage.getItem(CREDENTIALS_KEY)) {
         await loadWidget(key, skillName, false);
@@ -361,6 +370,8 @@ export const TalkToSkillWidget = forwardRef<TalkToSkillWidgetHandle, TalkToSkill
       await loadWidget(key, skillName, true);
       await dismissNameDialog();
       await injectWidgetStyles();
+    } catch {
+      setError('Failed to load chat. Please try again.');
     } finally {
       setLoading(false);
     }
@@ -369,14 +380,32 @@ export const TalkToSkillWidget = forwardRef<TalkToSkillWidgetHandle, TalkToSkill
   useImperativeHandle(ref, () => ({ trigger: handleClick }), [handleClick]);
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={loading}
-      className="fixed bottom-6 right-6 z-[1000000] flex size-12 items-center justify-center rounded-full bg-[#10b981] text-white shadow-lg transition-transform hover:scale-105 hover:bg-[#0d9e6e] focus:outline-none focus:ring-2 focus:ring-[#10b981]/50 focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50"
-      aria-label="Talk to this package"
-      data-testid="talk-bubble">
-      {loading ? <Loader2 className="size-5 animate-spin" /> : <MessageCircle className="size-5" />}
-    </button>
+    <>
+      {error && (
+        <div
+          role="alert"
+          data-testid="talk-error"
+          className="fixed bottom-20 right-6 z-[1000001] flex max-w-xs items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive shadow-lg backdrop-blur-sm">
+          <span className="flex-1">{error}</span>
+          <button
+            type="button"
+            data-testid="talk-error-dismiss"
+            onClick={() => setError(null)}
+            className="mt-0.5 shrink-0 rounded p-0.5 hover:bg-destructive/20"
+            aria-label="Dismiss error">
+            <X className="size-3.5" />
+          </button>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading}
+        className="fixed bottom-6 right-6 z-[1000000] flex size-12 items-center justify-center rounded-full bg-[#10b981] text-white shadow-lg transition-transform hover:scale-105 hover:bg-[#0d9e6e] focus:outline-none focus:ring-2 focus:ring-[#10b981]/50 focus:ring-offset-2 focus:ring-offset-background disabled:opacity-50"
+        aria-label="Talk to this package"
+        data-testid="talk-bubble">
+        {loading ? <Loader2 className="size-5 animate-spin" /> : <MessageCircle className="size-5" />}
+      </button>
+    </>
   );
 });

--- a/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
+++ b/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
@@ -50,3 +50,25 @@ Feature: Talk to this Skill
   Scenario: Bot secret is never exposed in skill detail response
     When I visit the talk skill detail page
     Then the page source does not contain "prompt2botSecret"
+
+  Scenario: Clicking talk button when API fails shows error feedback
+    When I visit the talk skill detail page
+    And the talk API is intercepted to return a 500 error
+    And I force-click the floating chat bubble
+    Then I see the talk error message
+    And the talk error contains "Unable to start chat"
+
+  Scenario: Clicking talk button when bot key is missing shows error feedback
+    When I visit the talk skill detail page
+    And the talk API is intercepted to return a null bot key
+    And I force-click the floating chat bubble
+    Then I see the talk error message
+    And the talk error contains "temporarily unavailable"
+
+  Scenario: Talk error can be dismissed
+    When I visit the talk skill detail page
+    And the talk API is intercepted to return a 500 error
+    And I force-click the floating chat bubble
+    Then I see the talk error message
+    When I dismiss the talk error
+    Then I do not see the talk error message

--- a/bdd/steps/browser/talk-to-skill.steps.ts
+++ b/bdd/steps/browser/talk-to-skill.steps.ts
@@ -143,3 +143,40 @@ Then('the page source does not contain {string}', async ({ page }) => {
   const content = await page.content();
   expect(content).not.toContain('prompt2botSecret');
 });
+
+When('the talk API is intercepted to return a 500 error', async ({ page }) => {
+  await page.route('**/api/v1/skills/*/talk', (route) =>
+    route.fulfill({ status: 500, contentType: 'application/json', body: '{"error":"Internal server error"}' })
+  );
+});
+
+When('the talk API is intercepted to return a null bot key', async ({ page }) => {
+  await page.route('**/api/v1/skills/*/talk', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ chatLink: 'https://example.com', botPublicKey: null })
+    })
+  );
+});
+
+When('I force-click the floating chat bubble', async ({ page }) => {
+  await page.getByTestId('talk-bubble').click({ force: true });
+  await page.waitForTimeout(1000);
+});
+
+Then('I see the talk error message', async ({ page }) => {
+  await expect(page.getByTestId('talk-error')).toBeVisible({ timeout: 5000 });
+});
+
+Then('I do not see the talk error message', async ({ page }) => {
+  await expect(page.getByTestId('talk-error')).not.toBeVisible();
+});
+
+Then('the talk error contains {string}', async ({ page }, text: string) => {
+  await expect(page.getByTestId('talk-error')).toContainText(text);
+});
+
+When('I dismiss the talk error', async ({ page }) => {
+  await page.getByTestId('talk-error-dismiss').click();
+});


### PR DESCRIPTION
## Summary

Fixes #373 — "Talk to this skill" button showed a spinner then nothing when the API failed.

- Replace 3 silent failure paths in `TalkToSkillWidget` with visible error toasts
- API returns 500 → "Unable to start chat. Please try again later."
- Bot public key is null → "Chat service is temporarily unavailable."
- Widget script fails to load → "Failed to load chat. Please try again."
- Error toast is dismissible via X button

## BDD Tests

3 new scenarios, 7 new step definitions — all passing:

- ✅ Clicking talk button when API fails shows error feedback
- ✅ Clicking talk button when bot key is missing shows error feedback
- ✅ Talk error can be dismissed

2 existing tests confirmed no regression:

- ✅ Header button is visible on skill detail page
- ✅ Floating chat bubble is visible on skill detail page