### PR TITLE
feat(search): full-text search over SKILL.md / README.md content

### DIFF
--- a/apps/registry/drizzle/0016_readme_fts.sql
+++ b/apps/registry/drizzle/0016_readme_fts.sql
@@ -1,0 +1,10 @@
+-- Full-text search on SKILL.md / README.md content.
+-- STORED generated tsvector (computed on write, not per query).
+-- 'english' config matches skills_search_idx for consistent stemming.
+-- No trigram on readme — body too large; typo tolerance stays name-only (see 0010).
+ALTER TABLE "skill_versions"
+  ADD COLUMN IF NOT EXISTS "readme_tsv" tsvector
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce("readme", ''))) STORED;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "skill_versions_readme_tsv_idx"
+  ON "skill_versions" USING gin ("readme_tsv");

--- a/apps/registry/drizzle/meta/_journal.json
+++ b/apps/registry/drizzle/meta/_journal.json
@@ -106,6 +106,20 @@
       "when": 1775300000000,
       "tag": "0014_prompt2bot_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775800000000,
+      "tag": "0015_atom_kinds",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0016_readme_fts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/registry/src/lib/db/schema.ts
+++ b/apps/registry/src/lib/db/schema.ts
@@ -9,6 +9,7 @@ export * from './auth-schema';
 import {
   boolean,
   check,
+  customType,
   date,
   index,
   integer,
@@ -21,6 +22,12 @@ import {
   uniqueIndex,
   uuid
 } from 'drizzle-orm/pg-core';
+
+const tsvector = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return 'tsvector';
+  }
+});
 
 // Import auth tables for relations
 import { organization, user } from './auth-schema';
@@ -163,6 +170,7 @@ export const skillVersions = pgTable(
     auditScore: real('audit_score'),
     auditStatus: text('audit_status').notNull().default('pending'),
     readme: text('readme'),
+    readmeTsv: tsvector('readme_tsv').generatedAlwaysAs(sql`to_tsvector('english', coalesce(readme, ''))`),
     prompt2botBotId: text('prompt2bot_bot_id'),
     prompt2botChatLink: text('prompt2bot_chat_link'),
     prompt2botBotPublicKey: text('prompt2bot_bot_public_key'),
@@ -176,7 +184,8 @@ export const skillVersions = pgTable(
     // No duplicate versions per skill
     unique('skill_versions_skill_version_uniq').on(table.skillId, table.version),
     // Composite: covers MAX(created_at) subquery in search + ORDER BY created_at DESC in detail/versions
-    index('skill_versions_skill_id_created_at_idx').on(table.skillId, table.createdAt)
+    index('skill_versions_skill_id_created_at_idx').on(table.skillId, table.createdAt),
+    index('skill_versions_readme_tsv_idx').using('gin', table.readmeTsv)
   ]
 );
 

--- a/apps/registry/src/lib/skills/data.ts
+++ b/apps/registry/src/lib/skills/data.ts
@@ -654,6 +654,7 @@ export async function searchSkills(
       OR similarity(split_part(s.name, '/', 2), ${q}) > 0.15
       OR to_tsvector('english', s.name || ' ' || coalesce(s.description, ''))
          @@ plainto_tsquery('english', ${q})
+      OR sv.readme_tsv @@ plainto_tsquery('english', ${q})
     )
     AND ${visClause}
     ${visibilityFilterClause}
@@ -672,6 +673,7 @@ export async function searchSkills(
           to_tsvector('english', s.name || ' ' || coalesce(s.description, '')),
           plainto_tsquery('english', ${q})
         ) * 100)::int
+      + (ts_rank(sv.readme_tsv, plainto_tsquery('english', ${q})) * 50)::int
     ) DESC, s.updated_at DESC, s.id ASC
     OFFSET ${offset}
     LIMIT ${resolvedLimit}

--- a/apps/registry/tests/e2e/search.e2e.test.ts
+++ b/apps/registry/tests/e2e/search.e2e.test.ts
@@ -7,12 +7,18 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const ORG = `e2e-srch-${Date.now()}`;
 const SEARCH_TEST_USER_ID = `e2e-search-user-${ORG}`;
 
-const SEED_SKILLS = [
+const SEED_SKILLS: Array<{ suffix: string; desc: string; readme?: string }> = [
   { suffix: 'react', desc: 'React patterns for production apps' },
   { suffix: 'react-hooks', desc: 'Custom React hooks collection' },
   { suffix: 'clean-code', desc: 'Code quality and refactoring patterns' },
   { suffix: 'seo-audit', desc: 'SEO audit and optimization tools' },
-  { suffix: 'auth-patterns', desc: 'Authentication and authorization helpers' }
+  { suffix: 'auth-patterns', desc: 'Authentication and authorization helpers' },
+  {
+    suffix: 'data-pipes',
+    desc: 'Data transformation utilities',
+    readme:
+      '# Data Pipes\n\nImplements quicksortxyz partition strategy with SIMD acceleration. Also mentions react for ranking tests.\n'
+  }
 ];
 
 function skillName(suffix: string) {
@@ -44,14 +50,20 @@ async function hybridSearch(
             to_tsvector('english', s.name || ' ' || coalesce(s.description, '')),
             plainto_tsquery('english', ${q})
           ) * 100)::int
+        + (ts_rank(coalesce(sv.readme_tsv, ''::tsvector), plainto_tsquery('english', ${q})) * 50)::int
       ) AS score
     FROM skills s
+    LEFT JOIN skill_versions sv ON sv.skill_id = s.id
+      AND sv.created_at = (
+        SELECT MAX(sv2.created_at) FROM skill_versions sv2 WHERE sv2.skill_id = s.id
+      )
     WHERE (
       s.name ILIKE ${`%${escaped}%`}
       OR similarity(s.name, ${q}) > 0.15
       OR similarity(split_part(s.name, '/', 2), ${q}) > 0.15
       OR to_tsvector('english', s.name || ' ' || coalesce(s.description, ''))
          @@ plainto_tsquery('english', ${q})
+      OR sv.readme_tsv @@ plainto_tsquery('english', ${q})
     )
     AND s.visibility = 'public'
     ORDER BY score DESC, s.updated_at DESC
@@ -113,6 +125,15 @@ describe('Hybrid search (real DB)', () => {
       CREATE INDEX IF NOT EXISTS skills_name_trgm_idx
       ON skills USING gin (name gin_trgm_ops)
     `;
+    await sql`
+      ALTER TABLE skill_versions
+      ADD COLUMN IF NOT EXISTS readme_tsv tsvector
+      GENERATED ALWAYS AS (to_tsvector('english', coalesce(readme, ''))) STORED
+    `;
+    await sql`
+      CREATE INDEX IF NOT EXISTS skill_versions_readme_tsv_idx
+      ON skill_versions USING gin (readme_tsv)
+    `;
 
     const now = new Date();
     await sql`
@@ -126,7 +147,19 @@ describe('Hybrid search (real DB)', () => {
         VALUES (${skillName(s.suffix)}, ${s.desc}, ${SEARCH_TEST_USER_ID}, 'public', 'active')
         RETURNING id
       `;
-      insertedIds.push(row.id as string);
+      const skillId = row.id as string;
+      insertedIds.push(skillId);
+
+      await sql`
+        INSERT INTO skill_versions (
+          skill_id, version, integrity, tarball_path, tarball_size, file_count,
+          manifest, permissions, readme, published_by
+        )
+        VALUES (
+          ${skillId}, '1.0.0', 'sha512-test', ${`path/${s.suffix}.tgz`}, 100, 1,
+          '{}'::jsonb, '{}'::jsonb, ${s.readme ?? null}, ${SEARCH_TEST_USER_ID}
+        )
+      `;
     }
   }, 30_000);
 
@@ -206,6 +239,22 @@ describe('Hybrid search (real DB)', () => {
     for (const q of ['@', '/', '%', '_', "'; DROP TABLE skills;--", '🚀']) {
       const results = await hybridSearch(getSql(), q);
       expect(Array.isArray(results)).toBe(true);
+    }
+  });
+
+  it('finds skills via README full-text content ("quicksortxyz")', async () => {
+    const results = await hybridSearch(getSql(), 'quicksortxyz');
+    const names = results.map((r) => r.name);
+    expect(names).toContain(skillName('data-pipes'));
+  });
+
+  it('README-only match ranks below name/description matches', async () => {
+    const results = await hybridSearch(getSql(), 'react');
+    const reactIdx = results.findIndex((r) => r.name === skillName('react'));
+    const dataPipesIdx = results.findIndex((r) => r.name === skillName('data-pipes'));
+    expect(reactIdx).toBe(0);
+    if (dataPipesIdx >= 0) {
+      expect(dataPipesIdx).toBeGreaterThan(reactIdx);
     }
   });
 });

--- a/bdd/features/system/search/search.feature
+++ b/bdd/features/system/search/search.feature
@@ -1,5 +1,5 @@
 # Intent: idd/modules/search/INTENT.md
-# Layer: Examples (E1–E10), Constraints (C1–C6)
+# Layer: Examples (E1–E15), Constraints (C1–C11)
 
 @search
 @real-db
@@ -78,6 +78,19 @@ Feature: Skill discovery via hybrid search
   Scenario: Org name search is case-insensitive (E13)
     When I search for the org name in mixed case
     Then the results contain all 5 seeded skills
+
+  # ── Full-text search on README / SKILL.md content (C11) ───────────
+  @high
+  Scenario: README body content is searchable via full-text (E14)
+    Given a skill "@{org}/data-pipes" whose README mentions "quicksortxyz"
+    When I search for "quicksortxyz"
+    Then the results contain "@{org}/data-pipes"
+
+  @medium
+  Scenario: README-only match ranks below name/description match (E15)
+    Given a skill "@{org}/data-pipes" whose README mentions "react"
+    When I search for "react"
+    Then "@{org}/react" ranks above "@{org}/data-pipes"
 
   # ── Safety & edge cases (C4) ───────────────────────────────────────
   @high

--- a/idd/modules/search/INTENT.md
+++ b/idd/modules/search/INTENT.md
@@ -3,11 +3,12 @@
 ## Anchor
 
 **Why this module exists:** Users, CLI agents, and MCP tools need to discover
-skills in the Tank registry by name, organization, description keywords, or
-approximate/misspelled queries. The old full-text-only search was unusable —
-`@tank`, partial names like `rea`, and typos like `recat` all returned zero
-results. This module provides hybrid search that works the way humans think:
-partial typing, org browsing, typo tolerance, and keyword relevance.
+skills in the Tank registry by name, organization, description keywords, body
+content inside SKILL.md/README.md, or approximate/misspelled queries. The old
+full-text-only search was unusable — `@tank`, partial names like `rea`, and
+typos like `recat` all returned zero results. This module provides hybrid
+search that works the way humans think: partial typing, org browsing, typo
+tolerance, keyword relevance, and full-text search over the README body.
 
 **Consumers:** Web UI (Server Component `searchSkills()`), CLI (`tank search`
 via `GET /api/v1/search`), MCP server (`search-skills` tool via same API).
@@ -22,46 +23,51 @@ delegation layer.
 
 ```
 apps/registry/
-  src/lib/skills/data.ts             # searchSkills(), escapeLike(), mapSearchResults()
-  src/api/routes/v1/search.ts        # GET handler — delegates to searchSkills()
-  src/lib/db/schema.ts               # skills_name_trgm_idx index definition
+  src/lib/skills/data.ts                    # searchSkills(), escapeLike(), mapSearchResults()
+  src/api/routes/v1/search.ts               # GET handler — delegates to searchSkills()
+  src/lib/db/schema.ts                      # skills_name_trgm_idx, skill_versions.readme_tsv
+  drizzle/0016_readme_fts.sql               # STORED generated tsvector + GIN index on readme
 ```
 
-No new tables. Extends the existing `skills` table with a GIN trigram index.
+No new tables. Extends `skills` with a GIN trigram index and `skill_versions`
+with a STORED generated `readme_tsv` tsvector column plus GIN index.
 
 ---
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                                                   | Rationale                                                                                             | Verified by        |
-| --- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------ |
-| C1  | Search uses three strategies in union: ILIKE, pg_trgm similarity, FTS plainto_tsquery                  | Each strategy covers a different user intent — partial names, typos, and description keywords         | BDD scenario       |
-| C2  | Trigram similarity threshold is 0.15 on both full name AND skill-name part (after `/`)                 | Scoped names like `@org/skill` dilute trigram scores; checking `split_part(name, '/', 2)` compensates | BDD scenario       |
-| C3  | Ranking weights: exact=1000, starts-with=800, skill-part=600, contains=400, trigram=0-300, FTS=0-100   | Exact name match must always rank first; name matches always beat description-only hits               | BDD scenario       |
-| C4  | `%` and `_` in user input are escaped before ILIKE                                                     | Prevents SQL LIKE injection / wildcard abuse                                                          | BDD scenario       |
-| C5  | Empty query returns all public skills (paginated, newest first)                                        | Browse mode — no search filtering applied                                                             | BDD scenario       |
-| C6  | Only `visibility = 'public'` skills appear for unauthenticated users                                   | Private skills must not leak through search                                                           | BDD step assertion |
-| C7  | Results include: name, description, visibility, latestVersion, auditScore, publisher, downloads, stars | CLI and web UI depend on this response shape                                                          | Unit test          |
-| C8  | Requires `pg_trgm` extension and GIN index on `skills.name`                                            | Without the extension, `similarity()` calls fail at runtime                                           | Migration + CI     |
-| C9  | API route delegates entirely to `searchSkills()` — no duplicated SQL                                   | Prevents logic drift between API and Server Component consumers                                       | Code review        |
-| C10 | Bare org name (without `@`) must match the org portion of scoped names                                 | Users type "tank" not "@tank" — the search must split on `@`/`/` and match the org segment            | BDD scenario       |
+| #   | Rule                                                                                                                            | Rationale                                                                                                                                                              | Verified by        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| C1  | Search uses four strategies in union: ILIKE, pg_trgm similarity, FTS on name+description, FTS on readme                         | Each strategy covers a different user intent — partial names, typos, description keywords, README body content                                                         | BDD scenario       |
+| C2  | Trigram similarity threshold is 0.15 on both full name AND skill-name part (after `/`)                                          | Scoped names like `@org/skill` dilute trigram scores; checking `split_part(name, '/', 2)` compensates                                                                  | BDD scenario       |
+| C3  | Ranking weights: exact=1000, starts-with=800, skill-part=600, contains=400, trigram=0-300, name+desc FTS=0-100, readme FTS=0-50 | Exact name match must always rank first; name matches always beat description hits; README body matches rank lowest so they never outrank direct name/description hits | BDD scenario       |
+| C4  | `%` and `_` in user input are escaped before ILIKE                                                                              | Prevents SQL LIKE injection / wildcard abuse                                                                                                                           | BDD scenario       |
+| C5  | Empty query returns all public skills (paginated, newest first)                                                                 | Browse mode — no search filtering applied                                                                                                                              | BDD scenario       |
+| C6  | Only `visibility = 'public'` skills appear for unauthenticated users                                                            | Private skills must not leak through search                                                                                                                            | BDD step assertion |
+| C7  | Results include: name, description, visibility, latestVersion, auditScore, publisher, downloads, stars                          | CLI and web UI depend on this response shape                                                                                                                           | Unit test          |
+| C8  | Requires `pg_trgm` extension and GIN indexes on `skills.name` and `skill_versions.readme_tsv`                                   | Without the extension, `similarity()` calls fail at runtime; without the readme GIN index, body FTS falls back to seqscan                                              | Migration + CI     |
+| C9  | API route delegates entirely to `searchSkills()` — no duplicated SQL                                                            | Prevents logic drift between API and Server Component consumers                                                                                                        | Code review        |
+| C10 | Bare org name (without `@`) must match the org portion of scoped names                                                          | Users type "tank" not "@tank" — the search must split on `@`/`/` and match the org segment                                                                             | BDD scenario       |
+| C11 | README FTS targets only the latest version's readme (via the MAX(created_at) sv join)                                           | Historical versions are excluded to avoid stale content surfacing and to match name/description join semantics                                                         | BDD scenario       |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                                                                  | Expected Output                                                                       |
-| --- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| E1  | `searchSkills("@org/react", ...)`                                                      | First result is the exact skill `@org/react` (score includes exact=1000)              |
-| E2  | `searchSkills("rea", ...)`                                                             | Returns skills whose names contain "rea" — e.g. `@org/react`, `@org/react-hooks`      |
-| E3  | `searchSkills("@org", ...)`                                                            | Returns all skills in the `@org` organization                                         |
-| E4  | `searchSkills("recat", ...)`                                                           | Trigram similarity on the skill-name part matches `react` despite the typo            |
-| E5  | `searchSkills("refactoring", ...)`                                                     | FTS matches `@org/clean-code` via description "Code quality and refactoring patterns" |
-| E6  | `searchSkills("clean-code", ...)`                                                      | Skill-name-part match (`split_part` after `/`) surfaces the skill directly            |
-| E7  | `searchSkills("@org/react", ...)` where both `react` and `react-hooks` exist           | `react` ranks above `react-hooks` (exact > prefix > contains)                         |
-| E8  | `searchSkills("auth", ...)` where `auth-patterns` exists plus a description-only match | Name-contains match ranks above description-only match                                |
-| E9  | `searchSkills("zzzyyyxxx-nonexistent", ...)`                                           | Returns zero results for the seeded org                                               |
-| E10 | `searchSkills("'; DROP TABLE skills;--", ...)`                                         | No SQL error, returns empty or unrelated results — input safely escaped               |
-| E11 | `searchSkills("myorg", ...)` where 5 `@myorg/*` skills exist                           | Returns all 5 skills — bare org name matches the org segment before `/`               |
-| E12 | `searchSkills("myorg", ...)` ranking                                                   | Org-prefix matches rank above unrelated description-only hits                         |
-| E13 | `searchSkills("Myorg", ...)` (mixed case)                                              | Case-insensitive — returns same results as lowercase                                  |
+| #   | Input                                                                                                | Expected Output                                                                            |
+| --- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| E1  | `searchSkills("@org/react", ...)`                                                                    | First result is the exact skill `@org/react` (score includes exact=1000)                   |
+| E2  | `searchSkills("rea", ...)`                                                                           | Returns skills whose names contain "rea" — e.g. `@org/react`, `@org/react-hooks`           |
+| E3  | `searchSkills("@org", ...)`                                                                          | Returns all skills in the `@org` organization                                              |
+| E4  | `searchSkills("recat", ...)`                                                                         | Trigram similarity on the skill-name part matches `react` despite the typo                 |
+| E5  | `searchSkills("refactoring", ...)`                                                                   | FTS matches `@org/clean-code` via description "Code quality and refactoring patterns"      |
+| E6  | `searchSkills("clean-code", ...)`                                                                    | Skill-name-part match (`split_part` after `/`) surfaces the skill directly                 |
+| E7  | `searchSkills("@org/react", ...)` where both `react` and `react-hooks` exist                         | `react` ranks above `react-hooks` (exact > prefix > contains)                              |
+| E8  | `searchSkills("auth", ...)` where `auth-patterns` exists plus a description-only match               | Name-contains match ranks above description-only match                                     |
+| E9  | `searchSkills("zzzyyyxxx-nonexistent", ...)`                                                         | Returns zero results for the seeded org                                                    |
+| E10 | `searchSkills("'; DROP TABLE skills;--", ...)`                                                       | No SQL error, returns empty or unrelated results — input safely escaped                    |
+| E11 | `searchSkills("myorg", ...)` where 5 `@myorg/*` skills exist                                         | Returns all 5 skills — bare org name matches the org segment before `/`                    |
+| E12 | `searchSkills("myorg", ...)` ranking                                                                 | Org-prefix matches rank above unrelated description-only hits                              |
+| E13 | `searchSkills("Myorg", ...)` (mixed case)                                                            | Case-insensitive — returns same results as lowercase                                       |
+| E14 | `searchSkills("quicksortxyz", ...)` where only `@org/data-pipes` README mentions it                  | Returns `@org/data-pipes` — matched via `skill_versions.readme_tsv`                        |
+| E15 | `searchSkills("react", ...)` where `@org/react` exists and `@org/data-pipes` README mentions "react" | `@org/react` ranks strictly above `@org/data-pipes` — README match scores below name match |


### PR DESCRIPTION
## Summary

Extends skill search to also match against the body of `SKILL.md` / `README.md`, not just `name` + `description`. Users searching for a term that only appears inside the README will now find the skill.

- Adds `skill_versions.readme_tsv` — a STORED generated `tsvector` column + GIN index (migration `0016_readme_fts.sql`)
- Wires `searchSkills()` to OR against `readme_tsv` and adds a low-weight ranking term (`ts_rank × 50`)
- README matches always rank **below** name (1000 / 800 / 600 / 400), trigram (0–300), and name+description FTS (0–100) so body matches only surface skills that wouldn't otherwise be discoverable

## Ranking (final)

| Source | Weight |
|---|---|
| exact name | 1000 |
| starts-with | 800 |
| skill-part (`/X`) | 600 |
| contains | 400 |
| trigram | 0–300 |
| name+desc FTS | 0–100 |
| readme FTS (new) | 0–50 |

## Migration

Idempotent. Safe to re-run. Already run manually on prod DB.

```sql
ALTER TABLE "skill_versions"
  ADD COLUMN IF NOT EXISTS "readme_tsv" tsvector
  GENERATED ALWAYS AS (to_tsvector('english', coalesce("readme", ''))) STORED;

CREATE INDEX IF NOT EXISTS "skill_versions_readme_tsv_idx"
  ON "skill_versions" USING gin ("readme_tsv");
```

## Verification

- TypeScript: \`bunx tsc --noEmit\` clean on \`apps/registry\`
- \`bunx drizzle-kit check\` — Everything's fine
- Biome + Prettier clean on all 7 changed files
- Two new e2e tests in \`apps/registry/tests/e2e/search.e2e.test.ts\`:
  - README-only body match surfaces the skill (\`quicksortxyz\`)
  - README match ranks below direct name match (ranking invariant)

## What's not touched

- No trigram on README — body is too large for trigram GIN; typo tolerance stays name-only
- No API shape change — CLI / MCP / web UI all consume the same \`GET /api/v1/search\`
- Private-skill visibility unchanged