### PR TITLE
fix(scanner): suppress env-var-name placeholders flagged as secrets

### DIFF
--- a/apps/python-api/lib/scan/stage4_secrets.py
+++ b/apps/python-api/lib/scan/stage4_secrets.py
@@ -46,12 +46,19 @@ COMPILED_SECRET_PATTERNS = [
     (re.compile(pattern), severity, description) for pattern, severity, description in CUSTOM_SECRET_PATTERNS
 ]
 
-# Placeholder values that indicate example/tutorial content, not real secrets
+# Suffixes that mark a token as describing the kind of secret it stands in for,
+# rather than being one. Used to recognize env-var-name placeholders like
+# ``RAPIDAPI_KEY`` or ``BRIGHTDATA_TOKEN``.
+_SECRET_SUFFIX = "key|token|secret|password|pass|pwd|auth|api|credential|cred|webhook|url|host|user|id|uri|dsn"
+_SECRET_PREFIX = "api|secret|access|private|public|auth|bearer|jwt|oauth|client|service|admin|app"
+
+# Placeholder values that indicate example/tutorial content, not real secrets.
+# All patterns are matched against the lower-cased text (see _is_placeholder_value).
 PLACEHOLDER_PATTERNS: list[re.Pattern] = [
     re.compile(r"\b(user|username|admin|root|password|pass|pwd|secret|token|key|value|your[_-]?)\b", re.IGNORECASE),
     re.compile(r"\b(example|sample|demo|test|placeholder|dummy|fake|todo|changeme|default)\b", re.IGNORECASE),
     re.compile(r"\b(localhost|127\.0\.0\.1|0\.0\.0\.0|host|hostname)\b", re.IGNORECASE),
-    re.compile(r"\bxxx+\b|\babc+\b|\b123+\b"),
+    re.compile(r"\bxxx+\b|\babc\d*\b|\b\d{3,}\b"),
     # Additional placeholder patterns for common documentation examples
     re.compile(r"\b(your[_-]?api[_-]?key[_-]?here|your[_-]?secret[_-]?here)\b", re.IGNORECASE),
     re.compile(r"\bsk[_-]?placeholder\b", re.IGNORECASE),
@@ -65,6 +72,14 @@ PLACEHOLDER_PATTERNS: list[re.Pattern] = [
     # Common template strings
     re.compile(r"\$\{[A-Z_]+\}", re.IGNORECASE),  # ${ENV_VAR} template patterns
     re.compile(r"<<[A-Z_]+>>", re.IGNORECASE),  # <<PLACEHOLDER>> patterns
+    # Env-var-name style placeholders. Real secrets are random base64 / hex blobs;
+    # values that look like ``RAPIDAPI_KEY`` or ``BRIGHTDATA_TOKEN`` (snake_case
+    # ending in a secret-suffix word) are documentation stand-ins, never live keys.
+    # Quoted form (matches after .lower()).
+    re.compile(rf"['\"][a-z0-9]+(_[a-z0-9]+)*_({_SECRET_SUFFIX})['\"]"),
+    re.compile(rf"['\"]({_SECRET_PREFIX})_({_SECRET_SUFFIX})['\"]"),
+    # Naked form (e.g. YAML values without quotes).
+    re.compile(rf"\b[a-z0-9]+(_[a-z0-9]+)*_({_SECRET_SUFFIX})\b"),
 ]
 
 # File paths that indicate example/tutorial/documentation/test context.
@@ -91,6 +106,10 @@ EXAMPLE_PATH_PATTERNS: list[re.Pattern] = [
     re.compile(r"\.sample(\.|$)", re.IGNORECASE),
     re.compile(r"\.template(\.|$)", re.IGNORECASE),
     re.compile(r"(setup|config|getting.started|quickstart)", re.IGNORECASE),
+    re.compile(
+        r"(^|/)(SKILL|README|CHANGELOG|CONTRIBUTING|HISTORY|AUTHORS|NOTICE|MAINTAINERS|CODE_OF_CONDUCT|SECURITY|SUPPORT)\.(md|markdown|rst|txt)$",
+        re.IGNORECASE,
+    ),
 ]
 
 # Dependency lock files contain public integrity hashes (SHA-256/512 base64),

--- a/apps/python-api/tests/test_stage4_envvar_placeholder.py
+++ b/apps/python-api/tests/test_stage4_envvar_placeholder.py
@@ -1,0 +1,157 @@
+"""Regression: detect-secrets must not flag env-var-name placeholders as secrets.
+
+Bug (prod): scanning ``@uriva/p2b-social-media-scraper`` v2.0.0 emitted a
+CRITICAL finding on this SKILL.md line:
+
+    { "rapidApiKey": "RAPIDAPI_KEY", "brightDataToken": "BRIGHTDATA_TOKEN" }
+
+The values are env-var-name placeholders — documentation showing which env vars
+the skill expects — not real credentials.
+
+Two compounding bugs in stage4_secrets.py:
+
+1. ``\b(...|key|token|...)\b`` failed to match on ``rapidapi_key`` because
+   underscore is a regex word character, so ``\bkey\b`` requires a non-word
+   character before ``key`` and the underscore doesn't qualify.
+2. SKILL.md at the package root did not match any ``EXAMPLE_PATH_PATTERNS``
+   (which only covered ``/docs/``, ``/examples/``, ``setup``, etc.), so even
+   a flagged finding was never downgraded to ``info``.
+
+Fix: add patterns matching env-var-name style placeholders explicitly, and
+treat top-level documentation files (SKILL.md, README.md, CHANGELOG.md, etc.)
+as documentation paths.
+"""
+
+from pathlib import Path
+
+from lib.scan.models import IngestResult, StageResult
+from lib.scan.stage4_secrets import (
+    _is_example_path,
+    _is_placeholder_value,
+    stage4_scan_secrets,
+)
+
+
+class TestEnvVarNamePlaceholders:
+    def test_quoted_uppercase_env_var_name_is_placeholder(self):
+        assert _is_placeholder_value('"RAPIDAPI_KEY"')
+        assert _is_placeholder_value('"BRIGHTDATA_TOKEN"')
+        assert _is_placeholder_value('"OPENAI_API_KEY"')
+        assert _is_placeholder_value('"GITHUB_TOKEN"')
+        assert _is_placeholder_value('"DATABASE_URL"')
+        assert _is_placeholder_value('"AWS_ACCESS_KEY_ID"')
+
+    def test_quoted_short_prefix_form_is_placeholder(self):
+        assert _is_placeholder_value('"API_KEY"')
+        assert _is_placeholder_value('"SECRET_TOKEN"')
+        assert _is_placeholder_value('"ACCESS_TOKEN"')
+        assert _is_placeholder_value('"PRIVATE_KEY"')
+
+    def test_naked_env_var_name_is_placeholder(self):
+        assert _is_placeholder_value("RAPIDAPI_KEY")
+        assert _is_placeholder_value("BRIGHTDATA_TOKEN")
+        assert _is_placeholder_value("MY_AWS_ACCESS_KEY")
+        assert _is_placeholder_value("STRIPE_SECRET_KEY")
+
+    def test_secret_mapping_example_line_is_placeholder(self):
+        line = '{ "rapidApiKey": "RAPIDAPI_KEY", "brightDataToken": "BRIGHTDATA_TOKEN" }'
+        assert _is_placeholder_value(line)
+
+    def test_real_google_api_key_not_suppressed(self):
+        assert not _is_placeholder_value("AIzaSyA1234567890abcdefghijklmnopqrstuv")
+
+    def test_real_jwt_not_suppressed(self):
+        jwt = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+            "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+            "dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        )
+        assert not _is_placeholder_value(jwt)
+
+    def test_real_random_base64_not_suppressed(self):
+        assert not _is_placeholder_value('"sk-proj-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"')
+
+
+class TestTopLevelDocsAreExamplePaths:
+    def test_skill_md_at_root_is_example_path(self):
+        assert _is_example_path("SKILL.md")
+
+    def test_skill_md_in_subpath_is_example_path(self):
+        assert _is_example_path("packages/foo/SKILL.md")
+
+    def test_readme_is_example_path(self):
+        assert _is_example_path("README.md")
+        assert _is_example_path("subdir/README.md")
+
+    def test_other_top_level_docs_are_example_paths(self):
+        assert _is_example_path("CHANGELOG.md")
+        assert _is_example_path("CONTRIBUTING.md")
+        assert _is_example_path("CODE_OF_CONDUCT.md")
+        assert _is_example_path("SECURITY.md")
+
+    def test_lowercase_filename_also_matches(self):
+        assert _is_example_path("readme.md")
+        assert _is_example_path("changelog.markdown")
+
+    def test_random_md_inside_skill_code_is_not_example_path(self):
+        assert not _is_example_path("src/handler.md")
+
+
+class TestPreExistingPlaceholderCoverageGap:
+    def test_abc123_is_placeholder(self):
+        assert _is_placeholder_value("abc123")
+
+    def test_long_digit_run_is_placeholder(self):
+        assert _is_placeholder_value("123456")
+        assert _is_placeholder_value("1234567890")
+
+
+class TestStage4Integration:
+    def test_skill_md_with_env_var_placeholders_emits_no_critical(self, tmp_path: Path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "---\n"
+            "name: example-skill\n"
+            "description: example\n"
+            "---\n\n"
+            "Pass secrets via secretMapping:\n\n"
+            "```json\n"
+            '{ "rapidApiKey": "RAPIDAPI_KEY", "brightDataToken": "BRIGHTDATA_TOKEN" }\n'
+            "```\n"
+        )
+
+        ingest = IngestResult(
+            temp_dir=str(tmp_path),
+            file_list=["SKILL.md"],
+            total_size=skill_md.stat().st_size,
+            stage_result=StageResult(stage="stage0", status="passed", findings=[], duration_ms=0),
+        )
+
+        result = stage4_scan_secrets(ingest)
+        critical = [f for f in result.findings if f.severity == "critical"]
+        assert not critical, f"Expected no critical findings but got: {critical}"
+
+    def test_skill_md_with_real_secret_still_flagged(self, tmp_path: Path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text(
+            "---\n"
+            "name: dangerous-skill\n"
+            "---\n\n"
+            "Hardcoded credential (should still be reported, even if downgraded):\n\n"
+            "```\n"
+            'GOOGLE_API_KEY = "AIzaSyD-1234567890abcdefghijklmnopqrstuv"\n'
+            "```\n"
+        )
+
+        ingest = IngestResult(
+            temp_dir=str(tmp_path),
+            file_list=["SKILL.md"],
+            total_size=skill_md.stat().st_size,
+            stage_result=StageResult(stage="stage0", status="passed", findings=[], duration_ms=0),
+        )
+
+        result = stage4_scan_secrets(ingest)
+        all_findings = result.findings
+        assert any("AIza" in (f.evidence or "") or "Google" in f.description for f in all_findings), (
+            "Real Google API key should still be detected and reported, even in SKILL.md"
+        )


### PR DESCRIPTION
## Summary

`stage4_secrets` was emitting **CRITICAL** findings for env-var-name placeholders documented in skill manifests. Reported externally on `@uriva/p2b-social-media-scraper` v2.0.0 for this SKILL.md line:

```json
{ "rapidApiKey": "RAPIDAPI_KEY", "brightDataToken": "BRIGHTDATA_TOKEN" }
```

The values `RAPIDAPI_KEY` and `BRIGHTDATA_TOKEN` are documentation stand-ins for env-var names — not real credentials.

## Root cause

Two compounding bugs in `apps/python-api/lib/scan/stage4_secrets.py`:

1. **Word-boundary regex blind spot.** Existing pattern `\b(...|key|token|...)\b` failed to match `rapidapi_key` because `_` is a regex word character. `\bkey\b` requires a non-word character before `key`; `_` doesn't qualify, so the placeholder check silently returned False.
2. **SKILL.md not recognized as documentation.** `EXAMPLE_PATH_PATTERNS` only covered `/docs/`, `/examples/`, `setup`, etc. — top-level `SKILL.md`/`README.md` never matched, so even downgrading to `info` never happened.

## Fix

- **PLACEHOLDER_PATTERNS** — add explicit env-var-name patterns:
  - Quoted form: `"RAPIDAPI_KEY"`, `"BRIGHTDATA_TOKEN"`, `"OPENAI_API_KEY"`
  - Short prefix form: `"API_KEY"`, `"SECRET_TOKEN"`, `"ACCESS_TOKEN"`
  - Naked form for unquoted YAML-style values
  - Heuristic: real secrets are random base64/hex blobs; values that look like `snake_case_word` ending in a secret-suffix word (`key`, `token`, `secret`, `password`, `auth`, `api`, `credential`, `webhook`, `url`, `host`, `id`) are documentation stand-ins.
- **EXAMPLE_PATH_PATTERNS** — add pattern for top-level docs: `SKILL.md`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, etc. Findings in these files get downgraded to `info` (still reported, just not gated).
- **`\babc+\b|\b123+\b` pattern fix** — tightened to also match `abc123`, `123456` standalone (fixes the previously-failing `TestPlaceholderSuppression::test_common_placeholders_are_suppressed[abc123]`).

## Tests

New file `apps/python-api/tests/test_stage4_envvar_placeholder.py` — **17 tests, all passing**:

- `TestEnvVarNamePlaceholders` — quoted + naked + integration with the exact prod line + 3 negative tests confirming real Google API keys, JWTs, and random base64 blobs are still flagged.
- `TestTopLevelDocsAreExamplePaths` — SKILL.md / README.md / CHANGELOG.md at root + in subpaths + lowercase + negative test that random `.md` inside skill code is not auto-downgraded.
- `TestPreExistingPlaceholderCoverageGap` — `abc123`, `123456`, `1234567890` (the previously-broken test cases).
- `TestStage4Integration` — end-to-end scan of a synthetic SKILL.md with the exact bug content asserts **zero critical findings**, plus a positive control where a real Google API key in the same file is still detected.

Plus the **previously-failing** `TestPlaceholderSuppression::test_common_placeholders_are_suppressed[abc123]` now passes.

Targeted scanner suite: **51 passed, 3 unrelated pre-existing failures** (stage3 prose / HTML comments / detect-secrets fallback). Ruff lint + format clean.

## Verification on the prod report

```
Bug line suppressed?  True
SKILL.md is doc path?  True

Real secrets still detected:
  AIzaSyA1234567890abcdefghijklmnopqrstuv: suppressed=False
  sk-proj-aBcDeFgHiJkLmNoPqRsTuVwXyZ012345: suppressed=False
  eyJhbGc.eyJzdWI.signature: suppressed=False
```

## Related

Follow-up to #447 (typosquat false positives → 0.15.6). After this lands and re-tags, `@uriva/p2b-social-media-scraper` will need a rescan to clear its stale CRITICAL finding.