### PR TITLE
fix(registry): exclude stageT findings from security severity counts

### DIFF
--- a/apps/registry/src/lib/skills/data.ts
+++ b/apps/registry/src/lib/skills/data.ts
@@ -16,6 +16,7 @@ import { sql } from 'drizzle-orm';
 import { db } from '~/lib/db';
 import { visibilityClause } from '~/lib/db/visibility';
 import { extractAtomKinds } from '~/lib/skills/atoms';
+import { computeSecurityCounts } from '~/lib/skills/security-counts';
 
 function resolveAtomKinds(column: unknown, manifest: unknown): string[] {
   if (Array.isArray(column) && column.length > 0) return column as string[];
@@ -330,18 +331,25 @@ export async function getSkillDetail(
     }
   }
 
+  const findingsForScanDetails = Array.isArray(scanFindingsJson) ? scanFindingsJson : [];
+  // Recompute severity counts from the actual findings array, excluding
+  // advisory stages (e.g. stageT). The pre-computed counts on scan_results
+  // include all findings, which causes the Security tab to render badges that
+  // do not match its filtered findings list. See security-counts.ts.
+  const securityCounts = computeSecurityCounts(findingsForScanDetails);
+
   const scanDetails: ScanDetails = scanResultJson
     ? {
         verdict: scanResultJson.verdict as string | null,
         stagesRun: Array.isArray(scanResultJson.stagesRun) ? (scanResultJson.stagesRun as string[]) : [],
         durationMs: typeof scanResultJson.durationMs === 'number' ? scanResultJson.durationMs : null,
         scannedAt,
-        findings: Array.isArray(scanFindingsJson) ? scanFindingsJson : [],
-        criticalCount: Number(scanResultJson.criticalCount) || 0,
-        highCount: Number(scanResultJson.highCount) || 0,
-        mediumCount: Number(scanResultJson.mediumCount) || 0,
-        lowCount: Number(scanResultJson.lowCount) || 0,
-        infoCount: Number(scanResultJson.infoCount) || 0,
+        findings: findingsForScanDetails,
+        criticalCount: securityCounts.critical,
+        highCount: securityCounts.high,
+        mediumCount: securityCounts.medium,
+        lowCount: securityCounts.low,
+        infoCount: securityCounts.info,
         llm_analysis:
           scanResultJson.llm_analysis && typeof scanResultJson.llm_analysis === 'object'
             ? (scanResultJson.llm_analysis as LLMAnalysisInfo)

--- a/apps/registry/src/lib/skills/security-counts.test.ts
+++ b/apps/registry/src/lib/skills/security-counts.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression: Security tab severity badges and findings list must agree.
+ *
+ * Bug (prod): @uriva/safescript v0.1.17 displayed "1 medium 3 low" badges
+ * with "Verified Safe — No security issues found" headline AND an empty
+ * findings list. The badges read pre-computed counts from scan_results
+ * (which include every stage), but the findings list filters out advisory
+ * stage 'stageT' (Token Usage Analysis). Token-efficiency findings were
+ * being painted as security severity badges with nothing to drill into.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ADVISORY_STAGES, computeSecurityCounts, isSecurityFinding } from './security-counts';
+
+describe('isSecurityFinding', () => {
+  it('returns true for normal scanner stages', () => {
+    expect(isSecurityFinding({ stage: 'stage0', severity: 'low' })).toBe(true);
+    expect(isSecurityFinding({ stage: 'stage1', severity: 'medium' })).toBe(true);
+    expect(isSecurityFinding({ stage: 'stage5', severity: 'critical' })).toBe(true);
+  });
+
+  it('returns false for advisory stageT (token usage)', () => {
+    expect(isSecurityFinding({ stage: 'stageT', severity: 'medium' })).toBe(false);
+    expect(isSecurityFinding({ stage: 'stageT', severity: 'low' })).toBe(false);
+  });
+
+  it('treats every entry in ADVISORY_STAGES as non-security', () => {
+    for (const stage of ADVISORY_STAGES) {
+      expect(isSecurityFinding({ stage, severity: 'critical' })).toBe(false);
+    }
+  });
+});
+
+describe('computeSecurityCounts', () => {
+  it('returns zero counts for empty input', () => {
+    expect(computeSecurityCounts([])).toEqual({ critical: 0, high: 0, medium: 0, low: 0, info: 0 });
+  });
+
+  it('returns zero counts for null/undefined input', () => {
+    expect(computeSecurityCounts(null)).toEqual({ critical: 0, high: 0, medium: 0, low: 0, info: 0 });
+    expect(computeSecurityCounts(undefined)).toEqual({ critical: 0, high: 0, medium: 0, low: 0, info: 0 });
+  });
+
+  it('counts security-stage findings by severity', () => {
+    const counts = computeSecurityCounts([
+      { stage: 'stage4', severity: 'critical' },
+      { stage: 'stage5', severity: 'critical' },
+      { stage: 'stage2', severity: 'high' },
+      { stage: 'stage3', severity: 'medium' },
+      { stage: 'stage3', severity: 'medium' },
+      { stage: 'stage1', severity: 'low' },
+      { stage: 'stage2', severity: 'info' }
+    ]);
+    expect(counts).toEqual({ critical: 2, high: 1, medium: 2, low: 1, info: 1 });
+  });
+
+  it('excludes stageT findings entirely (the prod regression)', () => {
+    const counts = computeSecurityCounts([
+      { stage: 'stageT', severity: 'medium' },
+      { stage: 'stageT', severity: 'low' },
+      { stage: 'stageT', severity: 'low' },
+      { stage: 'stageT', severity: 'low' }
+    ]);
+    expect(counts).toEqual({ critical: 0, high: 0, medium: 0, low: 0, info: 0 });
+  });
+
+  it('counts only the security half of a mixed findings list', () => {
+    const counts = computeSecurityCounts([
+      { stage: 'stage4', severity: 'critical' },
+      { stage: 'stageT', severity: 'critical' },
+      { stage: 'stage5', severity: 'medium' },
+      { stage: 'stageT', severity: 'medium' },
+      { stage: 'stageT', severity: 'low' }
+    ]);
+    expect(counts).toEqual({ critical: 1, high: 0, medium: 1, low: 0, info: 0 });
+  });
+
+  it('ignores findings with unknown severity values', () => {
+    const counts = computeSecurityCounts([
+      { stage: 'stage4', severity: 'urgent' },
+      { stage: 'stage4', severity: '' },
+      { stage: 'stage4', severity: 'critical' }
+    ]);
+    expect(counts).toEqual({ critical: 1, high: 0, medium: 0, low: 0, info: 0 });
+  });
+
+  it('reproduces the @uriva/safescript prod regression: 4 stageT findings collapse to all-zero security counts', () => {
+    const counts = computeSecurityCounts([
+      { stage: 'stageT', severity: 'medium' },
+      { stage: 'stageT', severity: 'low' },
+      { stage: 'stageT', severity: 'low' },
+      { stage: 'stageT', severity: 'low' }
+    ]);
+    expect(counts.critical + counts.high + counts.medium + counts.low + counts.info).toBe(0);
+  });
+});

--- a/apps/registry/src/lib/skills/security-counts.ts
+++ b/apps/registry/src/lib/skills/security-counts.ts
@@ -1,0 +1,59 @@
+/**
+ * Stages whose findings are advisory and must NOT be counted as security
+ * findings. The Python scanner currently emits one such stage:
+ *
+ *   - ``stageT`` (Token Usage Analysis): per its own docstring,
+ *     "Advisory-only — findings never affect the scan verdict." These are
+ *     surfaced separately on the Token Efficiency tab.
+ *
+ * The Security tab filters these out of the visible findings list, so the
+ * severity badges next to it must use the same filter or the UI will show
+ * "1 medium 3 low" alongside an empty findings table — which is what the
+ * prod regression looked like for ``@uriva/safescript``.
+ */
+export const ADVISORY_STAGES: readonly string[] = ['stageT'];
+
+export interface FindingForCounts {
+  readonly stage: string;
+  readonly severity: string;
+}
+
+export interface SeverityCounts {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  info: number;
+}
+
+export function isSecurityFinding(finding: FindingForCounts): boolean {
+  return !ADVISORY_STAGES.includes(finding.stage);
+}
+
+export function computeSecurityCounts(findings: readonly FindingForCounts[] | null | undefined): SeverityCounts {
+  const counts: SeverityCounts = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  if (!findings) return counts;
+
+  for (const f of findings) {
+    if (!isSecurityFinding(f)) continue;
+    switch (f.severity) {
+      case 'critical':
+        counts.critical++;
+        break;
+      case 'high':
+        counts.high++;
+        break;
+      case 'medium':
+        counts.medium++;
+        break;
+      case 'low':
+        counts.low++;
+        break;
+      case 'info':
+        counts.info++;
+        break;
+    }
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## Summary

Package detail page UI bug: severity badges and the findings list disagreed.

For `@uriva/safescript` v0.1.17:

- **Headline:** \"Verified Safe — No security issues found\"
- **Badges:** \"1 medium 3 low\"
- **Sidebar:** \"1 medium finding, 3 low findings\"
- **Findings list:** EMPTY

## Root cause

The Security tab and the sidebar Security widget both read `scanDetails.criticalCount / highCount / mediumCount / lowCount`, which the data layer copies straight from the pre-computed `scan_results` table columns. The Python scanner populates those columns by counting **all** findings — including `stageT` (Token Usage Analysis).

But `stageT` is **explicitly advisory** (its own docstring: \"Advisory-only — findings never affect the scan verdict\") and the Security tab correctly filters `stageT` out of its findings list (`buildSecurityTab`, line 215). The badges did not get the same treatment.

Result: 4 token-efficiency findings rendered as 1 medium + 3 low security badges with nothing to drill into.

## Fix

New file `apps/registry/src/lib/skills/security-counts.ts` — pure helper:

\`\`\`ts
export const ADVISORY_STAGES: readonly string[] = ['stageT'];
export function computeSecurityCounts(findings): SeverityCounts { ... }
\`\`\`

In `getSkillDetail` (data.ts), recompute counts from the actual findings array using this helper, and use the recomputed values in the `scanDetails` object. This fixes:

- `SecurityOverview` (Security tab top badges + summary text)
- `SkillSidebar` (right-sidebar Security widget)
- `TrustBadge` (uses critical/high/medium counts)

…all in one place because they all consume `scanDetails.{critical,high,medium,low}Count`.

The pre-computed `scan_results.{critical,medium,...}_count` DB columns are left untouched. Fixing them at source would require a Python-scanner change + a DB backfill or full rescan; not necessary for the user-visible bug. Filed mentally as a followup. (Same bug also exists in `top-skills.ts:101` SQL — separate code path, separate followup.)

## Tests

New `apps/registry/src/lib/skills/security-counts.test.ts` — **10 tests, all passing**:

- `isSecurityFinding` — normal stages return true, every advisory stage returns false
- `computeSecurityCounts` — empty/null input, mixed-stage input, severity counting accuracy, unknown-severity values get ignored
- The exact prod regression: 4 stageT findings (1 medium + 3 low) collapse to all-zero security counts

LSP typecheck clean. Biome lint+format clean. Full registry test suite: 87 passed; 4 pre-existing test-file load failures in `dep-audit/__tests__/*` and `external-skills-scan.test.ts` are unrelated Zod-import issues that exist on main.

## Deploy

Frontend-only fix. No scanner/Docker change needed. Vercel auto-deploys from main → nightly.tankpkg.dev and from stable → www.tankpkg.dev. Once this merges and stable picks it up, the @uriva/safescript page will display correctly without a rescan.