### PR TITLE
fix(ci): force IPv4 for DB migrations

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      NODE_OPTIONS: --dns-result-order=ipv4first
 
     steps:
       - name: Validate DATABASE_URL secret


### PR DESCRIPTION
## Summary
- set NODE_OPTIONS=--dns-result-order=ipv4first for the DB migration workflow
- keeps the existing script-level IPv4 preference but applies it at process startup so postgres connections avoid unroutable IPv6 on GitHub-hosted runners

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/db-migrate.yml")'
- LSP diagnostics: clean
- GIT_MASTER=1 git diff --check
- pre-push checks passed