### PR TITLE
chore: update Homebrew formula for v0.14.1

### DIFF
--- a/Formula/tank.rb
+++ b/Formula/tank.rb
@@ -1,19 +1,19 @@
 class Tank < Formula
   desc "Security-first package manager for AI agent skills"
   homepage "https://tankpkg.dev"
-  version "0.11.0"
+  version "0.14.1"
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-arm64.tar.gz"
-    sha256 "979371a6cf932885f860276bea9bc26142c7aaa60f96584b20eb8807c7e74d16"
+    sha256 "7b4bfd2e43e4e7f7e7534915e50e43d9bfcd860cb514f0551d9d56f40ba7abb1"
   elsif OS.mac?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-x64.tar.gz"
-    sha256 "9985c90adf8fb193ed806d216dd847c5b8f7649ec203597c3c48bece1a1fed82"
+    sha256 "a3f29f55c5eeea2b0d66cf01daf1d20841c1da5a44689f83bf3cd156df447c06"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-arm64.tar.gz"
-    sha256 "2cab811821ece816f434bdd2a5ab0621c32d689c919ca06921deaf0e66303186"
+    sha256 "430aec1c1d5e77658f959ce4aec71e06630976d0d7fc66b3b9d7c829493e08a4"
   else
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-x64.tar.gz"
-    sha256 "187fd376f00266037a5f1d862281c075c2e4e1f9154c080cf4a1ff7d2b3e89e7"
+    sha256 "fb4b8fe0c3ac22698595b578d77cddb2ccbe019a7f5d02e64e8bf8663eadf489"
   end
   def install
     bin.install Dir["tank-*"].first => "tank"


### PR DESCRIPTION
Auto-generated by release pipeline. PR creation step failed in CI because branch was already pushed from earlier cancelled run; opening manually.