### PR TITLE
fix(scripts): check-versions.sh no longer requires Python 3.11 tomllib

### DIFF
--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -29,7 +29,11 @@ extract_version() {
       grep "^appVersion:" "$file" | sed 's/appVersion: "\(.*\)"/\1/' | tr -d ' '
       ;;
     */sdk-python/pyproject.toml)
-      python3 -c "import sys, tomllib; data = tomllib.load(open('$file', 'rb')); print(data['project'].get('version', 'dynamic'))"
+      if grep -qE '^dynamic\s*=\s*\[.*"version"' "$file"; then
+        echo "dynamic"
+      else
+        grep "^version" "$file" | head -1 | sed 's/version = "\(.*\)"/\1/' | tr -d ' '
+      fi
       ;;
     *_version.py)
       grep "^__version__" "$file" | sed 's/__version__ = "\(.*\)"/\1/'


### PR DESCRIPTION
## Summary

The sdk-python pyproject.toml branch of `scripts/check-versions.sh` was calling:

```bash
python3 -c "import sys, tomllib; data = tomllib.load(open('$file', 'rb')); print(data['project'].get('version', 'dynamic'))"
```

`tomllib` is Python 3.11+. CI runners that get the default hosted Python (3.10 on some ubuntu-22.04 images when setup-python isn't explicit) hit `ModuleNotFoundError: No module named 'tomllib'`. Observed on the v0.14.0 tag push:

```
[ci-build-cli → just bump 0.14.0 → scripts/check-versions.sh]
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'tomllib'
Failed to extract version from packages/sdk-python/pyproject.toml
error: Recipe `bump` failed with exit code 1
```

This caused `build-linux-x64` and `build-linux-arm64` CLI binary jobs to fail. PyPI jobs were unaffected (they use `setup-python@v5` with an explicit 3.11).

## Fix

Replace the `python3 -c` call with `grep`-based detection of the `dynamic = ["version"]` declaration. No `python3` invocation remains in the script.

## Verification

- `bash scripts/check-versions.sh` → `All versions match: 0.14.0`
- `bash -x scripts/check-versions.sh 2>&1 | grep -E 'python3|tomllib'` → zero matches (fix confirmed)
- Behavior unchanged for all 11 version sources including the cross-file `[native]` pin check

## Why did this slip past PR #402 review?

Oracle flagged it: '`scripts/check-versions.sh` uses `python3 -c 'import tomllib'` — tomllib is Python 3.11+. Acceptable trade-off given repo's Python 3.11+ stated baseline?' I said yes. I was wrong — `ci-build-cli` runs without setup-python and inherits whatever Python the runner image ships, which on ubuntu-22.04 is 3.10.

## Follow-up

This is the only known breakage from v0.14.0. tank-sdk 0.14.0 is live on PyPI. tank-core is still building (macos-13 runner queue). After this merges, a 0.14.1 patch release will republish the CLI binaries that failed.