### PR TITLE
docs(vault): lead with user benefit instead of tokenization-proxy jargon

### DIFF
--- a/apps/registry/public/docs/vault.md
+++ b/apps/registry/public/docs/vault.md
@@ -5,7 +5,9 @@ description: Protect API keys and secrets from AI agent exfiltration with Tank's
 
 # Credential Vault
 
-Tank Vault is a **format-preserving tokenization proxy** that sits between your AI agent and the LLM provider. It intercepts outgoing requests, replaces real credentials with structurally identical fakes, and restores them in responses — so the model never sees your actual API keys, database URLs, or tokens.
+**Tank Vault prevents your real API keys, database URLs, and tokens from ever reaching LLM providers.** Your AI agent runs normally — but every outgoing request is silently swapped to use look-alike fakes before it leaves your machine, then swapped back on the way home so your code still works.
+
+Real credentials never enter provider logs. A prompt-injected skill cannot exfiltrate them. An LLM-provider breach reveals nothing useful from your infrastructure.
 
 <svg viewBox="0 0 800 250" xmlns="http://www.w3.org/2000/svg" class="max-w-full" style="font-family: 'Space Grotesk', sans-serif;">
   <defs>
@@ -82,6 +84,8 @@ Tank Vault eliminates this entire attack class. Real credentials never leave you
 ---
 
 ## How It Works
+
+Tank Vault is implemented as a **format-preserving tokenization proxy** — a transparent intermediary that sits between your agent and any HTTP endpoint. It detects credentials in outgoing traffic, swaps them for structurally identical placeholders, and restores the originals when the provider responds.
 
 ### 1. Credential Detection
 


### PR DESCRIPTION
Fixes #367.

## Summary

The Vault docs page opens with implementation jargon ("format-preserving tokenization proxy"). A first-time visitor has to parse several paragraphs and diagrams before understanding the user-facing value.

## Change

Two paragraphs:

1. **Opener replaced** with a plain-language benefit statement: real keys never reach LLM providers, your agent runs normally, breaches reveal nothing useful.
2. **Transition paragraph added** at the top of `## How It Works` so the technical term still appears — but at the natural point where the reader is asking *how does it actually do that*.

## Diff

```diff
# Credential Vault

-Tank Vault is a **format-preserving tokenization proxy** that sits between your AI agent and the LLM provider. It intercepts outgoing requests, replaces real credentials with structurally identical fakes, and restores them in responses — so the model never sees your actual API keys, database URLs, or tokens.
+**Tank Vault prevents your real API keys, database URLs, and tokens from ever reaching LLM providers.** Your AI agent runs normally — but every outgoing request is silently swapped to use look-alike fakes before it leaves your machine, then swapped back on the way home so your code still works.
+
+Real credentials never enter provider logs. A prompt-injected skill cannot exfiltrate them. An LLM-provider breach reveals nothing useful from your infrastructure.
```

```diff
 ## How It Works

+Tank Vault is implemented as a **format-preserving tokenization proxy** — a transparent intermediary that sits between your agent and any HTTP endpoint. It detects credentials in outgoing traffic, swaps them for structurally identical placeholders, and restores the originals when the provider responds.
+
 ### 1. Credential Detection
```

## Verification

- `bun run apps/registry/scripts/build-docs.ts` succeeds (`vault.md (22 headings)` parses cleanly)
- Single source file changed; pre-rendered `docs.json` is gitignored and rebuilt at build time per the AGENTS.md gotcha.

## Issue alignment

Original issue suggestions:
- ✅ Lead with **problem + benefit** in plain language
- ✅ Move technical "how" below the "what" and "why"
- ✅ One-liner TL;DR at the very top (the bold opener serves as the TL;DR)
- ✅ Diagrams now appear after the reader understands why they should care