### PR TITLE
fix(turbo): include VITE_* env vars in build cache key

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "env": ["VITE_*", "NITRO_PRESET", "NODE_ENV"],
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", ".output/**", ".tanstack", ".vercel/output/**", "build/**"]
     },


### PR DESCRIPTION
## Summary

- Adds `env: ["VITE_*", "NITRO_PRESET", "NODE_ENV"]` to the `build` task in `turbo.json` so Turbo's remote cache key includes the Vite-public env vars.

## Why

PostHog analytics stopped firing on `www.tankpkg.dev` (and nightly). Investigation:

1. Code in `apps/registry/src/lib/analytics.ts` reads `import.meta.env.VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST`. Missing → early return → `posthog.init()` never called.
2. Envs on Vercel were named `NEXT_PUBLIC_POSTHOG_*` (leftover from the Next.js era). Vite ignores the `NEXT_PUBLIC_` prefix, so the values never made it into bundles.
3. After renaming the Vercel envs to `VITE_POSTHOG_*`, redeploys still produced the same bundle hash (`main-BZnmKyZJ.js`) — Turbo's remote cache was replaying a stale artifact.

Root cause: Turbo hashes source inputs but only the env vars it's told about. `turbo.json` was silent on `VITE_*`, so changing them on Vercel was invisible to the cache key → every deploy reused the pre-env-var build.

## Verification after merge

```bash
# Wait for Vercel deploy to finish, then:
curl -sS https://nightly.tankpkg.dev | grep -oE 'main-[^\"]+\.js'
# Hash should differ from main-BZnmKyZJ.js

curl -sS \"https://nightly.tankpkg.dev/assets/main-<NEW-HASH>.js\" | \
  grep -oE 'phc_[a-zA-Z0-9]+|t\.tankpkg\.dev'
# Should print the PostHog key and host
```

Then on the live site: accept cookies, confirm requests go to `t.tankpkg.dev/e/`, verify events in PostHog Live.

Once nightly is confirmed green, cherry-pick / merge to `stable` to restore prod.

## Bonus

Any future `VITE_*` change on Vercel (feature flags, public API URLs, etc.) now correctly invalidates Turbo's cache.