### PR TITLE
fix(install): atomically replace install dir to handle removed files

### DIFF
--- a/packages/cli/src/__tests__/extract-safely.test.ts
+++ b/packages/cli/src/__tests__/extract-safely.test.ts
@@ -1,0 +1,152 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import * as tar from 'tar';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { extractSafely } from '~/lib/install-pipeline.js';
+
+interface FileSpec {
+  path: string;
+  content: string;
+}
+
+async function createTarballFromFiles(files: FileSpec[]): Promise<Buffer> {
+  const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-tarball-staging-'));
+  try {
+    for (const file of files) {
+      const fullPath = path.join(stagingDir, file.path);
+      fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+      fs.writeFileSync(fullPath, file.content);
+    }
+    const tarballPath = path.join(stagingDir, '__tarball__.tgz');
+    const entries = fs.readdirSync(stagingDir).filter((entry) => entry !== '__tarball__.tgz');
+    await tar.create({ gzip: true, file: tarballPath, cwd: stagingDir }, entries);
+    return fs.readFileSync(tarballPath);
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
+
+function createMalformedTarball(): Buffer {
+  return Buffer.from('this is not a valid gzipped tar archive', 'utf-8');
+}
+
+function listAllFiles(root: string): string[] {
+  const results: string[] = [];
+  function walk(current: string, relative: string): void {
+    if (!fs.existsSync(current)) return;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const childRel = relative ? `${relative}/${entry.name}` : entry.name;
+      const childAbs = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(childAbs, childRel);
+      } else {
+        results.push(childRel);
+      }
+    }
+  }
+  walk(root, '');
+  return results.sort();
+}
+
+function readFileText(root: string, relativePath: string): string {
+  return fs.readFileSync(path.join(root, ...relativePath.split('/')), 'utf-8');
+}
+
+function listStaleBackupSiblings(installPath: string): string[] {
+  const parent = path.dirname(installPath);
+  if (!fs.existsSync(parent)) return [];
+  const installName = path.basename(installPath);
+  return fs.readdirSync(parent).filter((name) => name.startsWith(`${installName}.tank-old-`));
+}
+
+describe('extractSafely (atomic install/update)', () => {
+  let workDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    workDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tank-extract-test-')));
+    destDir = path.join(workDir, 'install', '@tank', 'sample-skill');
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('extracts a fresh install into an empty destDir', async () => {
+    fs.mkdirSync(destDir, { recursive: true });
+    const tarball = await createTarballFromFiles([
+      { path: 'tank.json', content: '{"name":"@tank/sample-skill","version":"1.0.0"}' },
+      { path: 'SKILL.md', content: '# Sample\n' },
+      { path: 'references/guide.md', content: 'guide v1' }
+    ]);
+
+    await extractSafely(tarball, destDir);
+
+    expect(listAllFiles(destDir)).toEqual(['SKILL.md', 'references/guide.md', 'tank.json']);
+    expect(readFileText(destDir, 'references/guide.md')).toBe('guide v1');
+  });
+
+  it('replaces a previous install when the new version removes files inside a kept directory', async () => {
+    fs.mkdirSync(path.join(destDir, 'references'), { recursive: true });
+    fs.writeFileSync(path.join(destDir, 'tank.json'), '{"name":"@tank/sample-skill","version":"1.0.0"}');
+    fs.writeFileSync(path.join(destDir, 'references', 'guide.md'), 'guide v1');
+    fs.writeFileSync(path.join(destDir, 'references', 'source-coverage.md'), 'leftover');
+
+    const tarball = await createTarballFromFiles([
+      { path: 'tank.json', content: '{"name":"@tank/sample-skill","version":"1.0.1"}' },
+      { path: 'references/guide.md', content: 'guide v2' }
+    ]);
+
+    await extractSafely(tarball, destDir);
+
+    expect(listAllFiles(destDir)).toEqual(['references/guide.md', 'tank.json']);
+    expect(readFileText(destDir, 'references/guide.md')).toBe('guide v2');
+    expect(fs.existsSync(path.join(destDir, 'references', 'source-coverage.md'))).toBe(false);
+  });
+
+  it('removes top-level directories that no longer exist in the new version', async () => {
+    fs.mkdirSync(path.join(destDir, 'assets', 'evals'), { recursive: true });
+    fs.writeFileSync(path.join(destDir, 'tank.json'), '{"name":"@tank/sample-skill","version":"1.0.0"}');
+    fs.writeFileSync(path.join(destDir, 'assets', 'ATTRIBUTION.md'), 'old attribution');
+    fs.writeFileSync(path.join(destDir, 'assets', 'evals', 'eval.json'), '{}');
+
+    const tarball = await createTarballFromFiles([
+      { path: 'tank.json', content: '{"name":"@tank/sample-skill","version":"2.0.0"}' },
+      { path: 'SKILL.md', content: '# Slimmer skill\n' }
+    ]);
+
+    await extractSafely(tarball, destDir);
+
+    expect(listAllFiles(destDir)).toEqual(['SKILL.md', 'tank.json']);
+    expect(fs.existsSync(path.join(destDir, 'assets'))).toBe(false);
+  });
+
+  it('does not leave stale backup directories next to the install on success', async () => {
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(path.join(destDir, 'old.txt'), 'old');
+
+    const tarball = await createTarballFromFiles([{ path: 'new.txt', content: 'new' }]);
+
+    await extractSafely(tarball, destDir);
+
+    expect(listStaleBackupSiblings(destDir)).toEqual([]);
+  });
+
+  it('preserves the previous install when extraction fails (rollback)', async () => {
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(path.join(destDir, 'tank.json'), '{"name":"@tank/sample-skill","version":"1.0.0"}');
+    fs.writeFileSync(path.join(destDir, 'SKILL.md'), 'previous version');
+
+    const tarball = createMalformedTarball();
+
+    await expect(extractSafely(tarball, destDir)).rejects.toThrow();
+
+    expect(listAllFiles(destDir)).toEqual(['SKILL.md', 'tank.json']);
+    expect(readFileText(destDir, 'SKILL.md')).toBe('previous version');
+    expect(readFileText(destDir, 'tank.json')).toBe('{"name":"@tank/sample-skill","version":"1.0.0"}');
+    expect(listStaleBackupSiblings(destDir)).toEqual([]);
+  });
+});

--- a/packages/cli/src/bin/tank.ts
+++ b/packages/cli/src/bin/tank.ts
@@ -202,7 +202,7 @@ program
 
 program
   .command('remove')
-  .aliases(['rm', 'r'])
+  .aliases(['rm', 'r', 'uninstall'])
   .description('Remove an installed skill')
   .argument('<name>', 'Skill name (e.g., @org/skill-name)')
   .option('-g, --global', 'Remove a globally installed skill')

--- a/packages/sdk/src/install/pipeline.ts
+++ b/packages/sdk/src/install/pipeline.ts
@@ -231,6 +231,27 @@ function mkdirSafeNoSymlinks(targetDir: string): void {
   }
 }
 
+function isDirNonEmpty(dir: string): boolean {
+  try {
+    return fs.readdirSync(dir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function moveEntryAcrossDevices(src: string, dst: string): void {
+  try {
+    fs.renameSync(src, dst);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'EXDEV') {
+      fs.cpSync(src, dst, { recursive: true });
+      fs.rmSync(src, { recursive: true, force: true });
+      return;
+    }
+    throw err;
+  }
+}
+
 export async function extractSafely(tarball: Buffer, destDir: string): Promise<void> {
   if (tarball.length > MAX_DOWNLOAD_BYTES) {
     throw new TankIntegrityError(`Tarball exceeds ${MAX_DOWNLOAD_BYTES} byte limit`);
@@ -242,6 +263,8 @@ export async function extractSafely(tarball: Buffer, destDir: string): Promise<v
 
   let entryCount = 0;
   let totalBytes = 0;
+  let backupDir: string | null = null;
+
   try {
     await extract({
       file: tmpTarball,
@@ -275,21 +298,33 @@ export async function extractSafely(tarball: Buffer, destDir: string): Promise<v
 
     mkdirSafeNoSymlinks(destDir);
 
+    if (isDirNonEmpty(destDir)) {
+      backupDir = `${destDir}.tank-old-${crypto.randomUUID()}`;
+      fs.renameSync(destDir, backupDir);
+      mkdirSafeNoSymlinks(destDir);
+    }
+
     for (const entry of fs.readdirSync(tmpDir)) {
       if (entry === path.basename(tmpTarball)) continue;
       const src = path.join(tmpDir, entry);
       const dst = path.join(destDir, entry);
+      moveEntryAcrossDevices(src, dst);
+    }
+
+    if (backupDir !== null) {
+      fs.rmSync(backupDir, { recursive: true, force: true });
+      backupDir = null;
+    }
+  } catch (err) {
+    if (backupDir !== null && fs.existsSync(backupDir)) {
       try {
-        fs.renameSync(src, dst);
-      } catch (err: unknown) {
-        if ((err as NodeJS.ErrnoException).code === 'EXDEV') {
-          fs.cpSync(src, dst, { recursive: true });
-          fs.rmSync(src, { recursive: true, force: true });
-        } else {
-          throw err;
-        }
+        fs.rmSync(destDir, { recursive: true, force: true });
+        fs.renameSync(backupDir, destDir);
+      } catch {
+        /* best-effort rollback; surface the original failure */
       }
     }
+    throw err;
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- `tank update` now succeeds when a new package version removes files or directories that the previous version installed
- `tank uninstall` now works (alias for `tank remove`)

## Bug

Reported by user:
> `tank update -g <pkg>` failed with `ENOTEMPTY: directory not empty, rename '/var/folders/.../tank-extract-XXX/references' -> '~/.tank/skills/@tank/<pkg>/references'`
> when the new version dropped files inside `references/` that the previous version had.

## Root cause

`extractSafely` in `packages/sdk/src/install/pipeline.ts` extracted the new tarball into a temp dir, then renamed each top-level entry on top of the existing install. POSIX `rename(2)` cannot replace a non-empty directory, so directories shared between the two versions caused `ENOTEMPTY`.

## Fix

Atomic backup → move → rollback in `extractSafely`:
1. After tar extraction, if `destDir` is non-empty, rename it to a sibling `${destDir}.tank-old-<uuid>` backup
2. Recreate `destDir` empty and move new tarball entries in
3. Drop the backup on success
4. On any failure, restore the backup so the previous install survives

Plus `'uninstall'` added to the alias list of the existing `remove` command — closes the second item in the bug report (`tank uninstall` returning `unknown command`).

## Testing

5 new vitest tests in `packages/cli/src/__tests__/extract-safely.test.ts` using real `tar.create`-built tarballs (no mocks):

- extracts a fresh install into an empty destDir
- replaces a previous install when the new version removes files inside a kept directory **(reproduces the user bug; pre-fix: ENOTEMPTY, post-fix: pass)**
- removes top-level directories that no longer exist in the new version
- does not leave stale backup directories next to the install on success
- preserves the previous install when extraction fails (rollback)

All 5 pass after the fix; relevant 2 fail before the fix with the exact error from the bug report.

## Verification

- `bun x biome check`: clean
- `tsc --noEmit` (CLI + SDK): clean
- `bun run vitest run` (CLI): 507 passed, 0 new failures (36 pre-existing macOS-only failures unrelated to this change — `/var` symlink issue in `mkdirSafeNoSymlinks`, fail identically on origin/main)
- Oracle review: PASS with one non-blocking note about `installFromLockfile`'s pre-rmSync (separate code path; rollback is fully active for the actual `tank update` path)
- `node dist/bin/tank.js uninstall --help`: routes to `remove`

## Out of scope (per user's bug report, deferred)

- "skills.lock is deprecated" warning fires on every command — surface once per invocation. (Will track separately.)

## Changes

| File | Change |
|---|---|
| `packages/sdk/src/install/pipeline.ts` | atomic-replace + rollback in `extractSafely`; new `isDirNonEmpty`, `moveEntryAcrossDevices` helpers |
| `packages/cli/src/__tests__/extract-safely.test.ts` | new — 5 regression tests |
| `packages/cli/src/bin/tank.ts` | add `uninstall` to remove's alias list |