### PR TITLE
fix(db): use transaction-mode pooler for postgres-js compat

### DIFF
--- a/apps/registry/src/lib/db/index.ts
+++ b/apps/registry/src/lib/db/index.ts
@@ -10,7 +10,10 @@ function ensureInitialized() {
   if (_db) return;
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error('DATABASE_URL is not configured. Complete the setup wizard first.');
-  _sql = postgres(url, { max: 1 });
+  // DATABASE_URL must use the Supabase pooler in transaction mode (port 6543).
+  // `prepare: false` is required — PgBouncer transaction mode does not support
+  // prepared statements (postgres-js uses them by default).
+  _sql = postgres(url, { max: 1, prepare: false });
   _db = drizzle(_sql, { schema });
 }
 


### PR DESCRIPTION
## Summary

Intermittent **HTTP 500** on every DB-touching endpoint (`/api/v1/skills/.../files`, `/api/v1/search`, etc.) under cold-start bursts on Vercel.

**Root cause:** Supabase pooler in **session mode** (port 5432) caps at `pool_size: 15`. Each Vercel cold-start instance opens 1 session-mode client which is held for the entire session lifetime. Concurrent cold starts (e.g., bursts of CLI installs) blow past 15 → pooler returns:

```
PostgresError: (EMAXCONNSESSION) max clients reached in session mode
                - max clients are limited to pool_size: 15
                code: 'XX000', severity_local: 'FATAL'
```

## Evidence (Vercel runtime logs, prod)

Same `XX000 EMAXCONNSESSION` across multiple endpoints in a 1h window:

| Time (UTC) | Endpoint | Skill |
|---|---|---|
| 14:41:22 (×3) | `/api/v1/skills/:name/:version/files` | `@tank/github-issues@0.1.0`, `@tank/skill-creator@2.0.0` |
| 15:57:24-27 (×8) | `/files` and `/files/:path` | `@tank/local-llm-fit`, `@tank/tank-project-setup`, `@tank/llm-app-patterns` |
| 18:58:27 (×3) | `/api/v1/search` | (unrelated query — same root cause) |

All cold-started, all `1.5s+` duration, all returning `XX000 FATAL` from the pooler before any user code ran beyond the first DB query.

## Fix (this PR)

Single line + 3-line comment in `apps/registry/src/lib/db/index.ts`:

\`\`\`diff
-  _sql = postgres(url, { max: 1 });
+  // DATABASE_URL must use the Supabase pooler in transaction mode (port 6543).
+  // \`prepare: false\` is required — PgBouncer transaction mode does not support
+  // prepared statements (postgres-js uses them by default).
+  _sql = postgres(url, { max: 1, prepare: false });
\`\`\`

## ⚠️ Required Vercel env-var change (BEFORE merging)

This PR alone is **not** sufficient. The runtime fix needs both:

1. ✅ This code change (sets \`prepare: false\`)
2. ⏳ **Flip \`DATABASE_URL\` from port 5432 → 6543** in Vercel:
   - Production env: \`safe-skills-directory\` project → Settings → Environment Variables → \`DATABASE_URL\` → change \`:5432/postgres\` → \`:6543/postgres\`
   - Same for nightly env

Without (2): code keeps hitting session mode → bug persists.
Without (1): code hits transaction mode but prepared statements break → silent query failures.

**Recommended deploy order:** merge this PR → wait for Vercel deploy to finish → flip env var → redeploy. Or update env var first, deploy this PR, redeploy. Either way both must land before the system is healthy.

## Why \`prepare: false\`?

PgBouncer transaction mode reuses one server connection for many client statements, releasing it back to the pool after each statement. Prepared statements depend on session-scoped state (the \`PREPARE name AS ...\` only persists for that connection), which transaction mode breaks. \`postgres-js\` enables prepared statements by default; setting \`prepare: false\` makes it use simple-query mode that's compatible with transaction-mode pooling.

## Verification

- \`bunx --bun tsc --noEmit\` on \`apps/registry\` → clean (after \`bun run scripts/build-docs.ts\` to populate \`src/generated/docs.json\`)
- \`bun run lint:readonly\` → clean
- \`bun run format:readonly\` → clean
- Pre-push hook → all 3 checks pass (\`✓ lint passed\`, \`✓ format passed\`, \`✓ typecheck passed\`)
- Endpoint reproduction (post-warm): \`curl https://www.tankpkg.dev/api/v1/skills/%40tank%2Fgithub-issues/0.1.0/files\` → 200 OK with valid file list

## What this PR does NOT change

- \`max: 1\` — kept (one connection per serverless instance is correct)
- \`tar-stream\`, gunzip, S3 storage — all fine; were red herrings during early diagnosis
- Other DB-touching code — no changes needed; the fix at the connection layer benefits every consumer

## Side observation (out of scope)

\`@tank/git-worktrees\`-style ctx workspace for tankpkg has a stale Vercel token (expired ~10 days ago). Worth filing as a separate ctx bug: token-refresh isn't propagating into \`~/.config/ctx/store/tankpkg/vercel/auth.json\`.