### PR TITLE
fix(scan): skip dependency lock files in stage 4 secrets scan

### DIFF
--- a/apps/python-api/lib/scan/stage4_secrets.py
+++ b/apps/python-api/lib/scan/stage4_secrets.py
@@ -81,10 +81,47 @@ EXAMPLE_PATH_PATTERNS: list[re.Pattern] = [
     re.compile(r"(setup|config|getting.started|quickstart)", re.IGNORECASE),
 ]
 
+# Dependency lock files contain public integrity hashes (SHA-256/512 base64),
+# not secrets. Supplements detect_secrets.filters.heuristic.is_lock_file,
+# which only covers a subset of ecosystems (misses deno, pnpm, bun, uv, etc.).
+LOCK_FILE_BASENAMES: frozenset[str] = frozenset(
+    {
+        # Covered by detect-secrets built-in filter (listed for custom-pattern stage):
+        "Brewfile.lock.json",
+        "Cartfile.resolved",
+        "composer.lock",
+        "Gemfile.lock",
+        "Package.resolved",
+        "package-lock.json",
+        "Podfile.lock",
+        "yarn.lock",
+        "Pipfile.lock",
+        "poetry.lock",
+        "Cargo.lock",
+        "packages.lock.json",
+        # Not covered by detect-secrets built-in — must be filtered here:
+        "deno.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+        "bun.lock",
+        "uv.lock",
+        "mix.lock",
+        "flake.lock",
+        "shrinkwrap.yaml",
+        "npm-shrinkwrap.json",
+        "go.sum",
+    }
+)
+
 
 def _is_example_path(file_path: str) -> bool:
     """Check if file is in an example/tutorial/documentation context."""
     return any(p.search(file_path) for p in EXAMPLE_PATH_PATTERNS)
+
+
+def _is_lock_file(file_path: str) -> bool:
+    """Check if file is a dependency lock file with public integrity hashes."""
+    return Path(file_path).name in LOCK_FILE_BASENAMES
 
 
 def _is_placeholder_value(matched_text: str) -> bool:
@@ -160,10 +197,13 @@ def run_detect_secrets(temp_dir: str) -> list[Finding]:
                 "plugins_used": plugins,
                 "filters_used": [
                     {"path": "detect_secrets.filters.allowlist.is_line_allowlisted"},
+                    {"path": "detect_secrets.filters.heuristic.is_lock_file"},
                 ],
             }
         ):
             for file_path in get_files_to_scan(temp_dir, should_scan_all_files=True, root=temp_dir):
+                if _is_lock_file(file_path):
+                    continue
                 abs_path = os.path.join(temp_dir, file_path)
                 try:
                     for secret in scan_file(abs_path):
@@ -239,6 +279,9 @@ def run_custom_patterns(temp_dir: str, file_list: list[str]) -> list[Finding]:
     for file_path in file_list:
         ext = Path(file_path).suffix.lower()
         if ext in SKIP_EXTENSIONS:
+            continue
+
+        if _is_lock_file(file_path):
             continue
 
         full_path = Path(temp_dir) / file_path

--- a/apps/python-api/tests/test_stage4_lock_files.py
+++ b/apps/python-api/tests/test_stage4_lock_files.py
@@ -1,0 +1,132 @@
+"""Regression: lock files contain public integrity hashes, not secrets.
+
+Bug: Stage 4 reported 800+ critical Base64HighEntropyString findings for
+package-lock.json and high-entropy findings for deno.lock. Lock files are
+dependency pins with public SHA-256/512 integrity hashes and must be skipped.
+"""
+
+from pathlib import Path
+
+from lib.scan.models import IngestResult, StageResult
+from lib.scan.stage4_secrets import (
+    LOCK_FILE_BASENAMES,
+    _is_lock_file,
+    run_custom_patterns,
+    stage4_scan_secrets,
+)
+
+
+def _make_ingest(tmp_path: Path, files: list[str]) -> IngestResult:
+    return IngestResult(
+        temp_dir=str(tmp_path),
+        file_list=files,
+        total_size=sum((tmp_path / f).stat().st_size for f in files),
+        stage_result=StageResult(stage="stage0", status="passed", findings=[], duration_ms=0),
+    )
+
+
+PACKAGE_LOCK_SAMPLE = """{
+  "name": "sample",
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/foo": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz",
+      "integrity": "sha512-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYz=="
+    }
+  }
+}
+"""
+
+DENO_LOCK_SAMPLE = """{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/assert": "1.0.0"
+  },
+  "jsr": {
+    "@std/assert@1.0.0": {
+      "integrity": "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789AbCdEfGhIjKlMnOpQrStUvWxYz"
+    }
+  }
+}
+"""
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    (tmp_path / name).write_text(content)
+    return name
+
+
+class TestLockFileIdentification:
+    def test_package_lock_json_recognized(self):
+        assert _is_lock_file("package-lock.json")
+        assert _is_lock_file("site/package-lock.json")
+
+    def test_deno_lock_recognized(self):
+        assert _is_lock_file("deno.lock")
+        assert _is_lock_file("some/nested/deno.lock")
+
+    def test_common_ecosystem_lockfiles_recognized(self):
+        for name in [
+            "yarn.lock",
+            "pnpm-lock.yaml",
+            "bun.lock",
+            "bun.lockb",
+            "Cargo.lock",
+            "poetry.lock",
+            "uv.lock",
+            "go.sum",
+            "composer.lock",
+            "Gemfile.lock",
+            "Pipfile.lock",
+        ]:
+            assert _is_lock_file(name), name
+            assert name in LOCK_FILE_BASENAMES, name
+
+    def test_non_lockfile_not_recognized(self):
+        assert not _is_lock_file("package.json")
+        assert not _is_lock_file("src/lock.ts")
+        assert not _is_lock_file("my-lock.txt")
+
+
+class TestCustomPatternsSkipLockFiles:
+    def test_package_lock_json_yields_no_findings(self, tmp_path: Path):
+        name = _write(tmp_path, "package-lock.json", PACKAGE_LOCK_SAMPLE)
+        findings = run_custom_patterns(str(tmp_path), [name])
+        assert findings == []
+
+    def test_deno_lock_yields_no_findings(self, tmp_path: Path):
+        name = _write(tmp_path, "deno.lock", DENO_LOCK_SAMPLE)
+        findings = run_custom_patterns(str(tmp_path), [name])
+        assert findings == []
+
+    def test_nested_package_lock_skipped(self, tmp_path: Path):
+        sub = tmp_path / "site"
+        sub.mkdir()
+        (sub / "package-lock.json").write_text(PACKAGE_LOCK_SAMPLE)
+        findings = run_custom_patterns(str(tmp_path), ["site/package-lock.json"])
+        assert findings == []
+
+    def test_non_lockfile_still_scanned(self, tmp_path: Path):
+        name = _write(
+            tmp_path,
+            "config.js",
+            'const key = "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789AbCdEfGhIjKlMnOp==";\n',
+        )
+        findings = run_custom_patterns(str(tmp_path), [name])
+        assert any("high-entropy" in f.description.lower() for f in findings), (
+            "High-entropy pattern should still fire on non-lock files"
+        )
+
+
+class TestFullStage4SkipsLockFiles:
+    def test_full_pipeline_no_lockfile_findings(self, tmp_path: Path):
+        files = [
+            _write(tmp_path, "package-lock.json", PACKAGE_LOCK_SAMPLE),
+            _write(tmp_path, "deno.lock", DENO_LOCK_SAMPLE),
+        ]
+        result = stage4_scan_secrets(_make_ingest(tmp_path, files))
+        lock_findings = [f for f in result.findings if f.location and any(lf in f.location for lf in files)]
+        assert lock_findings == [], (
+            f"Expected zero findings in lock files, got: {[(f.severity, f.description, f.location) for f in lock_findings]}"
+        )


### PR DESCRIPTION
## Summary

- Stage 4 secrets scan treated public integrity hashes in dependency lock files as leaked secrets, flooding scan reports with hundreds of critical false positives (e.g. \`@uriva/safescript@0.1.1\` returned 807 \"critical\" findings — ~800 were \`Base64 High Entropy String\` hits on \`site/package-lock.json\` and \`deno.lock\`).
- Lock files contain SHA-256/512 integrity hashes for supply-chain verification, not credentials. They must be excluded from secret detection.

## Changes

- Enable \`detect_secrets.filters.heuristic.is_lock_file\` in \`run_detect_secrets\` (built-in filter covering npm, yarn, PyPI, Ruby, Composer, Cargo, Swift, CocoaPods).
- Add \`LOCK_FILE_BASENAMES\` to cover ecosystems the built-in filter misses: Deno, pnpm, Bun, uv, Elixir Mix, Nix Flakes, Go sum files, npm shrinkwrap.
- Short-circuit lock files in both \`run_detect_secrets\` and \`run_custom_patterns\` before reading file contents (belt-and-suspenders, and avoids wasted I/O).
- New regression test file \`tests/test_stage4_lock_files.py\` with 9 cases: basename recognition across ecosystems, custom-pattern skipping, nested lock file paths, non-lock files still scanned, and full-pipeline verification.

## Verification

Smoke test reproducing the original bug scenario:

\`\`\`
Custom-pattern findings on lock files: 0
detect-secrets findings on lock files: 0
TOTAL in lock files: 0 (was ~800+ before fix)
\`\`\`

- \`just test scanner\`: 9/9 new regression tests pass. 6 pre-existing failures are unrelated (confirmed by running the suite without my changes — same failures in \`test_scanner_report_redesign.py\`, \`test_description_truncation.py\`, \`test_skill_corpus.py\`).
- \`just lint python\`: clean.
- Lint debt in unrelated files blocks the pre-push hook; pushed with \`--no-verify\` per gotcha #10.

## Why this matters

- Lock files are committed to every JS/TS/Python/Rust/Go skill. Without this fix, essentially any skill that ships a lock file would be marked \"Unsafe\" with hundreds of critical findings, making the security report unusable and eroding trust in the scanner.
- Real secrets in non-lock files still fire — high-entropy pattern, detect-secrets, and custom patterns are only bypassed for the exact lock file basenames.