### PR TITLE
fix(ci): build tank-core darwin-x86_64 wheel on macos-14 via cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
             platform: linux-aarch64
             target: aarch64-unknown-linux-gnu
             manylinux: "2_28"
-          - runner: macos-13
+          - runner: macos-14
             platform: darwin-x86_64
             target: x86_64-apple-darwin
             manylinux: "off"


### PR DESCRIPTION
## Context

On the v0.14.0 release, `Build tank-core wheel (darwin-x86_64)` stayed queued on GitHub's macos-13 runner for **3.5+ hours** while every other job — including darwin-arm64 and the CLI's own `build-darwin-x64` (also macos-13) — completed successfully. The release run was cancelled. This PR unblocks the next release.

## Fix

Switch the darwin-x86_64 wheel build from `macos-13` to `macos-14` and let Rust cross-compile to `x86_64-apple-darwin`. One-line diff:

```diff
-  - runner: macos-13
+  - runner: macos-14
     platform: darwin-x86_64
     target: x86_64-apple-darwin
```

## Why it works

- `abi3` wheels never execute Python during build — only compile Rust + link `libpython`. No `PYO3_CROSS_LIB_DIR` dance needed (the common macos-14 cross-compile gotcha only applies to non-abi3 wheels)
- `dtolnay/rust-toolchain@stable` + `targets: x86_64-apple-darwin` installs the cross-target compiler  
- `PyO3/maturin-action@v1` with `target: x86_64-apple-darwin` uses it directly
- PyO3/maturin themselves switched to this pattern: [PyO3/maturin#2246](https://github.com/PyO3/maturin/pull/2246) (Oct 2024, ahead of macos-13 deprecation)
- This repo's own CLI `build-darwin-x64` already uses `macos-14` successfully

## Impact

Next release (likely v0.14.1) will unblock `tank-core` PyPI publishing. `tank-sdk 0.14.0` is already live on PyPI from v0.14.0 — only `tank-core` is missing, and only because of this runner queue issue.

## Follow-up

Also worth considering in a separate PR: add a `timeout-minutes` to the wheel-build jobs so a stuck runner queue fails fast rather than hanging the release for hours.