### PR TITLE
fix(scanner): combine if/elif branches in tree detection (SIM114)

### DIFF
--- a/apps/python-api/lib/scan/stage_token.py
+++ b/apps/python-api/lib/scan/stage_token.py
@@ -704,9 +704,9 @@ def _get_shortening_tip(section: dict) -> str | None:
 
     tree_line_count = 0
     for line in lines:
-        if re.match(r"^[\u2500-\u257f\u2502\u2514\u250c\u2510\u2518\u251c\u2524\u252c\u2534\u253c\s]+[a-z]", line):
-            tree_line_count += 1
-        elif re.match(r"^\s+[a-z_]+/\s*$", line, re.IGNORECASE):
+        if re.match(
+            r"^[\u2500-\u257f\u2502\u2514\u250c\u2510\u2518\u251c\u2524\u252c\u2534\u253c\s]+[a-z]", line
+        ) or re.match(r"^\s+[a-z_]+/\s*$", line, re.IGNORECASE):
             tree_line_count += 1
     if tree_line_count > 10:
         tips.append(


### PR DESCRIPTION
## Summary

Pre-existing ruff `SIM114` violation in `apps/python-api/lib/scan/stage_token.py` was failing the "Ruff lint" step of `ci.yml` on every push since the rule landed. CI has been red on `main` for days.

## Fix

Mechanical `ruff --fix` + `ruff format`: two `re.match()` branches that both increment `tree_line_count` by 1 are combined with `or`.

```py
# before
if re.match(pattern_a, line):
    tree_line_count += 1
elif re.match(pattern_b, line):
    tree_line_count += 1

# after
if re.match(pattern_a, line) or re.match(pattern_b, line):
    tree_line_count += 1
```

## Verification

- `uv run ruff check apps/python-api` — all checks passed
- `uv run ruff format --check apps/python-api` — 66 files already formatted
- No behavioral change. Identical semantics.

## Motivation

Unblocks the CI gate on #402 (tank-sdk PyPI publish) and any other PR that was inheriting red CI.