### PR TITLE
fix(auth): skip email verification when no email backend is configured

### DIFF
--- a/apps/registry/src/lib/auth/core.ts
+++ b/apps/registry/src/lib/auth/core.ts
@@ -10,6 +10,20 @@ import { getFromAddress, getProvider, sendEmail } from '~/services/email/service
 
 function createAuth() {
   const isSelfHosted = process.env.TANK_MODE === 'selfhosted';
+  const emailBackendConfigured = !!process.env.RESEND_API_KEY || !!process.env.SMTP_HOST;
+  const credentialsEnabled = enabledProviders.has('credentials');
+  // Email verification only meaningful when there's a real backend to send from.
+  // Without one, sendEmail's `console` provider returns success without sending,
+  // leaving the user permanently unverified. Auto-verify in that case (matches
+  // self-hosted behavior) and warn loudly so ops can fix the misconfig.
+  const requireEmailVerification = credentialsEnabled && !isSelfHosted && emailBackendConfigured;
+  if (credentialsEnabled && !isSelfHosted && !emailBackendConfigured) {
+    // biome-ignore lint/suspicious/noConsole: startup misconfig warning — must be visible
+    console.warn(
+      '[auth] No email backend configured (RESEND_API_KEY or SMTP_HOST). Email verification SKIPPED. ' +
+        'Configure email to enable verification at sign-up.'
+    );
+  }
 
   return betterAuth({
     database: drizzleAdapter(db, {
@@ -19,11 +33,11 @@ function createAuth() {
     basePath: '/api/auth',
     secret: process.env.BETTER_AUTH_SECRET || env.BETTER_AUTH_SECRET,
     emailAndPassword: {
-      enabled: enabledProviders.has('credentials'),
-      requireEmailVerification: enabledProviders.has('credentials') && !isSelfHosted
+      enabled: credentialsEnabled,
+      requireEmailVerification
     },
     emailVerification: {
-      sendOnSignUp: enabledProviders.has('credentials') && !isSelfHosted,
+      sendOnSignUp: requireEmailVerification,
       autoSignInAfterVerification: true,
       sendVerificationEmail: async ({ user, url }) => {
         const rateLimit = await checkVerificationRateLimit(user.email);


### PR DESCRIPTION
## Summary

- Cloud-mode sign-up silently succeeded but no verification email was sent: `getProvider()` falls back to `'console'` when `RESEND_API_KEY` and `SMTP_HOST` are both unset, and `'console'` returns `{success: true}` without doing anything (`services/email/service.ts:100`). Users never receive a verification link and remain permanently unverified.
- This is currently blocking sign-ups on `nightly.tankpkg.dev` and any production-mode deployment missing email config.

## Fix

Gate `requireEmailVerification` and `emailVerification.sendOnSignUp` on actual email backend availability. When cloud mode + credentials enabled + no email backend, auto-verify at sign-up (matches self-hosted behavior) and emit a loud startup warning.

## Why this is safe

The prior behavior also created unverified accounts — silently. Now ops sees the misconfig in startup logs immediately. Production with `RESEND_API_KEY` (or `SMTP_HOST`) configured is unaffected.

## Follow-ups

1. Org invitation emails (`core.ts:73-83`) still use `sendEmail` and silently succeed via `console` provider. Consider tightening that path the same way.
2. `services/email/service.ts:100` — the `console` provider in cloud mode could fail explicitly instead of silently returning success, surfacing misconfig sooner.