### PR TITLE
fix(registry): prompt2bot create-bot-api no longer returns secret

### DIFF
--- a/apps/registry/src/lib/prompt2bot.ts
+++ b/apps/registry/src/lib/prompt2bot.ts
@@ -24,7 +24,12 @@ export interface CreateSkillBotParams {
 
 export interface CreateSkillBotResult {
   botId: string;
-  secret: string;
+  /**
+   * Remote Tools secret. Only issued by prompt2bot when the bot is
+   * configured with custom tools that call back into our API. `null`
+   * for plain chat bots (our current usage).
+   */
+  secret: string | null;
   chatLink: string;
   botPublicKey: string | null;
 }
@@ -93,15 +98,20 @@ export async function createSkillBot(params: CreateSkillBotParams): Promise<Crea
       error?: string;
     };
 
-    if (!data.success || !data.botId || !data.secret || !data.chatLink) {
+    // Required fields: botId + chatLink. `secret` is only issued for bots
+    // with custom tools; we don't request any, so it is expected to be absent.
+    if (!data.success || !data.botId || !data.chatLink) {
+      const missing = [!data.success && 'success=false', !data.botId && 'botId', !data.chatLink && 'chatLink']
+        .filter(Boolean)
+        .join(',');
       // biome-ignore lint/suspicious/noConsole: intentional — server-side diagnostic for bot creation failures
-      console.error(`[prompt2bot] create-bot-api returned error:`, data.error ?? 'unknown');
+      console.error(`[prompt2bot] create-bot-api rejected: ${data.error ?? `missing=${missing}`}`);
       return null;
     }
 
     return {
       botId: data.botId,
-      secret: data.secret,
+      secret: data.secret ?? null,
       chatLink: data.chatLink,
       botPublicKey: data.aliceAndBotPublicId ?? null
     };


### PR DESCRIPTION
## Summary

- Fixes `POST /api/v1/skills/{name}/talk` returning 500 for every skill without a cached bot
- Root cause: prompt2bot's `create-bot-api` dropped the `secret` field from its response; our guard still required it
- Unblocks the "Talk to this skill" feature in production

## Evidence

Live probe against `https://api.prompt2bot.com/api` (2026-04-20):

```json
{
  "success": true,
  "botId": "…",
  "chatLink": "https://aliceandbot.com/chat?chatWith=…",
  "aliceAndBotPublicId": "…",
  "conversationsLink": "…",
  "viewChatGroupId": "…"
}
```

No `secret` field. Our guard in `prompt2bot.ts:96`:

```ts
if (!data.success || !data.botId || !data.secret || !data.chatLink) { … return null; }
```

…tripped on `!data.secret`, returned `null`, mapped to 500 in `talk.ts:124`, and logged the famously-useless `[prompt2bot] create-bot-api returned error: unknown` (since `data.error` was also undefined).

Vercel runtime logs on `dpl_5XA7dohm55YEVA4nSWPQnHq62cGx`:

```
[prompt2bot] create-bot-api returned error: unknown   ×8
```

Only skills with a pre-cached `prompt2botBotId` (created before the upstream contract change) kept working, which made the regression look environmental.

## Change

- `CreateSkillBotResult.secret`: `string` → `string | null`
- Guard now requires `botId` + `chatLink` only; `secret` is passed through optionally
- Error log now lists the actual missing fields (`missing=botId,chatLink` etc.) so the next upstream contract shift is debuggable from one log line
- `skill_versions.prompt2bot_secret` DB column is already nullable — no migration needed
- Kept `secret` plumbed through to DB write in `talk.ts` so Remote Tools support (per `idd/modules/talk-to-skill/INTENT.md`) stays available if prompt2bot re-introduces the field

## Verification

- `just typecheck` (pre-existing unrelated `@internal/bdd` errors — not touched)
- `bunx tsc --noEmit --project apps/registry/tsconfig.json` → clean
- `bunx biome check apps/registry/src/lib/prompt2bot.ts` → clean
- `lsp_diagnostics` on both touched files → no issues

## Post-merge prod check

```bash
curl -X POST https://www.tankpkg.dev/api/v1/skills/%40uriva%2Fsafescript/talk \
  -H 'Content-Length: 0' -w '\n%{http_code}\n'
# Expected: 200 with {chatLink, botPublicKey}
```

## Not included

- Mapping `invalid-api-token` → 503 (misconfigured) instead of 500: defer to a follow-up; the current log line is now informative enough to catch it
- Reaching out to prompt2bot to confirm whether `secret` removal is permanent vs regression: worth doing via Discord, but the code handles both outcomes