### PR TITLE
fix(search): restore audit scores in search results

### DIFF
--- a/apps/registry/src/lib/skills/data.ts
+++ b/apps/registry/src/lib/skills/data.ts
@@ -169,6 +169,7 @@ export interface SkillSearchResult {
   description: string | null;
   visibility: 'public' | 'private';
   latestVersion: string | null;
+  auditScore: number | null;
   scanVerdict: string | null;
   publisher: string;
   downloads: number;
@@ -588,6 +589,7 @@ export async function searchSkills(
         s.visibility,
         s.updated_at AS "updatedAt",
         sv.version AS "latestVersion",
+        sv.audit_score AS "auditScore",
         sr.verdict AS "scanVerdict",
         coalesce(u.name, '') AS publisher,
         ${downloadsSql} AS downloads,
@@ -630,6 +632,7 @@ export async function searchSkills(
       s.visibility,
       s.updated_at AS "updatedAt",
       sv.version AS "latestVersion",
+      sv.audit_score AS "auditScore",
       sr.verdict AS "scanVerdict",
       coalesce(u.name, '') AS publisher,
       ${downloadsSql} AS downloads,
@@ -691,6 +694,7 @@ function mapSearchResults(rows: Record<string, unknown>[], page: number, limit: 
       description: row.description as string | null,
       visibility: (row.visibility as 'public' | 'private') ?? 'public',
       latestVersion: (row.latestVersion as string) ?? null,
+      auditScore: row.auditScore != null ? Number(row.auditScore) : null,
       scanVerdict: (row.scanVerdict as string) ?? null,
       publisher: (row.publisher as string) ?? '',
       downloads: Number(row.downloads) || 0,

--- a/packages/cli/src/__tests__/search.test.ts
+++ b/packages/cli/src/__tests__/search.test.ts
@@ -202,6 +202,67 @@ describe('searchCommand', () => {
     expect(output).toContain('2.0');
   });
 
+  it('shows N/A instead of undefined when audit score is missing', async () => {
+    const { searchCommand } = await import('~/commands/search.js');
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              name: '@org/unscored',
+              description: 'Score has not been computed yet',
+              latestVersion: '1.0.0',
+              publisher: 'org',
+              downloads: 10
+            }
+          ],
+          page: 1,
+          limit: 20,
+          total: 1
+        }),
+        { status: 200 }
+      )
+    );
+
+    await searchCommand({ query: 'unscored', configDir });
+
+    const output = getAllOutput();
+    expect(output).toContain('N/A');
+    expect(output).not.toContain('undefined');
+  });
+
+  it('shows N/A when audit score is null', async () => {
+    const { searchCommand } = await import('~/commands/search.js');
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              name: '@org/pending',
+              description: 'Score is pending',
+              latestVersion: '1.0.0',
+              auditScore: null,
+              publisher: 'org',
+              downloads: 10
+            }
+          ],
+          page: 1,
+          limit: 20,
+          total: 1
+        }),
+        { status: 200 }
+      )
+    );
+
+    await searchCommand({ query: 'pending', configDir });
+
+    const output = getAllOutput();
+    expect(output).toContain('N/A');
+    expect(output).not.toContain('undefined');
+  });
+
   it('includes auth token when present in config', async () => {
     const { searchCommand } = await import('~/commands/search.js');
 

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -10,9 +10,9 @@ export interface SearchOptions {
 
 interface SearchResult {
   name: string;
-  description: string;
-  latestVersion: string;
-  auditScore: number;
+  description: string | null;
+  latestVersion: string | null;
+  auditScore?: number | null;
   publisher: string;
   downloads: number;
 }
@@ -30,6 +30,15 @@ function scoreColor(score: number): (text: string) => string {
   if (score >= 7) return chalk.green;
   if (score >= 4) return chalk.yellow;
   return chalk.red;
+}
+
+function formatScore(score: number | null | undefined): string {
+  if (score == null || !Number.isFinite(score)) {
+    return chalk.dim(padRight('N/A', 8));
+  }
+
+  const scoreStr = Number.isInteger(score) ? score.toFixed(1) : String(score);
+  return scoreColor(score)(padRight(scoreStr, 8));
 }
 
 function truncate(text: string, maxLen: number): string {
@@ -79,9 +88,8 @@ export async function searchCommand(options: SearchOptions): Promise<void> {
   // Print each result
   for (const result of data.results) {
     const name = chalk.bold(padRight(result.name, 30));
-    const version = padRight(result.latestVersion, 10);
-    const scoreStr = Number.isInteger(result.auditScore) ? result.auditScore.toFixed(1) : String(result.auditScore);
-    const score = scoreColor(result.auditScore)(padRight(scoreStr, 8));
+    const version = padRight(result.latestVersion ?? '-', 10);
+    const score = formatScore(result.auditScore);
     const desc = truncate(result.description ?? '', MAX_DESC_LENGTH);
 
     console.log(`${name}${version}${score}${desc}`);

--- a/packages/internals-schemas/src/types/api.ts
+++ b/packages/internals-schemas/src/types/api.ts
@@ -40,9 +40,16 @@ export interface SearchResult {
   name: string;
   description: string | null;
   visibility?: SkillVisibility;
-  version: string;
+  latestVersion: string | null;
+  /** @deprecated Use latestVersion. Search API responses do not include this alias. */
+  version?: string | null;
   auditScore: number | null;
+  publisher: string;
   downloads: number;
+  stars: number;
+  updatedAt?: string;
+  atomKinds?: string[];
+  scanVerdict?: string | null;
 }
 
 export interface SearchResponse {

--- a/packages/mcp-server/src/tools/search-skills.ts
+++ b/packages/mcp-server/src/tools/search-skills.ts
@@ -5,9 +5,9 @@ import { TankApiClient } from '~/lib/api-client.js';
 
 interface SearchResult {
   name: string;
-  version: string;
+  latestVersion?: string | null;
   description: string | null;
-  auditScore: number | null;
+  auditScore?: number | null;
   downloads: number;
   publisher: string;
 }
@@ -57,7 +57,8 @@ export function registerSearchSkillsTool(server: McpServer): void {
       // Format as markdown table
       const header = '| Skill | Score | Downloads | Description |\n|-------|-------|-----------|-------------|';
       const rows = results.map((skill) => {
-        const score = skill.auditScore !== null ? skill.auditScore.toFixed(1) : '-';
+        const score =
+          typeof skill.auditScore === 'number' && Number.isFinite(skill.auditScore) ? skill.auditScore.toFixed(1) : '-';
         const downloads =
           skill.downloads > 1000 ? `${(skill.downloads / 1000).toFixed(1)}k` : skill.downloads.toString();
         const desc = skill.description?.slice(0, 50) ?? 'No description';


### PR DESCRIPTION
## Summary
- Return `auditScore` from registry search responses again.
- Render missing search scores as `N/A`/`-` in CLI and MCP instead of `undefined`.
- Align the shared search response type with the runtime API shape.

## Verification
- `bun run test src/__tests__/search.test.ts` in `packages/cli`
- `bun run typecheck` in `packages/cli`
- `bun run typecheck` in `packages/mcp-server`
- `bun run typecheck` in `packages/internals-schemas`
- `bun run typecheck` in `apps/registry`
- `bun x biome check apps/registry/src/lib/skills/data.ts packages/cli/src/commands/search.ts packages/cli/src/__tests__/search.test.ts packages/mcp-server/src/tools/search-skills.ts packages/internals-schemas/src/types/api.ts`