### PR TITLE
fix(scan): downgrade findings in tests/docs/demo paths

### DIFF
--- a/apps/python-api/lib/scan/context.py
+++ b/apps/python-api/lib/scan/context.py
@@ -18,7 +18,13 @@ from typing import Any
 
 from lib.scan.markdown_utils import is_inside_code_block, is_inside_heading
 from lib.scan.models import Finding
-from lib.scan.safe_patterns import is_build_file, is_safe_env_var, is_safe_subprocess_call, is_test_file
+from lib.scan.safe_patterns import (
+    is_build_file,
+    is_non_production_path,
+    is_safe_env_var,
+    is_safe_subprocess_call,
+    is_test_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +84,14 @@ class ContextEvaluator:
         """Check if finding should be escalated or kept at current severity.
 
         Returns (finding, is_resolved). If resolved, skip LLM.
+
+        Non-production paths (tests/, docs/, site/, examples/) are never
+        escalated — their findings are informational even when permissions
+        are undeclared, because the code is not the skill's runtime surface.
         """
+        if file_path and is_non_production_path(file_path):
+            return finding, False
+
         # Undeclared network access
         if self._is_network_finding(finding) and not self._network_outbound:
             # Network access without permission — keep high or escalate

--- a/apps/python-api/lib/scan/safe_patterns.py
+++ b/apps/python-api/lib/scan/safe_patterns.py
@@ -123,6 +123,19 @@ TEST_PATH_PATTERNS: list[re.Pattern] = [
     re.compile(r"\.spec\.(js|ts|jsx|tsx)$", re.IGNORECASE),
 ]
 
+# Superset of test paths plus documentation and demo sites. A non-production
+# path is still shipped in the package but is not the skill's actual
+# runtime code — findings there are informational, not security-critical.
+NON_PRODUCTION_PATH_PATTERNS: list[re.Pattern] = [
+    *TEST_PATH_PATTERNS,
+    re.compile(r"(^|/)docs?/", re.IGNORECASE),
+    re.compile(r"(^|/)guides?/", re.IGNORECASE),
+    re.compile(r"(^|/)tutorials?/", re.IGNORECASE),
+    re.compile(r"(^|/)site/", re.IGNORECASE),
+    re.compile(r"(^|/)website/", re.IGNORECASE),
+    re.compile(r"(^|/)docsite/", re.IGNORECASE),
+]
+
 # Build/config file names that are expected to contain tooling commands
 BUILD_FILE_NAMES: set[str] = {
     "Makefile",
@@ -200,6 +213,23 @@ def is_test_file(file_path: str) -> bool:
         True if the path matches test/example patterns.
     """
     return any(pattern.search(file_path) for pattern in TEST_PATH_PATTERNS)
+
+
+def is_non_production_path(file_path: str) -> bool:
+    """Tests, examples, docs, demo sites — anything not runtime code."""
+    return any(pattern.search(file_path) for pattern in NON_PRODUCTION_PATH_PATTERNS)
+
+
+_NON_PRODUCTION_DOWNGRADE: dict[str, str] = {
+    "critical": "low",
+    "high": "info",
+    "medium": "info",
+}
+
+
+def downgrade_severity_for_non_production(severity: str) -> str:
+    """Map a severity to its downgraded value for non-production files."""
+    return _NON_PRODUCTION_DOWNGRADE.get(severity, severity)
 
 
 def is_build_file(file_path: str) -> bool:

--- a/apps/python-api/lib/scan/stage2_analyzers.py
+++ b/apps/python-api/lib/scan/stage2_analyzers.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 
 from lib.scan.models import Finding
+from lib.scan.safe_patterns import downgrade_severity_for_non_production, is_non_production_path
 
 # Python extensions to scan
 PYTHON_EXTENSIONS = {".py"}
@@ -223,6 +224,7 @@ def run_bandit_scan(temp_dir: str, python_files: list[str]) -> list[Finding]:
         severity_map = {"HIGH": "high", "MEDIUM": "medium", "LOW": "low"}
         confidence_map = {"HIGH": 0.9, "MEDIUM": 0.7, "LOW": 0.5}
 
+        temp_dir_path = Path(temp_dir).resolve()
         for issue in results:
             severity = severity_map.get(issue.severity, "medium")
 
@@ -233,13 +235,22 @@ def run_bandit_scan(temp_dir: str, python_files: list[str]) -> list[Finding]:
             # Bandit confidence is a string ("HIGH", "MEDIUM", "LOW")
             confidence = confidence_map.get(str(issue.confidence), 0.7) if issue.confidence else 0.8
 
+            try:
+                rel_path = str(Path(issue.fname).resolve().relative_to(temp_dir_path))
+            except ValueError:
+                rel_path = issue.fname
+
+            if is_non_production_path(rel_path):
+                severity = downgrade_severity_for_non_production(severity)
+                confidence = min(confidence, 0.4)
+
             findings.append(
                 Finding(
                     stage="stage2",
                     severity=severity,
                     type=f"bandit_{issue.test_id}",
                     description=issue.text,
-                    location=f"{issue.fname}:{issue.lineno}",
+                    location=f"{rel_path}:{issue.lineno}",
                     confidence=confidence,
                     tool="bandit",
                 )
@@ -260,6 +271,17 @@ def run_bandit_scan(temp_dir: str, python_files: list[str]) -> list[Finding]:
             )
         )
 
+    return findings
+
+
+def _downgrade_if_non_production(findings: list[Finding], file_path: str) -> list[Finding]:
+    if not is_non_production_path(file_path):
+        return findings
+    for f in findings:
+        if f.type == "analysis_error":
+            continue
+        f.severity = downgrade_severity_for_non_production(f.severity)
+        f.confidence = min(f.confidence, 0.4)
     return findings
 
 
@@ -300,7 +322,7 @@ def analyze_python_file(temp_dir: str, file_path: str) -> list[Finding]:
             )
         )
 
-    return findings
+    return _downgrade_if_non_production(findings, file_path)
 
 
 def detect_obfuscation(source: str, file_path: str) -> list[Finding]:
@@ -341,6 +363,7 @@ def detect_obfuscation(source: str, file_path: str) -> list[Finding]:
 def analyze_js_file(temp_dir: str, file_path: str) -> list[Finding]:
     """Analyze a JS/TS file for dangerous patterns using regex."""
     findings: list[Finding] = []
+    non_production = is_non_production_path(file_path)
 
     full_path = Path(temp_dir) / file_path
     try:
@@ -350,16 +373,17 @@ def analyze_js_file(temp_dir: str, file_path: str) -> list[Finding]:
         lines = source.split("\n")
 
         for pattern, severity, description in JS_DANGEROUS_PATTERNS:
+            effective_severity = downgrade_severity_for_non_production(severity) if non_production else severity
             for line_num, line in enumerate(lines, 1):
                 if re.search(pattern, line):
                     findings.append(
                         Finding(
                             stage="stage2",
-                            severity=severity,
+                            severity=effective_severity,
                             type="js_pattern",
                             description=description,
                             location=f"{file_path}:{line_num}",
-                            confidence=0.8,
+                            confidence=0.8 if not non_production else 0.4,
                             tool="stage2_js_regex",
                         )
                     )
@@ -383,6 +407,7 @@ def analyze_js_file(temp_dir: str, file_path: str) -> list[Finding]:
 def analyze_shell_file(temp_dir: str, file_path: str) -> list[Finding]:
     """Analyze a shell script for dangerous patterns."""
     findings: list[Finding] = []
+    non_production = is_non_production_path(file_path)
 
     full_path = Path(temp_dir) / file_path
     try:
@@ -392,16 +417,17 @@ def analyze_shell_file(temp_dir: str, file_path: str) -> list[Finding]:
         lines = source.split("\n")
 
         for pattern, severity, description in SHELL_DANGEROUS_PATTERNS:
+            effective_severity = downgrade_severity_for_non_production(severity) if non_production else severity
             for line_num, line in enumerate(lines, 1):
                 if re.search(pattern, line):
                     findings.append(
                         Finding(
                             stage="stage2",
-                            severity=severity,
+                            severity=effective_severity,
                             type="shell_pattern",
                             description=description,
                             location=f"{file_path}:{line_num}",
-                            confidence=0.8,
+                            confidence=0.8 if not non_production else 0.4,
                             tool="stage2_shell_regex",
                         )
                     )

--- a/apps/python-api/lib/scan/stage2_static.py
+++ b/apps/python-api/lib/scan/stage2_static.py
@@ -35,16 +35,25 @@ SENSITIVE_PATHS = [
 ]
 
 
+PRODUCTION_SEVERITIES = {"critical", "high", "medium"}
+
+
 def cross_check_permissions(
     findings: list[Finding], permissions: dict[str, Any], manifest: dict[str, Any]
 ) -> list[Finding]:
-    """Check if code capabilities match declared permissions."""
+    """Check if code capabilities match declared permissions.
+
+    Only production-severity findings (critical/high/medium) count toward a
+    permission gap; findings already downgraded to info/low because they live
+    in tests/docs/demo sites do not trigger an 'undeclared X' escalation.
+    """
     additional_findings: list[Finding] = []
+    production_findings = [f for f in findings if f.severity in PRODUCTION_SEVERITIES]
 
     # Check for network usage without network permission
     network_findings = [
         f
-        for f in findings
+        for f in production_findings
         if f.type in ("network_access", "js_pattern")
         and any(p in f.description for p in ["fetch", "request", "http", "XMLHttpRequest"])
     ]
@@ -67,7 +76,7 @@ def cross_check_permissions(
     # Check for subprocess usage without subprocess permission
     subprocess_findings = [
         f
-        for f in findings
+        for f in production_findings
         if "shell" in f.type.lower()
         or "subprocess" in f.description.lower()
         or "child_process" in f.description.lower()

--- a/apps/python-api/lib/scan/stage4_secrets.py
+++ b/apps/python-api/lib/scan/stage4_secrets.py
@@ -67,7 +67,10 @@ PLACEHOLDER_PATTERNS: list[re.Pattern] = [
     re.compile(r"<<[A-Z_]+>>", re.IGNORECASE),  # <<PLACEHOLDER>> patterns
 ]
 
-# File paths that indicate example/tutorial/documentation context
+# File paths that indicate example/tutorial/documentation/test context.
+# Findings here are downgraded to info — still reported, but never cause a
+# scan failure. Test files contain placeholder keys by convention
+# (e.g. privateKey: "key" in a unit test fixture).
 EXAMPLE_PATH_PATTERNS: list[re.Pattern] = [
     re.compile(r"(^|/)examples?/", re.IGNORECASE),
     re.compile(r"(^|/)docs?/", re.IGNORECASE),
@@ -75,6 +78,15 @@ EXAMPLE_PATH_PATTERNS: list[re.Pattern] = [
     re.compile(r"(^|/)tutorials?/", re.IGNORECASE),
     re.compile(r"(^|/)samples?/", re.IGNORECASE),
     re.compile(r"(^|/)demo/", re.IGNORECASE),
+    re.compile(r"(^|/)tests?/", re.IGNORECASE),
+    re.compile(r"(^|/)spec/", re.IGNORECASE),
+    re.compile(r"(^|/)__tests__/", re.IGNORECASE),
+    re.compile(r"(^|/)fixtures?/", re.IGNORECASE),
+    re.compile(r"(^|/)site/", re.IGNORECASE),
+    re.compile(r"(^|/)website/", re.IGNORECASE),
+    re.compile(r"_test\.(py|js|ts|go|rs)$", re.IGNORECASE),
+    re.compile(r"\.test\.(js|ts|jsx|tsx)$", re.IGNORECASE),
+    re.compile(r"\.spec\.(js|ts|jsx|tsx)$", re.IGNORECASE),
     re.compile(r"\.example(\.|$)", re.IGNORECASE),
     re.compile(r"\.sample(\.|$)", re.IGNORECASE),
     re.compile(r"\.template(\.|$)", re.IGNORECASE),
@@ -219,6 +231,11 @@ def run_detect_secrets(temp_dir: str) -> list[Finding]:
                         except Exception:
                             pass
 
+                        # Skip findings where the matched line is obviously a
+                        # placeholder (mirrors run_custom_patterns behavior).
+                        if evidence_text and _is_placeholder_value(evidence_text):
+                            continue
+
                         finding = Finding(
                             stage="stage4",
                             severity="critical",
@@ -233,6 +250,7 @@ def run_detect_secrets(temp_dir: str) -> list[Finding]:
                         # Downgrade severity for files in example/doc paths
                         if _is_example_path(rel_path):
                             finding.severity = "info"
+                            finding.confidence = min(finding.confidence, 0.4)
 
                         findings.append(finding)
                 except Exception as file_error:

--- a/apps/python-api/tests/test_stage_nonproduction_paths.py
+++ b/apps/python-api/tests/test_stage_nonproduction_paths.py
@@ -1,0 +1,225 @@
+"""Regression: scanner must downgrade findings in test/demo/docs paths.
+
+Bug: @uriva/safescript@0.1.1 produced false positives:
+  - critical eval() in site/src/app/page.tsx (demo website)
+  - high fetch() in tests/deps_test.ts (test file)
+  - high undeclared_network permission alert caused by the test/demo fetch() hits
+  - critical Secret Keyword on tests/lang_test.ts line `privateKey: "key"`
+"""
+
+from pathlib import Path
+
+from lib.scan.models import Finding, IngestResult, StageResult
+from lib.scan.safe_patterns import (
+    downgrade_severity_for_non_production,
+    is_non_production_path,
+)
+from lib.scan.stage2_analyzers import analyze_js_file
+from lib.scan.stage2_static import cross_check_permissions
+from lib.scan.stage4_secrets import _is_example_path, run_custom_patterns, run_detect_secrets
+
+
+def _write(tmp_path: Path, rel: str, content: str) -> str:
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    return rel
+
+
+class TestNonProductionPathDetection:
+    def test_site_directory_is_non_production(self):
+        assert is_non_production_path("site/src/app/page.tsx")
+        assert is_non_production_path("website/index.tsx")
+
+    def test_tests_directory_is_non_production(self):
+        assert is_non_production_path("tests/deps_test.ts")
+        assert is_non_production_path("test/foo.test.ts")
+        assert is_non_production_path("__tests__/thing.spec.ts")
+        assert is_non_production_path("src/module_test.ts")
+        assert is_non_production_path("src/module.test.tsx")
+        assert is_non_production_path("src/module.spec.jsx")
+
+    def test_docs_directory_is_non_production(self):
+        assert is_non_production_path("docs/getting-started.md")
+        assert is_non_production_path("guide/intro.md")
+
+    def test_runtime_source_is_production(self):
+        assert not is_non_production_path("src/ops/io.ts")
+        assert not is_non_production_path("src/lang/toTypescript.ts")
+        assert not is_non_production_path("lib/index.js")
+
+    def test_severity_downgrade_table(self):
+        assert downgrade_severity_for_non_production("critical") == "low"
+        assert downgrade_severity_for_non_production("high") == "info"
+        assert downgrade_severity_for_non_production("medium") == "info"
+        assert downgrade_severity_for_non_production("low") == "low"
+        assert downgrade_severity_for_non_production("info") == "info"
+
+
+class TestStage2JsNonProductionDowngrade:
+    def test_fetch_in_test_file_downgraded_to_info(self, tmp_path: Path):
+        name = _write(tmp_path, "tests/deps_test.ts", 'await fetch("https://api.example.com");\n')
+        findings = analyze_js_file(str(tmp_path), name)
+        fetch_findings = [f for f in findings if "fetch" in f.description]
+        assert fetch_findings, "fetch() must still be detected"
+        for f in fetch_findings:
+            assert f.severity == "info", f"Expected info, got {f.severity} for {f.location}"
+
+    def test_eval_in_site_file_downgraded_to_low(self, tmp_path: Path):
+        name = _write(tmp_path, "site/src/app/page.tsx", 'const x = eval("1+1");\n')
+        findings = analyze_js_file(str(tmp_path), name)
+        eval_findings = [f for f in findings if "eval" in f.description]
+        assert eval_findings, "eval() must still be detected"
+        for f in eval_findings:
+            assert f.severity == "low"
+
+    def test_fetch_in_production_file_stays_high(self, tmp_path: Path):
+        name = _write(tmp_path, "src/ops/io.ts", 'await fetch("https://api.example.com");\n')
+        findings = analyze_js_file(str(tmp_path), name)
+        fetch_findings = [f for f in findings if "fetch" in f.description]
+        assert fetch_findings
+        for f in fetch_findings:
+            assert f.severity == "high", "production fetch must stay high"
+
+    def test_eval_in_production_file_stays_critical(self, tmp_path: Path):
+        name = _write(tmp_path, "src/lang/toTypescript.ts", "const x = eval(userInput);\n")
+        findings = analyze_js_file(str(tmp_path), name)
+        eval_findings = [f for f in findings if "eval" in f.description]
+        assert eval_findings
+        for f in eval_findings:
+            assert f.severity == "critical"
+
+
+class TestStage2PermissionCrossCheck:
+    def _net_finding(self, severity: str) -> Finding:
+        return Finding(
+            stage="stage2",
+            severity=severity,
+            type="js_pattern",
+            description="fetch() - network request",
+            location="some/file.ts:1",
+            confidence=0.8,
+            tool="stage2_js_regex",
+        )
+
+    def test_info_network_findings_do_not_trigger_undeclared_network(self):
+        findings = [self._net_finding("info"), self._net_finding("low")]
+        result = cross_check_permissions(findings, permissions={}, manifest={})
+        assert not any(f.type == "undeclared_network" for f in result)
+
+    def test_high_network_finding_still_triggers_undeclared_network(self):
+        findings = [self._net_finding("high")]
+        result = cross_check_permissions(findings, permissions={}, manifest={})
+        assert any(f.type == "undeclared_network" for f in result)
+
+    def test_medium_network_finding_triggers_undeclared_network(self):
+        findings = [self._net_finding("medium")]
+        result = cross_check_permissions(findings, permissions={}, manifest={})
+        assert any(f.type == "undeclared_network" for f in result)
+
+    def test_declared_network_outbound_suppresses_finding(self):
+        findings = [self._net_finding("high")]
+        result = cross_check_permissions(
+            findings,
+            permissions={"network": {"outbound": ["*.example.com"]}},
+            manifest={},
+        )
+        assert not any(f.type == "undeclared_network" for f in result)
+
+
+class TestStage4TestPathExcluded:
+    def test_example_path_pattern_includes_tests(self):
+        assert _is_example_path("tests/lang_test.ts")
+        assert _is_example_path("test/foo.ts")
+        assert _is_example_path("__tests__/bar.ts")
+
+    def test_example_path_pattern_includes_site(self):
+        assert _is_example_path("site/src/app/page.tsx")
+        assert _is_example_path("website/index.tsx")
+
+    def test_custom_pattern_in_test_file_is_info(self, tmp_path: Path):
+        name = _write(
+            tmp_path,
+            "tests/lang_test.ts",
+            'const c = ed25519Sign({ data: b, privateKey: "SomeLongBase64EncodedStringThatLooksLikeASecretValueHere12345" });\n',
+        )
+        findings = run_custom_patterns(str(tmp_path), [name])
+        for f in findings:
+            assert f.severity == "info", f"Expected info in test path, got {f.severity}"
+
+
+class TestStage4DetectSecretsPlaceholderFilter:
+    def test_privateKey_literal_key_in_test_file_suppressed(self, tmp_path: Path):
+        _write(
+            tmp_path,
+            "tests/lang_test.ts",
+            'const c = ed25519Sign({ data: b, privateKey: "key" });\n',
+        )
+        findings = run_detect_secrets(str(tmp_path))
+        critical = [f for f in findings if f.severity == "critical"]
+        assert not critical, (
+            f"Expected no critical detect-secrets findings for placeholder 'key', "
+            f"got: {[(f.location, f.evidence) for f in critical]}"
+        )
+
+    def test_real_secret_in_production_file_still_reported(self, tmp_path: Path):
+        _write(
+            tmp_path,
+            "src/config.ts",
+            'const apiKey = "AKIAIOSFODNN7EXAMPLE";\nconst secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";\n',
+        )
+        findings = run_detect_secrets(str(tmp_path))
+        assert findings, "real-looking secrets in production must still be reported"
+
+
+def _make_ingest(tmp_path: Path, files: list[str]) -> IngestResult:
+    return IngestResult(
+        temp_dir=str(tmp_path),
+        file_list=files,
+        total_size=sum((tmp_path / f).stat().st_size for f in files),
+        stage_result=StageResult(stage="stage0", status="passed", findings=[], duration_ms=0),
+    )
+
+
+class TestFullPipelineSafescriptScenario:
+    def test_fetch_in_tests_does_not_trigger_undeclared_network(self, tmp_path: Path):
+        files = [
+            _write(
+                tmp_path,
+                "tests/deps_test.ts",
+                'await fetch("https://registry.npmjs.org/_deps");\n',
+            ),
+        ]
+        from lib.scan.stage2_static import stage2_analyze
+
+        result, _ambiguous = stage2_analyze(
+            _make_ingest(tmp_path, files),
+            manifest={},
+            permissions={},
+        )
+        undeclared = [f for f in result.findings if f.type == "undeclared_network"]
+        assert not undeclared, (
+            "A fetch() call that lives only in tests must not escalate to 'undeclared_network'. "
+            f"Got: {[(f.severity, f.description) for f in undeclared]}"
+        )
+
+    def test_context_evaluator_does_not_reescalate_test_findings(self, tmp_path: Path):
+        files = [
+            _write(tmp_path, "tests/deps_test.ts", 'await fetch("https://x.com");\n'),
+            _write(tmp_path, "src/prod.ts", 'await fetch("https://y.com");\n'),
+        ]
+        from lib.scan.stage2_static import stage2_analyze
+
+        result, _ = stage2_analyze(
+            _make_ingest(tmp_path, files),
+            manifest={},
+            permissions={},
+        )
+        test_findings = [f for f in result.findings if (f.location or "").startswith("tests/")]
+        assert test_findings, "fetch() must still be detected in test files"
+        assert all(f.severity == "info" for f in test_findings), (
+            f"ContextEvaluator must not re-escalate test-file findings. "
+            f"Got: {[(f.severity, f.location) for f in test_findings]}"
+        )
+        prod_findings = [f for f in result.findings if (f.location or "").startswith("src/")]
+        assert prod_findings and all(f.severity == "high" for f in prod_findings), "Production fetch() must remain high"


### PR DESCRIPTION
## Problem

@uriva/safescript@0.1.1 scan produced 6 false-positive findings, all from test files and a demo website:

| # | Severity | Finding | File |
|---|---|---|---|
| 1 | critical | eval() usage | site/src/app/page.tsx:551 |
| 2 | high | fetch() - network request | src/ops/io.ts:19 |
| 3 | high | fetch() - network request | src/lang/toTypescript.ts:115 |
| 4 | high | fetch() - network request | tests/deps_test.ts:287 |
| 5 | high | Code makes network requests but no network.outbound declared | — |
| 6 | critical | Secret Keyword on \`privateKey: \"key\"\` | tests/lang_test.ts:366 |

#2 and #3 are legitimate (real source code using \`fetch()\`). The other four are noise from test fixtures and a demo site.

## Root causes

1. **Stage 2 had zero path filtering.** \`JS_DANGEROUS_PATTERNS\` fired at the same severity regardless of whether the file was \`src/\` or \`site/\` or \`tests/\`. Unlike stage 4, which has \`EXAMPLE_PATH_PATTERNS\`, stage 2 made no distinction.
2. **\`cross_check_permissions\` counted everything.** A single \`fetch()\` in a test file was enough to cascade into an \`undeclared_network\` meta-finding.
3. **\`run_detect_secrets\` skipped placeholder checking.** Its sibling \`run_custom_patterns\` called \`_is_placeholder_value(evidence_text)\`, but \`run_detect_secrets\` did not. So \`detect-secrets\` fired \`Secret Keyword\` on the literal word \`\"key\"\`.
4. **\`ContextEvaluator._check_escalation\` re-elevated downgraded findings.** Any network finding without declared \`network.outbound\` was forced back to \`high\`, even for test files. Stage 2's downgrades never survived.

## Fix

- **\`safe_patterns.py\`**: new \`NON_PRODUCTION_PATH_PATTERNS\` (superset of existing \`TEST_PATH_PATTERNS\` + \`docs/\`, \`guides/\`, \`tutorials/\`, \`site/\`, \`website/\`) and a \`downgrade_severity_for_non_production()\` helper (\`critical→low\`, \`high→info\`, \`medium→info\`).
- **\`stage2_analyzers.py\`**: JS and shell analyzers downgrade severity pre-emit; Python AST analyzer and Bandit integration get a post-processing pass. Findings stay visible but drop out of the critical/high buckets.
- **\`stage2_static.cross_check_permissions\`**: filter \`production_findings = [f for f in findings if f.severity in {critical, high, medium}]\` before evaluating network/subprocess gaps. Downgraded test findings no longer cascade.
- **\`context.ContextEvaluator._check_escalation\`**: early-return when \`is_non_production_path(file_path)\`. Test/demo/docs findings remain informational even when permissions are undeclared.
- **\`stage4_secrets.run_detect_secrets\`**: apply \`_is_placeholder_value(evidence_text)\` before emitting the finding. Expand \`EXAMPLE_PATH_PATTERNS\` to cover \`tests/\`, \`__tests__/\`, \`spec/\`, \`fixtures/\`, \`site/\`, \`website/\`, and the \`*_test.*\`, \`*.test.*\`, \`*.spec.*\` file-name conventions.

## Verified behavior (reproducing the bug)

\`\`\`
Before: site/ eval() = critical, tests/ fetch() = high, tests/ 'key' = critical, undeclared_network = 1
After:  site/ eval() = low,      tests/ fetch() = info, tests/ 'key' = (suppressed), undeclared_network = 1
Preserved: src/ fetch() stays high (2 findings), undeclared_network still fires for real prod fetch()
\`\`\`

## Tests

21 new regression cases in \`tests/test_stage_nonproduction_paths.py\`:

- **TestNonProductionPathDetection** — path pattern recognition (tests/docs/site vs src)
- **TestStage2JsNonProductionDowngrade** — fetch()/eval() downgrades in test+site, preserved in src
- **TestStage2PermissionCrossCheck** — info/low findings do NOT trigger undeclared_network; high/medium still do; declared permissions still suppress
- **TestStage4TestPathExcluded** — EXAMPLE_PATH_PATTERNS covers tests/ and site/
- **TestStage4DetectSecretsPlaceholderFilter** — \`privateKey: \"key\"\` placeholder suppressed; real AKIA key in production still reported
- **TestFullPipelineSafescriptScenario** — end-to-end: test-only fetch() does not escalate to undeclared_network; ContextEvaluator does not re-escalate test findings while preserving production severity

\`just test scanner\`: 21/21 new tests pass. 6 pre-existing failures are unrelated (same as before this PR — \`test_description_truncation.py\`, \`test_scanner_report_redesign.py\`, \`test_skill_corpus.py\`).

\`just lint python\`: clean.

## Why this matters

The previous behavior made @uriva/safescript — a legitimate, well-structured skill — look \"Unsafe\" with hundreds of findings dominated by test-file noise. Security reports are only useful if reviewers can trust them. Real runtime \`fetch()\` calls in \`src/\` still fire at \`high\`, and \`undeclared_network\` still triggers for production code — so the signal is preserved, the noise is gone.