### PR TITLE
docs(talk-to-skill): codify prompt2bot secret-optional contract (IDD+BDD)

### DIFF
--- a/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
+++ b/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
@@ -51,7 +51,8 @@ Feature: Talk to this Skill
     When I visit the talk skill detail page
     Then the page source does not contain "prompt2botSecret"
 
-  @regression @gh-issue-post-0.14.2
+  @regression
+  @gh-issue-post-0.14.2
   Scenario: Talk API tolerates prompt2bot response without `secret` field
     # Regression guard for the 2026-04-20 prompt2bot contract change:
     # `secret` is only issued for bots with custom tools. Our bots have

--- a/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
+++ b/bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature
@@ -50,3 +50,14 @@ Feature: Talk to this Skill
   Scenario: Bot secret is never exposed in skill detail response
     When I visit the talk skill detail page
     Then the page source does not contain "prompt2botSecret"
+
+  @regression @gh-issue-post-0.14.2
+  Scenario: Talk API tolerates prompt2bot response without `secret` field
+    # Regression guard for the 2026-04-20 prompt2bot contract change:
+    # `secret` is only issued for bots with custom tools. Our bots have
+    # none, so the field is absent and that must not fail bot creation.
+    When I call the talk API for the skill
+    Then the talk API returns HTTP 200
+    And the talk API returns a chat link
+    And the talk API returns a bot public key
+    And the stored prompt2bot_secret is either null or a non-empty string

--- a/bdd/qa/findings/004-prompt2bot-missing-secret.md
+++ b/bdd/qa/findings/004-prompt2bot-missing-secret.md
@@ -1,0 +1,59 @@
+# Finding 004: Talk API 500s after prompt2bot dropped `secret` field
+
+**Date:** 2026-04-20
+**Feature:** talk-to-skill.feature — Scenario: Talk API endpoint creates a bot and returns chat link
+**Severity:** Bug (application code — upstream contract drift)
+
+## Symptom
+
+`POST /api/v1/skills/{name}/talk` returned HTTP 500 `{"error":"Failed to create bot"}` for every skill that did not already have a cached `prompt2bot_bot_id`. Skills published before the regression kept working because they hit the cached-bot short-circuit at `talk.ts:84`.
+
+Vercel runtime log (production, 2026-04-20):
+
+```
+error λ POST /api/v1/skills/%40uriva%2Fsafescript/talk
+[prompt2bot] create-bot-api returned error: unknown
+```
+
+## Root Cause
+
+The prompt2bot `create-bot-api` endpoint changed its response shape. The `secret` field (Remote Tools secret) is no longer issued unless the bot is configured with custom tools. Our bots have none, so `secret` was absent.
+
+`prompt2bot.ts:96` required `secret` in the guard:
+
+```ts
+if (!data.success || !data.botId || !data.secret || !data.chatLink) { … return null; }
+```
+
+The guard tripped on `!data.secret`, `createSkillBot()` returned `null`, and `talk.ts:124` mapped that to HTTP 500.
+
+The `'unknown'` log was a second defect — `data.error` was also absent (the upstream returned `success: true`), so the fallback `data.error ?? 'unknown'` evaluated to the literal string `'unknown'` and produced a useless log line that hid the actual failure mode for weeks.
+
+Live probe against `https://api.prompt2bot.com/api` (2026-04-20) confirmed the new response:
+
+```json
+{
+  "success": true,
+  "botId": "…",
+  "chatLink": "https://aliceandbot.com/chat?chatWith=…",
+  "aliceAndBotPublicId": "…",
+  "conversationsLink": "…",
+  "viewChatGroupId": "…"
+}
+```
+
+No `secret`. No `error`.
+
+## Why BDD didn't catch it
+
+`bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature` has a scenario ("Talk API endpoint creates a bot and returns chat link") whose assertions would have caught this regression. But `.github/workflows/ci.yml:105` excludes `@internal/bdd` from the CI test filter:
+
+```yaml
+run: bunx turbo run test --filter='!@internal/e2e' --filter='!@internal/bdd'
+```
+
+This is the Bulletproof rule-4 violation the methodology warns against: a BDD scenario exists but is not executed against real dependencies in CI. Running the BDD suite in CI (separate issue) would have surfaced this the day the upstream contract changed.
+
+## Resolution
+
+See: [resolution 004](../resolutions/004-prompt2bot-missing-secret.md)

--- a/bdd/qa/resolutions/004-prompt2bot-missing-secret.md
+++ b/bdd/qa/resolutions/004-prompt2bot-missing-secret.md
@@ -1,0 +1,71 @@
+# Resolution 004: Make `secret` optional in prompt2bot create-bot-api response
+
+**Finding:** [004](../findings/004-prompt2bot-missing-secret.md)
+**Date:** 2026-04-20
+**Files changed:**
+
+- `apps/registry/src/lib/prompt2bot.ts`
+- `idd/modules/talk-to-skill/INTENT.md`
+- `bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature`
+- `bdd/steps/browser/talk-to-skill.steps.ts`
+- `bdd/steps/browser/fixtures.ts`
+
+## Change
+
+### 1. `CreateSkillBotResult.secret` is now `string | null`
+
+```ts
+export interface CreateSkillBotResult {
+  botId: string;
+  /** Remote Tools secret. Only issued when bot has custom tools; `null` otherwise. */
+  secret: string | null;
+  chatLink: string;
+  botPublicKey: string | null;
+}
+```
+
+### 2. Guard requires `botId` + `chatLink` only
+
+```ts
+if (!data.success || !data.botId || !data.chatLink) {
+  const missing = [!data.success && "success=false", !data.botId && "botId", !data.chatLink && "chatLink"]
+    .filter(Boolean)
+    .join(",");
+  console.error(`[prompt2bot] create-bot-api rejected: ${data.error ?? `missing=${missing}`}`);
+  return null;
+}
+```
+
+The new log enumerates missing fields instead of the opaque `'unknown'`. Future upstream contract changes are now a one-line diagnosis.
+
+### 3. DB column already nullable
+
+`skill_versions.prompt2bot_secret` (`schema.ts:169`) was declared without `.notNull()` from day one. `result.secret ?? null` stores correctly. No migration needed.
+
+### 4. Intent + Gherkin
+
+- `INTENT.md` gained two rows under **Examples** covering the present (secret absent) and future (missing required field) behaviour, plus an **Upstream API tolerance** constraint block.
+- `talk-to-skill.feature` gained a `@regression` scenario asserting HTTP 200 + stored `prompt2bot_secret` is either null or non-empty.
+- `talk-to-skill.steps.ts` gained `the talk API returns HTTP {int}` and `the stored prompt2bot_secret is either null or a non-empty string` step definitions.
+- `fixtures.ts:BddState` gained `lastResponseStatus?: number`.
+
+## Verification
+
+Real-system verification against the prompt2bot upstream + Vercel preview deployment (`safe-skills-directory-my4in81ik…vercel.app`, PR #414 preview):
+
+| Skill               | Before                     | After                                    |
+| ------------------- | -------------------------- | ---------------------------------------- |
+| `@uriva/safescript` | 500 `Failed to create bot` | **200** with `chatLink` + `botPublicKey` |
+| `@tank/react`       | 500                        | **200**                                  |
+| `@tank/nextjs`      | 500                        | **200**                                  |
+
+Direct probe of the upstream with a live token returned `success:true, botId, chatLink, aliceAndBotPublicId` (no `secret`). Fix handles it.
+
+- `bunx tsc --noEmit --project apps/registry/tsconfig.json` → clean
+- `bun run --filter '@internal/bdd' typecheck` → clean
+- `bunx biome check apps/registry/src/lib/prompt2bot.ts` → clean
+
+## Follow-up work
+
+- **CI gap:** `@internal/bdd` is excluded from CI (`ci.yml:105`). The new regression scenario is future-proofing but does not actively guard until BDD is wired into CI or a dedicated scheduled job. Tracking separately is worthwhile.
+- **Rotation telemetry:** If prompt2bot rotates `invalid-api-token` again, the new log (`create-bot-api rejected: invalid-api-token`) will surface in Vercel logs but still only after a user-visible 500. A Sentry breadcrumb or similar alerting would close this loop.

--- a/bdd/steps/browser/fixtures.ts
+++ b/bdd/steps/browser/fixtures.ts
@@ -23,6 +23,7 @@ export interface BddState {
   lastResult?: CliResult;
   lastResponse?: Response;
   lastResponseBody?: Record<string, unknown>;
+  lastResponseStatus?: number;
   lastActor?: string;
   skill?: SkillFixture;
   skillName?: string;

--- a/bdd/steps/browser/talk-to-skill.steps.ts
+++ b/bdd/steps/browser/talk-to-skill.steps.ts
@@ -107,7 +107,27 @@ When('I call the talk API for the skill', async ({ e2eContext, bddState }) => {
   const res = await fetch(`${e2eContext.registry}/api/v1/skills/${encoded}/talk`, { method: 'POST' });
   const body = (await res.json()) as Record<string, unknown>;
   bddState.lastResponseBody = body;
+  bddState.lastResponseStatus = res.status;
   cachedChatLink = body.chatLink as string;
+});
+
+Then('the talk API returns HTTP {int}', async ({ bddState }, status: number) => {
+  expect(bddState.lastResponseStatus).toBe(status);
+});
+
+Then('the stored prompt2bot_secret is either null or a non-empty string', async ({ e2eContext }) => {
+  if (!talkSkillName) throw new Error('No skill name resolved');
+  const rows = await e2eContext.sql`
+    SELECT sv.prompt2bot_secret AS secret
+    FROM skill_versions sv
+    JOIN skills s ON s.id = sv.skill_id
+    WHERE s.name = ${talkSkillName}
+    ORDER BY sv.created_at DESC
+    LIMIT 1
+  `;
+  expect(rows.length).toBeGreaterThan(0);
+  const secret = rows[0].secret as string | null;
+  expect(secret === null || (typeof secret === 'string' && secret.length > 0)).toBe(true);
 });
 
 Then('the talk API returns a chat link', async ({ bddState }) => {

--- a/idd/modules/talk-to-skill/INTENT.md
+++ b/idd/modules/talk-to-skill/INTENT.md
@@ -30,6 +30,12 @@ Embedded AI chat on every skill detail page. Users can ask questions about a ski
 - `prompt2botSecret` (Remote Tools Secret) stored in DB but NEVER included in any client-facing query result or API response
 - Only `chatLink` and `botPublicKey` are exposed to the browser
 
+### Upstream API tolerance
+
+- `createSkillBot()` requires only `botId` + `chatLink` from the prompt2bot response
+- `secret` is optional: only issued for bots with custom tools. Our current usage has none, so the field is expected to be absent. Stored as `NULL` when missing.
+- On upstream failure, the error log MUST enumerate the specific missing/falsy fields — never log a generic "unknown" reason
+
 ### Attribution
 
 - "Powered by prompt2bot · alice&bot" visible whenever the chat widget is open
@@ -55,3 +61,5 @@ Embedded AI chat on every skill detail page. Users can ask questions about a ski
 | Bot creation API fails                                   | Error shown to user; skill page continues to work normally              |
 | Attacker inspects network responses                      | `prompt2botSecret` never appears in any response body                   |
 | First-time anonymous visitor opens chat                  | Alice&Bot credentials are pre-seeded and no display-name dialog appears |
+| prompt2bot response omits `secret`                       | Bot creation succeeds; DB row has `prompt2bot_secret = NULL`            |
+| prompt2bot response omits `botId` or `chatLink`          | Bot creation fails; log lists the specific missing fields               |


### PR DESCRIPTION
## Summary

Companion to #414 — applies the Bulletproof methodology retroactively to the prompt2bot `create-bot-api` regression that was shipped first and documented second. Captures the intent, codifies the regression guard, and writes the paper trail so the next upstream contract change trips a CI line rather than a production 500.

## Artifacts

- `idd/modules/talk-to-skill/INTENT.md` — new **Upstream API tolerance** constraint block + two **Examples** rows for the present behaviour (response omits `secret`) and the red-line behaviour (response omits `botId` or `chatLink`)
- `bdd/features/browser/tanstack/talk-to-skill/talk-to-skill.feature` — new `@regression` scenario asserting HTTP 200 + stored `prompt2bot_secret` is either `NULL` or non-empty when the upstream omits `secret`
- `bdd/steps/browser/talk-to-skill.steps.ts` — new step definitions for HTTP-status assertion + DB-row invariant check
- `bdd/steps/browser/fixtures.ts` — `lastResponseStatus?: number` on `BddState`
- `bdd/qa/findings/004-prompt2bot-missing-secret.md` — full root-cause writeup
- `bdd/qa/resolutions/004-prompt2bot-missing-secret.md` — fix documentation linking back to #414

## Known follow-up (called out in the finding)

`.github/workflows/ci.yml:105` excludes `@internal/bdd` from CI:

```yaml
run: bunx turbo run test --filter='!@internal/e2e' --filter='!@internal/bdd'
```

The new regression scenario is future-proofing rather than an active guard until BDD is wired into a CI job or scheduled run. This is tracked in the finding + resolution — not something to fix in this PR, but worth a separate ticket.

## Verification

- `bun run --filter '@internal/bdd' typecheck` → clean
- LSP diagnostics clean on all touched files
- No application code changes — pure intent + test + docs