### PR TITLE
chore: update Homebrew formula for v0.15.5

### DIFF
--- a/Formula/tank.rb
+++ b/Formula/tank.rb
@@ -1,19 +1,19 @@
 class Tank < Formula
   desc "Security-first package manager for AI agent skills"
   homepage "https://tankpkg.dev"
-  version "0.15.4"
+  version "0.15.5"
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-arm64.tar.gz"
-    sha256 "daa580f05a722c2ad513e784fe2b17a45f74851249c63862d3761980cd5481e4"
+    sha256 "c5ccd1b917ea80a6494de28035ae76e3901e2c33bcca3b2e7e2681c29f0bc39b"
   elsif OS.mac?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-x64.tar.gz"
-    sha256 "dd24e683bf04714b246c8bb033ac7e0e0ea3d0485abf0980078d887029282c29"
+    sha256 "072847919b37a5dcd2fa56e621ccce18d3ce6011435691b9035ca260ed71dba2"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-arm64.tar.gz"
-    sha256 "a3c7c9426835351ba6fadccea02fb409febe7df5e00303efb0335e7230c8231c"
+    sha256 "c1419a44bfec72ad2885a64358bee0bf44f97333ffffcab4d655a53613df89d5"
   else
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-x64.tar.gz"
-    sha256 "19daca0004c80045a5ddc9219036ca44c651862afed3ab79e8fec9ec3d901d4e"
+    sha256 "666b5a7aebc1cd625e71b530fcabfbf54fffc54ba6e686cbe5245a44df0876dc"
   end
   def install
     bin.install Dir["tank-*"].first => "tank"


### PR DESCRIPTION
Auto-generated by release pipeline. Workflow successfully pushed the branch but GitHub Actions cannot create PRs from `GITHUB_TOKEN`.