### PR TITLE
fix(ci): promote DB host IPv4 pin to stable

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -45,6 +45,16 @@ jobs:
         with:
           node-version: 24
 
+      - name: Prefer IPv4 for database host
+        run: |
+          DB_HOST="$(node -e 'try { process.stdout.write(new URL(process.env.DATABASE_URL).hostname) } catch { process.exit(1) }')"
+          DB_IPV4="$(getent ahostsv4 "$DB_HOST" | awk '{ print $1; exit }')"
+          if [ -z "$DB_IPV4" ]; then
+            echo "No IPv4 address found for database host"
+            exit 1
+          fi
+          printf '%s %s\n' "$DB_IPV4" "$DB_HOST" | sudo tee -a /etc/hosts >/dev/null
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary
- promote PR #439 to stable
- DB Migrate now pins the DATABASE_URL hostname to an IPv4 address through a job-local /etc/hosts entry before Bun/postgres connects

## Verification
- PR #439 merged to main
- YAML parse/LSP/diff checks passed
- stable DB migrate will rerun after this merge