### PR TITLE
chore: update Homebrew formula for v0.14.3

### DIFF
--- a/Formula/tank.rb
+++ b/Formula/tank.rb
@@ -1,19 +1,19 @@
 class Tank < Formula
   desc "Security-first package manager for AI agent skills"
   homepage "https://tankpkg.dev"
-  version "0.14.2"
+  version "0.14.3"
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-arm64.tar.gz"
-    sha256 "176d6a6f122c7881874e4c5ab4c53002296ebd6a405ba984737d12d7fd29a271"
+    sha256 "81e7332f32b7f1ba56d3782d8284b84248520fed36ee554293709e7a147d2826"
   elsif OS.mac?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-x64.tar.gz"
-    sha256 "9c26dfc0e36bfa635570207a50b41bfbaaba0ade991590051c0e4969fa3b5a08"
+    sha256 "60f4e56021c9fa2e7eb3967d3b25c0c944e5a909c3d30a636f8068cfbc752042"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-arm64.tar.gz"
-    sha256 "37e8ba45f676047fe1556be9e55d4a390afae6952947f3312380e269cb10bbf2"
+    sha256 "655f935d6d10c3a6e4cede13ee3b15f3a49bbab27aaa9030c8424f6848d8aa6a"
   else
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-x64.tar.gz"
-    sha256 "85336ab60250fa4d9c5ef9f8c41b97400147c1e7af20766a06b951b6b4ebe629"
+    sha256 "8374215c5da937173886bea7349325749b70fd44a8b7eebeff06de8c6d7358fd"
   end
   def install
     bin.install Dir["tank-*"].first => "tank"


### PR DESCRIPTION
Auto-generated by release pipeline (PR creation step failed in CI due to bot permissions — this is the manual follow-up matching #409 / #412 pattern).