### PR TITLE
chore: update Homebrew formula for v0.15.4

### DIFF
--- a/Formula/tank.rb
+++ b/Formula/tank.rb
@@ -1,19 +1,19 @@
 class Tank < Formula
   desc "Security-first package manager for AI agent skills"
   homepage "https://tankpkg.dev"
-  version "0.14.3"
+  version "0.15.4"
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-arm64.tar.gz"
-    sha256 "81e7332f32b7f1ba56d3782d8284b84248520fed36ee554293709e7a147d2826"
+    sha256 "daa580f05a722c2ad513e784fe2b17a45f74851249c63862d3761980cd5481e4"
   elsif OS.mac?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-x64.tar.gz"
-    sha256 "60f4e56021c9fa2e7eb3967d3b25c0c944e5a909c3d30a636f8068cfbc752042"
+    sha256 "dd24e683bf04714b246c8bb033ac7e0e0ea3d0485abf0980078d887029282c29"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-arm64.tar.gz"
-    sha256 "655f935d6d10c3a6e4cede13ee3b15f3a49bbab27aaa9030c8424f6848d8aa6a"
+    sha256 "a3c7c9426835351ba6fadccea02fb409febe7df5e00303efb0335e7230c8231c"
   else
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-x64.tar.gz"
-    sha256 "8374215c5da937173886bea7349325749b70fd44a8b7eebeff06de8c6d7358fd"
+    sha256 "19daca0004c80045a5ddc9219036ca44c651862afed3ab79e8fec9ec3d901d4e"
   end
   def install
     bin.install Dir["tank-*"].first => "tank"


### PR DESCRIPTION
Auto-generated by release pipeline after GitHub Actions token could not create the PR.