### PR TITLE
fix(ci): pin DB migration host to IPv4

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -45,6 +45,16 @@ jobs:
         with:
           node-version: 24
 
+      - name: Prefer IPv4 for database host
+        run: |
+          DB_HOST="$(node -e 'try { process.stdout.write(new URL(process.env.DATABASE_URL).hostname) } catch { process.exit(1) }')"
+          DB_IPV4="$(getent ahostsv4 "$DB_HOST" | awk '{ print $1; exit }')"
+          if [ -z "$DB_IPV4" ]; then
+            echo "No IPv4 address found for database host"
+            exit 1
+          fi
+          printf '%s %s\n' "$DB_IPV4" "$DB_HOST" | sudo tee -a /etc/hosts >/dev/null
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary
- add a DB migrate workflow step that resolves the DATABASE_URL hostname to IPv4
- map that IPv4 to the original hostname in /etc/hosts for the job, preserving TLS/SNI while avoiding the failing IPv6 route

## Verification
- LSP diagnostics: clean
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/db-migrate.yml")'
- GIT_MASTER=1 git diff --check
- pre-push checks passed
- Oracle reviewed the approach as safe and appropriate