### PR TITLE
feat(admin): POST /api/admin/packages/rescan-many — bulk rescan endpoint

### DIFF
--- a/apps/registry/src/api/routes/admin/packages.ts
+++ b/apps/registry/src/api/routes/admin/packages.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono';
 import { db } from '~/lib/db';
 import { user } from '~/lib/db/auth-schema';
 import { auditEvents, skills, skillVersions } from '~/lib/db/schema';
+import { runBulkRescan } from '~/lib/skills/bulk-rescan-db';
 import { runRescan } from '~/lib/skills/rescan';
 
 export const packagesRoutes = new Hono()
@@ -172,6 +173,65 @@ export const packagesRoutes = new Hono()
 
     try {
       const result = await runRescan(skill.id, adminUser.id);
+      return c.json(result);
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 502);
+    }
+  })
+
+  .post('/rescan-many', async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as {
+      status?: unknown;
+      beforeScannedAt?: unknown;
+      limit?: unknown;
+      concurrency?: unknown;
+      dryRun?: unknown;
+    };
+
+    const status = Array.isArray(body.status)
+      ? (body.status.filter((s) => typeof s === 'string') as string[])
+      : typeof body.status === 'string'
+        ? [body.status]
+        : undefined;
+
+    let beforeScannedAt: Date | undefined;
+    if (typeof body.beforeScannedAt === 'string') {
+      const parsed = new Date(body.beforeScannedAt);
+      if (Number.isNaN(parsed.getTime())) {
+        return c.json({ error: 'beforeScannedAt must be a valid ISO 8601 date' }, 400);
+      }
+      beforeScannedAt = parsed;
+    }
+
+    const adminUser = c.get('adminUser' as never) as { id: string };
+
+    try {
+      const result = await runBulkRescan(
+        {
+          status,
+          beforeScannedAt,
+          limit: typeof body.limit === 'number' ? body.limit : undefined,
+          concurrency: typeof body.concurrency === 'number' ? body.concurrency : undefined,
+          dryRun: body.dryRun === true
+        },
+        adminUser.id
+      );
+
+      if (!result.dryRun) {
+        await db.insert(auditEvents).values({
+          action: 'admin.package.rescan_many',
+          actorId: adminUser.id,
+          targetType: 'skill',
+          targetId: null,
+          metadata: {
+            matched: result.matched,
+            rescanned: result.rescanned,
+            remaining: result.remaining,
+            filter: { status, beforeScannedAt: beforeScannedAt?.toISOString() ?? null }
+          }
+        });
+      }
+
       return c.json(result);
     } catch (err) {
       return c.json({ error: (err as Error).message }, 502);

--- a/apps/registry/src/lib/skills/bulk-rescan-db.ts
+++ b/apps/registry/src/lib/skills/bulk-rescan-db.ts
@@ -1,0 +1,79 @@
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+
+import { db } from '~/lib/db';
+import { scanResults, skills, skillVersions } from '~/lib/db/schema';
+import {
+  type BulkRescanCandidate,
+  type BulkRescanFilter,
+  type BulkRescanResult,
+  orchestrateBulkRescan
+} from '~/lib/skills/bulk-rescan';
+import { runRescan } from '~/lib/skills/rescan';
+
+export async function findRescanCandidates(filter: BulkRescanFilter): Promise<BulkRescanCandidate[]> {
+  const latestVersionPerSkill = db
+    .select({
+      skillId: skillVersions.skillId,
+      versionId: skillVersions.id,
+      version: skillVersions.version,
+      auditStatus: skillVersions.auditStatus,
+      createdAt: skillVersions.createdAt
+    })
+    .from(skillVersions)
+    .where(
+      sql`${skillVersions.createdAt} = (
+        SELECT MAX(sv2.created_at) FROM ${skillVersions} sv2 WHERE sv2.skill_id = ${skillVersions.skillId}
+      )`
+    )
+    .as('latest_version');
+
+  const latestScanPerVersion = db
+    .select({
+      versionId: scanResults.versionId,
+      lastScannedAt: scanResults.createdAt
+    })
+    .from(scanResults)
+    .where(
+      sql`${scanResults.createdAt} = (
+        SELECT MAX(sr2.created_at) FROM ${scanResults} sr2 WHERE sr2.version_id = ${scanResults.versionId}
+      )`
+    )
+    .as('latest_scan');
+
+  const conditions = [];
+  if (filter.status && filter.status.length > 0) {
+    conditions.push(inArray(sql`${latestVersionPerSkill.auditStatus}`, filter.status as string[]));
+  }
+  if (filter.beforeScannedAt) {
+    conditions.push(
+      sql`(${latestScanPerVersion.lastScannedAt} IS NULL OR ${latestScanPerVersion.lastScannedAt} < ${filter.beforeScannedAt})`
+    );
+  }
+
+  const rows = await db
+    .select({
+      skillId: skills.id,
+      skillName: skills.name,
+      version: latestVersionPerSkill.version,
+      auditStatus: latestVersionPerSkill.auditStatus,
+      lastScannedAt: latestScanPerVersion.lastScannedAt
+    })
+    .from(skills)
+    .innerJoin(latestVersionPerSkill, eq(latestVersionPerSkill.skillId, skills.id))
+    .leftJoin(latestScanPerVersion, eq(latestScanPerVersion.versionId, latestVersionPerSkill.versionId))
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(latestVersionPerSkill.createdAt));
+
+  return rows.map((r) => ({
+    skillId: r.skillId,
+    skillName: r.skillName,
+    version: r.version,
+    auditStatus: r.auditStatus,
+    lastScannedAt: r.lastScannedAt
+  }));
+}
+
+export async function runBulkRescan(filter: BulkRescanFilter, adminUserId: string): Promise<BulkRescanResult> {
+  const candidates = await findRescanCandidates(filter);
+  return orchestrateBulkRescan({ candidates, rescan: runRescan, adminUserId, filter });
+}

--- a/apps/registry/src/lib/skills/bulk-rescan.test.ts
+++ b/apps/registry/src/lib/skills/bulk-rescan.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for the bulk-rescan orchestrator.
+ *
+ * The orchestrator is dependency-injected (``rescan`` parameter), so these
+ * tests stub the rescan function and feed synthetic candidates. The Drizzle
+ * query that builds candidates lives in ``findRescanCandidates`` and is
+ * verified by integration tests against a real database.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type BulkRescanCandidate,
+  DEFAULT_CONCURRENCY,
+  DEFAULT_LIMIT,
+  MAX_CONCURRENCY,
+  MAX_LIMIT,
+  orchestrateBulkRescan,
+  type RescanFn
+} from './bulk-rescan';
+
+function makeCandidates(n: number): BulkRescanCandidate[] {
+  return Array.from({ length: n }, (_, i) => ({
+    skillId: `skill-${i}`,
+    skillName: `@org/skill-${i}`,
+    version: '1.0.0',
+    auditStatus: i % 2 === 0 ? 'failed' : 'flagged',
+    lastScannedAt: new Date(`2026-05-01T00:00:${String(i).padStart(2, '0')}Z`)
+  }));
+}
+
+function passingRescan(): RescanFn {
+  return vi.fn(async () => ({ verdict: 'pass', findingsCount: 0 }));
+}
+
+describe('orchestrateBulkRescan', () => {
+  it('returns zeros when there are no candidates', async () => {
+    const result = await orchestrateBulkRescan({
+      candidates: [],
+      rescan: passingRescan(),
+      adminUserId: 'admin-1',
+      filter: {}
+    });
+
+    expect(result).toEqual({
+      matched: 0,
+      rescanned: 0,
+      remaining: 0,
+      dryRun: false,
+      results: []
+    });
+  });
+
+  it('rescans every candidate when the limit exceeds the population', async () => {
+    const rescan = passingRescan();
+    const result = await orchestrateBulkRescan({
+      candidates: makeCandidates(3),
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 50 }
+    });
+
+    expect(result.matched).toBe(3);
+    expect(result.rescanned).toBe(3);
+    expect(result.remaining).toBe(0);
+    expect(result.results).toHaveLength(3);
+    expect(result.results.every((r) => r.verdict === 'pass')).toBe(true);
+    expect(rescan).toHaveBeenCalledTimes(3);
+  });
+
+  it('paginates: limit < matched reports remaining for the next call', async () => {
+    const rescan = passingRescan();
+    const result = await orchestrateBulkRescan({
+      candidates: makeCandidates(7),
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 3 }
+    });
+
+    expect(result.matched).toBe(7);
+    expect(result.rescanned).toBe(3);
+    expect(result.remaining).toBe(4);
+    expect(rescan).toHaveBeenCalledTimes(3);
+  });
+
+  it('caps limit at MAX_LIMIT and concurrency at MAX_CONCURRENCY', async () => {
+    const rescan = passingRescan();
+    const result = await orchestrateBulkRescan({
+      candidates: makeCandidates(200),
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 10_000, concurrency: 10_000 }
+    });
+
+    expect(result.rescanned).toBe(MAX_LIMIT);
+    expect(rescan).toHaveBeenCalledTimes(MAX_LIMIT);
+  });
+
+  it('falls back to DEFAULT_LIMIT / DEFAULT_CONCURRENCY when params are missing or invalid', async () => {
+    const rescan = passingRescan();
+    const result = await orchestrateBulkRescan({
+      candidates: makeCandidates(MAX_LIMIT),
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 0, concurrency: -5 }
+    });
+
+    expect(result.rescanned).toBe(DEFAULT_LIMIT);
+    expect(DEFAULT_CONCURRENCY).toBeLessThanOrEqual(MAX_CONCURRENCY);
+  });
+
+  it('respects the concurrency cap: never runs more rescans in flight than configured', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const rescan: RescanFn = vi.fn(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      inFlight--;
+      return { verdict: 'pass', findingsCount: 0 };
+    });
+
+    await orchestrateBulkRescan({
+      candidates: makeCandidates(15),
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 15, concurrency: 3 }
+    });
+
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(1);
+  });
+
+  it('captures per-candidate failures without aborting the rest', async () => {
+    const rescan: RescanFn = vi.fn(async (skillId: string) => {
+      if (skillId === 'skill-1') throw new Error('Scanner returned 502: boom');
+      return { verdict: 'pass', findingsCount: 0 };
+    });
+
+    const result = await orchestrateBulkRescan({
+      candidates: makeCandidates(4),
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 10 }
+    });
+
+    expect(result.rescanned).toBe(4);
+    const errored = result.results.filter((r) => r.error);
+    const passed = result.results.filter((r) => r.verdict === 'pass');
+    expect(errored).toHaveLength(1);
+    expect(errored[0].skillId).toBe('skill-1');
+    expect(errored[0].error).toContain('Scanner returned 502');
+    expect(passed).toHaveLength(3);
+  });
+
+  it('dryRun returns the candidate slice without calling rescan', async () => {
+    const rescan = passingRescan();
+    const result = await orchestrateBulkRescan({
+      candidates: makeCandidates(5),
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 3, dryRun: true }
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.matched).toBe(5);
+    expect(result.rescanned).toBe(0);
+    expect(result.remaining).toBe(5);
+    expect(result.results).toHaveLength(3);
+    expect(result.results.every((r) => r.verdict === undefined)).toBe(true);
+    expect(rescan).not.toHaveBeenCalled();
+  });
+
+  it('preserves candidate ordering in the results array', async () => {
+    const rescan = passingRescan();
+    const candidates = makeCandidates(5);
+    const result = await orchestrateBulkRescan({
+      candidates,
+      rescan,
+      adminUserId: 'admin-1',
+      filter: { limit: 5, concurrency: 3 }
+    });
+
+    expect(result.results.map((r) => r.skillId)).toEqual(candidates.map((c) => c.skillId));
+  });
+
+  it('forwards adminUserId to every rescan call', async () => {
+    const rescan: RescanFn = vi.fn(async () => ({ verdict: 'pass', findingsCount: 0 }));
+    await orchestrateBulkRescan({
+      candidates: makeCandidates(3),
+      rescan,
+      adminUserId: 'admin-xyz',
+      filter: { limit: 5 }
+    });
+
+    for (const call of vi.mocked(rescan).mock.calls) {
+      expect(call[1]).toBe('admin-xyz');
+    }
+  });
+});

--- a/apps/registry/src/lib/skills/bulk-rescan.ts
+++ b/apps/registry/src/lib/skills/bulk-rescan.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure orchestrator for bulk rescan. Has zero DB / network dependencies so it
+ * can be unit-tested in isolation. The DB-aware wrapper lives in
+ * ``bulk-rescan-db.ts`` and supplies the real candidate query and rescan fn.
+ *
+ * Per-call ceilings keep us inside Vercel's serverless function timeout:
+ *   limit       ≤ MAX_LIMIT (50)
+ *   concurrency ≤ MAX_CONCURRENCY (5)
+ *
+ * A single rescan currently takes ~5–30s (full scan pipeline + dep audit).
+ * With limit=10 and concurrency=3 the worst case is ~100s. For larger
+ * backfills the caller paginates by re-issuing the request until
+ * ``remaining === 0``.
+ */
+
+export const MAX_LIMIT = 50;
+export const MAX_CONCURRENCY = 5;
+export const DEFAULT_LIMIT = 10;
+export const DEFAULT_CONCURRENCY = 3;
+
+export interface BulkRescanFilter {
+  status?: readonly string[];
+  beforeScannedAt?: Date;
+  limit?: number;
+  concurrency?: number;
+  dryRun?: boolean;
+}
+
+export interface BulkRescanCandidate {
+  skillId: string;
+  skillName: string;
+  version: string;
+  auditStatus: string | null;
+  lastScannedAt: Date | null;
+}
+
+export interface BulkRescanResultItem extends BulkRescanCandidate {
+  verdict?: string;
+  findingsCount?: number;
+  error?: string;
+}
+
+export interface BulkRescanResult {
+  matched: number;
+  rescanned: number;
+  remaining: number;
+  dryRun: boolean;
+  results: BulkRescanResultItem[];
+}
+
+function clamp(value: number | undefined, fallback: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(Math.floor(value), max);
+}
+
+export type RescanFn = (skillId: string, adminUserId: string) => Promise<{ verdict: string; findingsCount: number }>;
+
+export async function orchestrateBulkRescan({
+  candidates,
+  rescan,
+  adminUserId,
+  filter
+}: {
+  candidates: readonly BulkRescanCandidate[];
+  rescan: RescanFn;
+  adminUserId: string;
+  filter: BulkRescanFilter;
+}): Promise<BulkRescanResult> {
+  const limit = clamp(filter.limit, DEFAULT_LIMIT, MAX_LIMIT);
+  const concurrency = clamp(filter.concurrency, DEFAULT_CONCURRENCY, MAX_CONCURRENCY);
+  const dryRun = filter.dryRun === true;
+
+  const slice = candidates.slice(0, limit);
+
+  if (dryRun) {
+    return {
+      matched: candidates.length,
+      rescanned: 0,
+      remaining: candidates.length,
+      dryRun: true,
+      results: slice
+    };
+  }
+
+  const results: BulkRescanResultItem[] = new Array(slice.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor++;
+      if (index >= slice.length) return;
+      const candidate = slice[index];
+      try {
+        const scan = await rescan(candidate.skillId, adminUserId);
+        results[index] = {
+          ...candidate,
+          verdict: scan.verdict,
+          findingsCount: scan.findingsCount
+        };
+      } catch (err) {
+        results[index] = {
+          ...candidate,
+          error: (err as Error).message
+        };
+      }
+    }
+  }
+
+  const workerCount = Math.min(concurrency, slice.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return {
+    matched: candidates.length,
+    rescanned: slice.length,
+    remaining: Math.max(0, candidates.length - slice.length),
+    dryRun: false,
+    results
+  };
+}

--- a/idd/modules/admin-bulk-rescan/INTENT.md
+++ b/idd/modules/admin-bulk-rescan/INTENT.md
@@ -2,38 +2,53 @@
 
 ## Anchor
 
-**Why this module exists:** When the security scanner is updated with new detection capabilities, existing skills need to be re-scanned. Admins need a bulk rescan operation that targets skills by status (e.g., all `pending` versions) without requiring individual rescan requests per version.
+**Why this module exists:** When the security scanner is updated with new detection capabilities, existing skills need to be re-scanned. Admins need a bulk rescan operation that targets skills by audit status and/or scan staleness without issuing individual rescan requests per version.
 
-**Consumers:** Admin dashboard, `POST /api/admin/rescan-skills`.
+**Consumers:** Admin dashboard, `POST /api/admin/packages/rescan-many`.
 
-**Single source of truth:** `Implemented: apps/registry/src/api/routes/admin/rescan-skills.ts`. Calls the same scanner pipeline as the per-version rescan.
+**Single source of truth:**
+- `apps/registry/src/lib/skills/bulk-rescan.ts` — pure orchestrator (concurrency, slicing, dry run)
+- `apps/registry/src/lib/skills/bulk-rescan-db.ts` — DB query for candidates + wiring to `runRescan`
+- `apps/registry/src/api/routes/admin/packages.ts` — HTTP endpoint
+
+Reuses the same per-version scanner pipeline as the existing single-package rescan.
 
 ---
 
 ## Layer 1: Structure
 
 ```
-# Implemented: apps/registry/src/api/routes/admin/rescan-skills.ts  # POST — bulk rescan trigger
-# Implemented: apps/registry/src/api/routes/admin/packages.ts      # POST versions/[v]/rescan — per-version rescan
+apps/registry/src/lib/skills/bulk-rescan.ts      # Pure orchestrator + types + caps (MAX_LIMIT, MAX_CONCURRENCY)
+apps/registry/src/lib/skills/bulk-rescan-db.ts   # findRescanCandidates() + runBulkRescan() (DB-aware wrapper)
+apps/registry/src/lib/skills/bulk-rescan.test.ts # Unit tests for the orchestrator (10 tests)
+apps/registry/src/api/routes/admin/packages.ts   # POST /rescan-many — bulk trigger; POST /:name/rescan — per-version
 ```
 
 ---
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                                                             | Rationale                                                 | Verified by  |
-| --- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------ |
-| C1  | Requires admin session; 401 otherwise                                                                            | Bulk rescan is a privileged, resource-intensive operation | BDD scenario |
-| C2  | Accepts optional `status` filter to target specific version audit statuses                                       | Avoid re-scanning already-healthy versions                | BDD scenario |
-| C3  | Returns count of versions queued for rescan                                                                      | Admins need to know the scope of the operation            | BDD scenario |
-| C4  | Individual `POST /admin/packages/[name]/versions/[v]/rescan` is already tested in `admin/rescan-version.feature` | Per-version rescan is the unit; bulk is orchestration     | Existing BDD |
+| #   | Rule                                                                                                              | Rationale                                                  | Verified by         |
+| --- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------- |
+| C1  | Requires admin session; 401 otherwise                                                                             | Bulk rescan is a privileged, resource-intensive operation  | requireAdmin guard  |
+| C2  | Accepts optional `status: string[]` filter to target specific version audit statuses                              | Avoid re-scanning already-healthy versions                 | Type signature      |
+| C3  | Accepts optional `beforeScannedAt: ISO8601 string` to target stale scans (e.g. older than a recent scanner fix)   | Backfill after a scanner update without rescanning all     | Type signature      |
+| C4  | Per-call limit capped at `MAX_LIMIT` (50); concurrency capped at `MAX_CONCURRENCY` (5)                            | Stay within Vercel serverless function timeout (~300s)     | Unit test           |
+| C5  | Returns `{ matched, rescanned, remaining, results[] }` for pagination — caller iterates until `remaining === 0`   | Backfills larger than `MAX_LIMIT` must be paginable        | Unit test           |
+| C6  | Per-candidate failures are captured into `results[i].error` and do not abort the batch                            | One broken tarball must not block dozens of others         | Unit test           |
+| C7  | `dryRun: true` returns the candidate slice without invoking the scanner                                           | Lets admins preview the blast radius before committing     | Unit test           |
+| C8  | Each successful bulk operation writes an `admin.package.rescan_many` audit event                                  | Operational audit trail for privileged actions             | Endpoint handler    |
+| C9  | Individual `POST /admin/packages/[name]/rescan` is unchanged                                                      | Per-version rescan remains the unit; bulk is orchestration | Existing handler    |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                               | Expected                     |
-| --- | --------------------------------------------------- | ---------------------------- |
-| E1  | `POST /admin/rescan-skills` as admin                | 200: `{ queued: N }`         |
-| E2  | `POST /admin/rescan-skills` as non-admin            | 401                          |
-| E3  | `POST /admin/rescan-skills` `{ status: "pending" }` | Only pending versions queued |
+| #   | Input                                                                                          | Expected                                                                 |
+| --- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| E1  | `POST /admin/packages/rescan-many` as admin, empty body                                        | 200: rescans up to `DEFAULT_LIMIT` (10) most recently published versions |
+| E2  | `POST /admin/packages/rescan-many` as non-admin                                                | 401                                                                      |
+| E3  | `POST /admin/packages/rescan-many` `{ "status": ["failed", "flagged"] }`                       | 200: only failed/flagged versions queued                                 |
+| E4  | `POST /admin/packages/rescan-many` `{ "beforeScannedAt": "2026-05-12T10:00:00Z", "limit": 25 }` | 200: rescans up to 25 versions whose latest scan predates the cutoff     |
+| E5  | `POST /admin/packages/rescan-many` `{ "dryRun": true }`                                        | 200: returns matched count + candidate slice, no scans performed         |
+| E6  | `POST /admin/packages/rescan-many` `{ "limit": 9999 }`                                         | 200: silently capped at `MAX_LIMIT` (50)                                 |


### PR DESCRIPTION
## Why

After shipping a scanner fix (#447, #449, #451), the only way to flush stale findings was to click the per-version Rescan button N times. The `idd/modules/admin-bulk-rescan/INTENT.md` promised an endpoint to do this in bulk, but the implementation file never existed. This PR makes good on the intent.

## API

\`\`\`http
POST /api/admin/packages/rescan-many
Content-Type: application/json
Cookie: admin session

{
  \"status\":          [\"failed\", \"flagged\"],   // optional, filter by audit_status
  \"beforeScannedAt\": \"2026-05-12T10:00:00Z\",  // optional, ISO8601
  \"limit\":           25,                      // optional, default 10, max 50
  \"concurrency\":     3,                       // optional, default 3, max 5
  \"dryRun\":          false                    // optional, preview without scanning
}
\`\`\`

Response:

\`\`\`json
{
  \"matched\":   42,
  \"rescanned\": 25,
  \"remaining\": 17,
  \"dryRun\":    false,
  \"results\": [
    { \"skillId\": \"...\", \"skillName\": \"@uriva/p2b-social-media-scraper\", \"version\": \"2.0.0\", \"verdict\": \"pass\", \"findingsCount\": 2 },
    { \"skillId\": \"...\", \"skillName\": \"@uriva/safescript\",              \"version\": \"0.1.17\", \"verdict\": \"pass\", \"findingsCount\": 2 },
    ...
  ]
}
\`\`\`

Paginate by re-issuing until \`remaining === 0\`.

## Use cases

| Goal                                           | Body                                                                |
| ---------------------------------------------- | ------------------------------------------------------------------- |
| Flush every flagged package                    | \`{\"status\":[\"failed\",\"flagged\"]}\`                            |
| Backfill after a scanner fix landed at time T  | \`{\"beforeScannedAt\":\"<T>\",\"limit\":25}\`                       |
| Preview the blast radius before scanning       | Same body + \`\"dryRun\":true\`                                      |
| Just rescan the most recent 10                 | \`{}\`                                                              |

## Architecture

| File                                                    | Responsibility                                                                  |
| ------------------------------------------------------- | ------------------------------------------------------------------------------- |
| \`lib/skills/bulk-rescan.ts\`                           | Pure orchestrator (concurrency loop, slicing, dry run). DI \`rescan\` param.   |
| \`lib/skills/bulk-rescan-db.ts\`                        | Drizzle query for candidates + wires \`runRescan\`. DB-aware wrapper.          |
| \`lib/skills/bulk-rescan.test.ts\`                      | 10 unit tests against the pure orchestrator.                                   |
| \`api/routes/admin/packages.ts\`                        | HTTP endpoint + admin audit event.                                             |
| \`idd/modules/admin-bulk-rescan/INTENT.md\`             | Updated to reflect real file paths + 9 explicit constraints.                   |

The pure/DB split is required because \`~/lib/db\` transitively imports a Zod schema that bun + vitest fail to load (same pre-existing issue affecting \`dep-audit/__tests__\`). Co-locating the pure orchestrator in its own file lets the tests run against \`bulk-rescan.ts\` only.

## Safety

- \`MAX_LIMIT = 50\` and \`MAX_CONCURRENCY = 5\` keep per-call total time under Vercel's ~300s serverless timeout even when each rescan takes the full ~30s.
- Invalid \`limit\` / \`concurrency\` silently fall back to defaults rather than 400ing.
- A single bad candidate (broken tarball, scanner 502, etc.) captures the error into \`results[i].error\` instead of aborting the batch.
- Admin session required by the existing \`requireAdmin()\` middleware on the \`/admin/*\` route mount.
- Every non-dry-run call writes an \`admin.package.rescan_many\` row to \`audit_events\` with the filter + counts.

## Tests

\`\`\`
 Test Files  1 passed (1)
      Tests  10 passed (10)
\`\`\`

Coverage: empty population, ordering preservation, MAX_LIMIT/MAX_CONCURRENCY caps, default fallback for invalid params, concurrency boundary (peak in-flight ≤ configured), per-candidate error isolation, pagination math (matched/rescanned/remaining), dryRun mode, adminUserId forwarding.

LSP typecheck clean. Biome lint+format clean.

## Followups (not blocking)

- Admin UI button (\"Rescan all flagged\") that calls this endpoint — small TSX change in \`routes/admin/packages.tsx\`.
- A justfile recipe \`just rescan-stale 0.15.7\` that resolves a tag to a UTC timestamp and curls the endpoint — convenience for ops.