### PR TITLE
fix(scanner): suppress typosquat false positives for popular packages

### DIFF
--- a/apps/python-api/lib/scan/stage5_helpers.py
+++ b/apps/python-api/lib/scan/stage5_helpers.py
@@ -159,31 +159,27 @@ def levenshtein_distance(s1: str, s2: str) -> int:
 def check_typosquatting(package_name: str, popular_packages: set[str]) -> tuple[str, int] | None:
     """Check if package name is a typosquat of a popular package.
 
-    Returns (original_package, distance) if potential typosquat found.
+    Returns ``(original_package, distance)`` if a potential typosquat is found,
+    else ``None``.
+
+    A package that itself belongs to ``popular_packages`` (case-insensitive) is
+    never a typosquat, even if it sits within edit distance 1-2 of another
+    popular name. This prevents false positives like ``react`` vs ``preact``,
+    ``next`` vs ``nuxt``, or ``redis`` vs ``redux``.
+
+    Iteration is deterministic (sorted) so the chosen match is stable across
+    Python versions and process restarts.
     """
     name_lower = package_name.lower()
+    popular_lower: set[str] = {p.lower() for p in popular_packages}
 
-    # Check for common typosquat patterns
-    for popular in popular_packages:
-        popular_lower = popular.lower()
+    if name_lower in popular_lower:
+        return None
 
-        # Exact match
-        if name_lower == popular_lower:
-            return None
-
-        # Levenshtein distance check
-        distance = levenshtein_distance(name_lower, popular_lower)
-
-        # Flag if distance is 1-2 and package is not the same length
+    for popular in sorted(popular_packages):
+        distance = levenshtein_distance(name_lower, popular.lower())
         if 1 <= distance <= 2:
             return (popular, distance)
-
-        # Check for common substitutions
-        # e.g., "reqeusts" vs "requests"
-        if len(name_lower) == len(popular_lower):
-            diffs = sum(1 for a, b in zip(name_lower, popular_lower, strict=False) if a != b)
-            if diffs == 1:
-                return (popular, 1)
 
     return None
 

--- a/apps/python-api/tests/test_stage5_typosquat.py
+++ b/apps/python-api/tests/test_stage5_typosquat.py
@@ -1,0 +1,106 @@
+"""Regression: typosquat detection must not flag legitimate popular packages.
+
+Bug (prod): scanning a Next.js skill flagged ``react`` as a HIGH-severity typosquat
+of ``preact`` (distance 1). Both names live in ``POPULAR_NPM_PACKAGES``, but
+Python's ``set`` iteration order is implementation-defined. ``check_typosquatting``
+returned on the first distance-1 match it encountered, which could be ``preact``
+before the loop ever reached the ``react`` exact-match check.
+
+Fix: short-circuit when the input itself is in the popular set, and iterate in
+sorted order so results are stable across runs and Python versions.
+"""
+
+from lib.scan.stage5_helpers import (
+    POPULAR_NPM_PACKAGES,
+    POPULAR_PYTHON_PACKAGES,
+    check_typosquatting,
+)
+
+
+class TestPopularPackagesAreNotTyposquats:
+    def test_react_not_flagged_as_preact(self) -> None:
+        assert check_typosquatting("react", POPULAR_NPM_PACKAGES) is None
+
+    def test_preact_not_flagged_as_react(self) -> None:
+        assert check_typosquatting("preact", POPULAR_NPM_PACKAGES) is None
+
+    def test_next_not_flagged_as_nuxt(self) -> None:
+        assert check_typosquatting("next", POPULAR_NPM_PACKAGES) is None
+
+    def test_nuxt_not_flagged_as_next(self) -> None:
+        assert check_typosquatting("nuxt", POPULAR_NPM_PACKAGES) is None
+
+    def test_redux_not_flagged_as_redis(self) -> None:
+        assert check_typosquatting("redux", POPULAR_NPM_PACKAGES) is None
+
+    def test_redis_not_flagged_as_redux(self) -> None:
+        assert check_typosquatting("redis", POPULAR_NPM_PACKAGES) is None
+
+    def test_every_popular_npm_package_is_safe(self) -> None:
+        offenders: list[tuple[str, str, int]] = []
+        for pkg in POPULAR_NPM_PACKAGES:
+            result = check_typosquatting(pkg, POPULAR_NPM_PACKAGES)
+            if result is not None:
+                offenders.append((pkg, result[0], result[1]))
+        assert not offenders, f"Popular npm packages flagged as typosquats: {offenders}"
+
+    def test_every_popular_python_package_is_safe(self) -> None:
+        offenders: list[tuple[str, str, int]] = []
+        for pkg in POPULAR_PYTHON_PACKAGES:
+            result = check_typosquatting(pkg, POPULAR_PYTHON_PACKAGES)
+            if result is not None:
+                offenders.append((pkg, result[0], result[1]))
+        assert not offenders, f"Popular Python packages flagged as typosquats: {offenders}"
+
+
+class TestRealTyposquatsStillCaught:
+    def test_reqeusts_flagged_as_requests(self) -> None:
+        result = check_typosquatting("reqeusts", POPULAR_PYTHON_PACKAGES)
+        assert result is not None
+        original, distance = result
+        assert original == "requests"
+        assert distance <= 2
+
+    def test_lodaash_flagged_as_lodash(self) -> None:
+        result = check_typosquatting("lodaash", POPULAR_NPM_PACKAGES)
+        assert result is not None
+        assert result[0] == "lodash"
+
+    def test_expres_flagged_as_express(self) -> None:
+        result = check_typosquatting("expres", POPULAR_NPM_PACKAGES)
+        assert result is not None
+        assert result[0] == "express"
+
+    def test_axioss_flagged_as_axios(self) -> None:
+        result = check_typosquatting("axioss", POPULAR_NPM_PACKAGES)
+        assert result is not None
+        assert result[0] == "axios"
+
+
+class TestNonMatches:
+    def test_unknown_package_returns_none(self) -> None:
+        assert check_typosquatting("my-cool-unique-skill", POPULAR_NPM_PACKAGES) is None
+
+    def test_completely_different_name(self) -> None:
+        assert check_typosquatting("zzz-something-totally-unrelated", POPULAR_NPM_PACKAGES) is None
+
+    def test_empty_popular_set(self) -> None:
+        assert check_typosquatting("react", set()) is None
+
+
+class TestCaseInsensitivity:
+    def test_uppercase_react_not_flagged(self) -> None:
+        assert check_typosquatting("REACT", POPULAR_NPM_PACKAGES) is None
+
+    def test_mixed_case_react_not_flagged(self) -> None:
+        assert check_typosquatting("React", POPULAR_NPM_PACKAGES) is None
+
+
+class TestDeterminism:
+    def test_popular_package_stable_across_calls(self) -> None:
+        results = {check_typosquatting("react", POPULAR_NPM_PACKAGES) for _ in range(50)}
+        assert results == {None}
+
+    def test_typosquat_match_stable_across_calls(self) -> None:
+        results = {check_typosquatting("reqeusts", POPULAR_PYTHON_PACKAGES) for _ in range(50)}
+        assert len(results) == 1, f"Non-deterministic typosquat match: {results}"


### PR DESCRIPTION
## Summary

`check_typosquatting` in the supply-chain stage was flagging legitimate popular packages as HIGH-severity typosquats whenever their name sat within edit distance 1-2 of another entry in the popular-package set.

**Confirmed false positives the scanner has been emitting in prod:**

| Ecosystem | Falsely flagged |
|---|---|
| npm | `react→preact`, `next→nuxt`, `redis→redux`, `cypress→express`, `jest→next`, `vite→vue`, `knex→next` |
| Python | `pip→six`, `uvicorn→gunicorn`, `black→flask`, `pytorch→torch` |

Reported externally for `@uriva/agentdocs` (which uses `react`).

## Root cause

Two compounding bugs in `apps/python-api/lib/scan/stage5_helpers.py::check_typosquatting`:

1. **Non-deterministic set iteration.** The function walked `popular_packages` (a `set`) and returned on the first distance-1 match. For input `react`, Python's hash order could visit `preact` before the `react` exact-match short-circuit and return `("preact", 1)`.
2. **No popular-vs-popular allowlist.** A package that is itself popular cannot meaningfully be a typosquat of another popular package, but the function had no such guard.

## Fix

- Short-circuit return `None` when the input name (case-insensitive) is in the popular set.
- Iterate in `sorted(...)` order for stable, reproducible results across Python versions and process restarts.
- Drop the redundant same-length single-char substitution branch — already covered by `levenshtein == 1`.

## Tests

New file `apps/python-api/tests/test_stage5_typosquat.py` — **19 tests, all passing**:

- `TestPopularPackagesAreNotTyposquats` — explicit cases + a defensive sweep over the full popular sets that asserts no entry is flagged against its own set. Future additions to `POPULAR_*` can never reintroduce this class of bug.
- `TestRealTyposquatsStillCaught` — `reqeusts→requests`, `lodaash→lodash`, `expres→express`, `axioss→axios`.
- `TestNonMatches`, `TestCaseInsensitivity`, `TestDeterminism` (50-run stability check).

Full scanner suite: **206 passed**, 6 pre-existing failures unrelated to stage5. Ruff lint + format clean.

## Verification on the original report

```
Re-scan @uriva/agentdocs deps:
  react: clean
  react-dom: clean
  next: clean
  typescript: clean
  @instantdb/react: clean
```

## Followup

Stale findings persisted in the DB for already-scanned skills will not auto-update. A one-off admin rescan filtered on `type=typosquatting` will purge them. Tracking separately.