### PR TITLE
feat(cli,adapters,schemas): fix MCP publishing for non-Node servers + add publish lifecycle hooks (#453, #454)

### DIFF
--- a/apps/registry/public/docs/cli.md
+++ b/apps/registry/public/docs/cli.md
@@ -134,7 +134,7 @@ tank install [name] [version-range]
 
 Remove an installed skill
 
-**Aliases:** `rm`, `r`
+**Aliases:** `rm`, `r`, `uninstall`
 
 ```bash
 tank remove <name>
@@ -378,7 +378,7 @@ tank upgrade [version]
 | `tank logout` | — | Remove authentication token from config |
 | `tank publish` | `pub` | Pack and publish a skill to the Tank registry |
 | `tank install` | `i` | Install a skill from the Tank registry, a URL, or all skills from lockfile |
-| `tank remove` | `rm`, `r` | Remove an installed skill |
+| `tank remove` | `rm`, `r`, `uninstall` | Remove an installed skill |
 | `tank update` | `up` | Update skills to latest versions within their ranges |
 | `tank verify` | — | Verify installed skills match the lockfile |
 | `tank permissions` | `perms` | Display resolved permission summary for installed skills |

--- a/apps/registry/public/llms-full.txt
+++ b/apps/registry/public/llms-full.txt
@@ -1805,7 +1805,7 @@ tank install [name] [version-range]
 
 Remove an installed skill
 
-**Aliases:** `rm`, `r`
+**Aliases:** `rm`, `r`, `uninstall`
 
 ```bash
 tank remove <name>
@@ -2049,7 +2049,7 @@ tank upgrade [version]
 | `tank logout` | — | Remove authentication token from config |
 | `tank publish` | `pub` | Pack and publish a skill to the Tank registry |
 | `tank install` | `i` | Install a skill from the Tank registry, a URL, or all skills from lockfile |
-| `tank remove` | `rm`, `r` | Remove an installed skill |
+| `tank remove` | `rm`, `r`, `uninstall` | Remove an installed skill |
 | `tank update` | `up` | Update skills to latest versions within their ranges |
 | `tank verify` | — | Verify installed skills match the lockfile |
 | `tank permissions` | `perms` | Display resolved permission summary for installed skills |
@@ -8407,7 +8407,9 @@ Source: https://tankpkg.dev/docs/vault
 
 # Credential Vault
 
-Tank Vault is a **format-preserving tokenization proxy** that sits between your AI agent and the LLM provider. It intercepts outgoing requests, replaces real credentials with structurally identical fakes, and restores them in responses — so the model never sees your actual API keys, database URLs, or tokens.
+**Tank Vault prevents your real API keys, database URLs, and tokens from ever reaching LLM providers.** Your AI agent runs normally — but every outgoing request is silently swapped to use look-alike fakes before it leaves your machine, then swapped back on the way home so your code still works.
+
+Real credentials never enter provider logs. A prompt-injected skill cannot exfiltrate them. An LLM-provider breach reveals nothing useful from your infrastructure.
 
 <svg viewBox="0 0 800 250" xmlns="http://www.w3.org/2000/svg" class="max-w-full" style="font-family: 'Space Grotesk', sans-serif;">
   <defs>
@@ -8484,6 +8486,8 @@ Tank Vault eliminates this entire attack class. Real credentials never leave you
 ---
 
 ## How It Works
+
+Tank Vault is implemented as a **format-preserving tokenization proxy** — a transparent intermediary that sits between your agent and any HTTP endpoint. It detects credentials in outgoing traffic, swaps them for structurally identical placeholders, and restores the originals when the provider responds.
 
 ### 1. Credential Detection
 

--- a/bdd/features/system/atom-architecture/tool-runtimes.feature
+++ b/bdd/features/system/atom-architecture/tool-runtimes.feature
@@ -1,0 +1,48 @@
+# Intent: idd/modules/atom-architecture/INTENT.md
+# Layer: Examples E24-E27 (issue #453)
+# Executable verification: packages/adapters/src/__tests__/tool-runtimes.test.ts
+
+@atom-architecture
+@mcp
+Feature: Non-Node MCP tool atoms compile to real client config
+  As a skill author publishing a Python (uvx) or other non-Node MCP server
+  I need Tank adapters to emit usable MCP config for OpenCode, Claude Code,
+  Cursor, Windsurf, Cline, and Roo Code
+  So that my tool registers with the AI agent instead of being silently
+  dropped as instruction-only.
+
+  @high
+  Scenario: Tool atom with mcp.runtime "uvx" compiles to uvx command (E24)
+    Given a tool atom { name: "web-search", mcp: { runtime: "uvx", package: "web-search-mcp" } }
+    When the OpenCode adapter compiles it
+    Then a single file is written at ".opencode/mcp/web-search.json"
+    And the file's "smoke-search.command" is ["uvx", "web-search-mcp"]
+    And no warnings are emitted
+
+  @high
+  Scenario: Tool atom with mcp.runtime "npx" prepends "-y" for non-interactive use (E25)
+    Given a tool atom { name: "tool-x", mcp: { runtime: "npx", package: "my-mcp", args: ["--flag"] } }
+    When the Claude Code adapter compiles it
+    Then ".mcp.json" contains command "npx" and args ["-y", "my-mcp", "--flag"]
+
+  @high
+  Scenario: extensions.<adapter> bag provides MCP command when no canonical mcp block (E26)
+    Given a tool atom whose only config is extensions.opencode = { command: "uvx", args: ["memory-mcp"], env: { KEY: "x" } }
+    When the OpenCode adapter compiles it
+    Then ".opencode/mcp/memory.json" contains command ["uvx", "memory-mcp"]
+    And the file contains environment { KEY: "x" }
+    And NO "has no MCP config" warning is emitted
+
+  @medium
+  Scenario: A tool with neither mcp nor matching extensions still emits a skipped warning (E27)
+    Given a tool atom with no mcp block and no extensions.opencode
+    When the OpenCode adapter compiles it
+    Then no files are written
+    And exactly one skipped warning is emitted
+
+  @medium
+  Scenario: Extension bag is adapter-scoped — extensions.cursor does not affect opencode
+    Given a tool atom with only extensions.cursor = { command: "uvx", args: ["x"] }
+    When the OpenCode adapter compiles it
+    Then no files are written
+    And a skipped warning is emitted

--- a/bdd/features/system/publish/lifecycle-hooks.feature
+++ b/bdd/features/system/publish/lifecycle-hooks.feature
@@ -1,0 +1,43 @@
+# Intent: idd/modules/publish/INTENT.md
+# Layer: Constraints C13-C15, Examples E11-E13 (issue #454)
+# Executable verification: packages/cli/src/__tests__/publish-lifecycle.test.ts
+
+@publish
+@lifecycle-hooks
+Feature: publish.build and publish.files lifecycle hooks
+  As a skill author shipping a compiled package (e.g. TypeScript -> dist/)
+  I need tank.json to declare a pre-publish build command and an explicit
+  files allow-list
+  So that "tank publish" is a single idempotent command that cannot
+  accidentally ship a broken or incomplete tarball.
+
+  @high
+  Scenario: publish.build runs before packing and aborts on failure (C13, E11)
+    Given a tank.json containing "publish": { "build": "exit 1" }
+    When I run "tank publish"
+    Then the build hook is executed before pack
+    And the publish aborts before any upload is attempted
+    And the CLI exits non-zero
+
+  @high
+  Scenario: publish.files restricts the tarball to declared globs (C14, E12)
+    Given a tank.json with publish.files = ["dist/**", "SKILL.md"]
+    And a directory containing tank.json, SKILL.md, src/index.ts, dist/main.js, and .gitignore listing "dist/"
+    When I run "tank publish --dry-run"
+    Then the tarball contains tank.json, SKILL.md, and dist/main.js
+    And the tarball does NOT contain src/index.ts
+    And the tarball does NOT contain anything under node_modules or .git regardless of globs
+
+  @medium
+  Scenario: publish.build and publish.files compose; publish key is stripped from outbound manifest (C15, E13)
+    Given a tank.json with both publish.build = "npm run build" and publish.files = ["dist/**"]
+    When I run "tank publish"
+    Then the build hook runs first
+    And on build success the packer applies the files allow-list
+    And the manifest body POSTed to /api/v1/skills has no "publish" key
+
+  @medium
+  Scenario: Manifest without publish block keeps legacy .tankignore/.gitignore behavior (backwards compat)
+    Given a tank.json with no publish block
+    When I run "tank publish --dry-run"
+    Then the packer respects .tankignore then .gitignore then defaults exactly as before

--- a/bdd/qa/resolutions/2026-05-20-mcp-publish-453-454.md
+++ b/bdd/qa/resolutions/2026-05-20-mcp-publish-453-454.md
@@ -1,0 +1,46 @@
+# Resolution — Issues #453 + #454
+
+Date: 2026-05-20
+Branch: `fix/mcp-publish-453-454`
+
+## Issue #453 — Non-Node MCP runtime support
+
+### Root cause
+- `toolIRSchema` accepted an `extensions` bag but the Zod refine demanded `command` OR (`runtime` + `entry`). The `extensions` field was never consulted by any adapter; `runtime: "uvx"` produced "no MCP config" because the adapter checked `if (!atom.mcp)` and the canonical block was missing.
+- All 6 adapters (opencode, claude-code, cursor, windsurf, cline, roo-code) hard-skipped non-Node tool atoms.
+
+### Fix
+1. Extend `mcpServerConfigSchema` to accept `package` and relax the refine: `command` OR (`runtime` + (`entry` OR `package`)).
+2. Add `packages/adapters/src/adapters/_mcp-resolution.ts` with `resolveMcpCommand(atom, adapterName)` that:
+   - Translates `mcp.runtime: "uvx"|"npx"|"bunx"|"pipx"|"node"|"python"` + `package`/`entry` into `{command, args, env}`.
+   - Falls back to `atom.extensions[adapterName]` when no canonical `mcp` block exists.
+   - Returns `null` only when neither path applies — adapters then emit the existing skipped warning.
+3. Wire `resolveMcpCommand` into every `emitTool` in the 6 adapters.
+
+### Verification
+- 25 new unit tests in `packages/adapters/src/__tests__/tool-runtimes.test.ts` exercising every (adapter × scenario) pair.
+- 6 schema tests in `packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts`.
+- End-to-end smoke (recorded in this commit log): a fixture using `mcp.runtime: uvx` + extensions fallback compiled to correct `.opencode/mcp/*.json` and `.mcp.json` via the built CLI/adapters.
+
+## Issue #454 — Publish lifecycle hooks
+
+### Root cause
+- `pack()` had no way to run a pre-pack command.
+- The only way to include gitignored `dist/` was to write a `.tankignore` overriding `.gitignore`. Fragile and easy to misconfigure (e.g. `src/` pattern accidentally matching `dist/src/`).
+
+### Fix
+1. Add optional `publish` block to `publishManifestSchema`: `{ build?: string, files?: string[] }`.
+2. New `packages/cli/src/lib/build-hook.ts` — `runBuildHook(directory, command)` spawns `shell -c <command>` with `stdio: 'inherit'`, rejects on non-zero exit.
+3. `pack()` accepts `{ files?: string[] }` second arg; when present, ignores `.tankignore`/`.gitignore`/defaults and packs only allow-listed files plus the manifest + SKILL.md/README.md if present. Security baseline (`node_modules`, `.git`) is still enforced.
+4. `publishCommand` reads `publish.{build,files}` from the manifest, runs the build hook before pack, and strips the `publish` key from the manifest body sent to `/api/v1/skills` (CLI-only concern, server has no business knowing about it).
+
+### Verification
+- 6 new unit tests in `packages/cli/src/__tests__/publish-lifecycle.test.ts` using real spawn and real filesystem (no mocks).
+- 5 schema tests in `packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts` (`publishManifestSchema` block).
+- End-to-end smoke: built CLI ran `tank publish --dry-run` on a fixture with `dist/` gitignored, `publish.build` creating `dist/main.js`, and `publish.files = ["dist/**","SKILL.md"]`. Tarball file list = `["tank.json","dist/main.js","SKILL.md"]`. `src.ts` was correctly excluded despite no `.tankignore`.
+
+## Regression evidence
+- packages/internals-schemas: 98/98 passing.
+- packages/adapters: 25/25 passing (only test suite — previously had none).
+- packages/cli: 549/549 passing. Two existing tests in `publish.test.ts` updated for the new `pack(dir, options)` signature.
+- `tsc --noEmit` clean across all three changed packages.

--- a/bdd/qa/resolutions/2026-05-20-mcp-publish-453-454.md
+++ b/bdd/qa/resolutions/2026-05-20-mcp-publish-453-454.md
@@ -6,10 +6,12 @@ Branch: `fix/mcp-publish-453-454`
 ## Issue #453 — Non-Node MCP runtime support
 
 ### Root cause
+
 - `toolIRSchema` accepted an `extensions` bag but the Zod refine demanded `command` OR (`runtime` + `entry`). The `extensions` field was never consulted by any adapter; `runtime: "uvx"` produced "no MCP config" because the adapter checked `if (!atom.mcp)` and the canonical block was missing.
 - All 6 adapters (opencode, claude-code, cursor, windsurf, cline, roo-code) hard-skipped non-Node tool atoms.
 
 ### Fix
+
 1. Extend `mcpServerConfigSchema` to accept `package` and relax the refine: `command` OR (`runtime` + (`entry` OR `package`)).
 2. Add `packages/adapters/src/adapters/_mcp-resolution.ts` with `resolveMcpCommand(atom, adapterName)` that:
    - Translates `mcp.runtime: "uvx"|"npx"|"bunx"|"pipx"|"node"|"python"` + `package`/`entry` into `{command, args, env}`.
@@ -18,6 +20,7 @@ Branch: `fix/mcp-publish-453-454`
 3. Wire `resolveMcpCommand` into every `emitTool` in the 6 adapters.
 
 ### Verification
+
 - 25 new unit tests in `packages/adapters/src/__tests__/tool-runtimes.test.ts` exercising every (adapter × scenario) pair.
 - 6 schema tests in `packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts`.
 - End-to-end smoke (recorded in this commit log): a fixture using `mcp.runtime: uvx` + extensions fallback compiled to correct `.opencode/mcp/*.json` and `.mcp.json` via the built CLI/adapters.
@@ -25,21 +28,25 @@ Branch: `fix/mcp-publish-453-454`
 ## Issue #454 — Publish lifecycle hooks
 
 ### Root cause
+
 - `pack()` had no way to run a pre-pack command.
 - The only way to include gitignored `dist/` was to write a `.tankignore` overriding `.gitignore`. Fragile and easy to misconfigure (e.g. `src/` pattern accidentally matching `dist/src/`).
 
 ### Fix
+
 1. Add optional `publish` block to `publishManifestSchema`: `{ build?: string, files?: string[] }`.
 2. New `packages/cli/src/lib/build-hook.ts` — `runBuildHook(directory, command)` spawns `shell -c <command>` with `stdio: 'inherit'`, rejects on non-zero exit.
 3. `pack()` accepts `{ files?: string[] }` second arg; when present, ignores `.tankignore`/`.gitignore`/defaults and packs only allow-listed files plus the manifest + SKILL.md/README.md if present. Security baseline (`node_modules`, `.git`) is still enforced.
 4. `publishCommand` reads `publish.{build,files}` from the manifest, runs the build hook before pack, and strips the `publish` key from the manifest body sent to `/api/v1/skills` (CLI-only concern, server has no business knowing about it).
 
 ### Verification
+
 - 6 new unit tests in `packages/cli/src/__tests__/publish-lifecycle.test.ts` using real spawn and real filesystem (no mocks).
 - 5 schema tests in `packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts` (`publishManifestSchema` block).
 - End-to-end smoke: built CLI ran `tank publish --dry-run` on a fixture with `dist/` gitignored, `publish.build` creating `dist/main.js`, and `publish.files = ["dist/**","SKILL.md"]`. Tarball file list = `["tank.json","dist/main.js","SKILL.md"]`. `src.ts` was correctly excluded despite no `.tankignore`.
 
 ## Regression evidence
+
 - packages/internals-schemas: 98/98 passing.
 - packages/adapters: 25/25 passing (only test suite — previously had none).
 - packages/cli: 549/549 passing. Two existing tests in `publish.test.ts` updated for the new `pack(dir, options)` signature.

--- a/idd/modules/admin-bulk-rescan/INTENT.md
+++ b/idd/modules/admin-bulk-rescan/INTENT.md
@@ -7,6 +7,7 @@
 **Consumers:** Admin dashboard, `POST /api/admin/packages/rescan-many`.
 
 **Single source of truth:**
+
 - `apps/registry/src/lib/skills/bulk-rescan.ts` — pure orchestrator (concurrency, slicing, dry run)
 - `apps/registry/src/lib/skills/bulk-rescan-db.ts` — DB query for candidates + wiring to `runRescan`
 - `apps/registry/src/api/routes/admin/packages.ts` — HTTP endpoint
@@ -28,27 +29,27 @@ apps/registry/src/api/routes/admin/packages.ts   # POST /rescan-many — bulk tr
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                                                              | Rationale                                                  | Verified by         |
-| --- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------- |
-| C1  | Requires admin session; 401 otherwise                                                                             | Bulk rescan is a privileged, resource-intensive operation  | requireAdmin guard  |
-| C2  | Accepts optional `status: string[]` filter to target specific version audit statuses                              | Avoid re-scanning already-healthy versions                 | Type signature      |
-| C3  | Accepts optional `beforeScannedAt: ISO8601 string` to target stale scans (e.g. older than a recent scanner fix)   | Backfill after a scanner update without rescanning all     | Type signature      |
-| C4  | Per-call limit capped at `MAX_LIMIT` (50); concurrency capped at `MAX_CONCURRENCY` (5)                            | Stay within Vercel serverless function timeout (~300s)     | Unit test           |
-| C5  | Returns `{ matched, rescanned, remaining, results[] }` for pagination — caller iterates until `remaining === 0`   | Backfills larger than `MAX_LIMIT` must be paginable        | Unit test           |
-| C6  | Per-candidate failures are captured into `results[i].error` and do not abort the batch                            | One broken tarball must not block dozens of others         | Unit test           |
-| C7  | `dryRun: true` returns the candidate slice without invoking the scanner                                           | Lets admins preview the blast radius before committing     | Unit test           |
-| C8  | Each successful bulk operation writes an `admin.package.rescan_many` audit event                                  | Operational audit trail for privileged actions             | Endpoint handler    |
-| C9  | Individual `POST /admin/packages/[name]/rescan` is unchanged                                                      | Per-version rescan remains the unit; bulk is orchestration | Existing handler    |
+| #   | Rule                                                                                                            | Rationale                                                  | Verified by        |
+| --- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------ |
+| C1  | Requires admin session; 401 otherwise                                                                           | Bulk rescan is a privileged, resource-intensive operation  | requireAdmin guard |
+| C2  | Accepts optional `status: string[]` filter to target specific version audit statuses                            | Avoid re-scanning already-healthy versions                 | Type signature     |
+| C3  | Accepts optional `beforeScannedAt: ISO8601 string` to target stale scans (e.g. older than a recent scanner fix) | Backfill after a scanner update without rescanning all     | Type signature     |
+| C4  | Per-call limit capped at `MAX_LIMIT` (50); concurrency capped at `MAX_CONCURRENCY` (5)                          | Stay within Vercel serverless function timeout (~300s)     | Unit test          |
+| C5  | Returns `{ matched, rescanned, remaining, results[] }` for pagination — caller iterates until `remaining === 0` | Backfills larger than `MAX_LIMIT` must be paginable        | Unit test          |
+| C6  | Per-candidate failures are captured into `results[i].error` and do not abort the batch                          | One broken tarball must not block dozens of others         | Unit test          |
+| C7  | `dryRun: true` returns the candidate slice without invoking the scanner                                         | Lets admins preview the blast radius before committing     | Unit test          |
+| C8  | Each successful bulk operation writes an `admin.package.rescan_many` audit event                                | Operational audit trail for privileged actions             | Endpoint handler   |
+| C9  | Individual `POST /admin/packages/[name]/rescan` is unchanged                                                    | Per-version rescan remains the unit; bulk is orchestration | Existing handler   |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                                                                          | Expected                                                                 |
-| --- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| E1  | `POST /admin/packages/rescan-many` as admin, empty body                                        | 200: rescans up to `DEFAULT_LIMIT` (10) most recently published versions |
-| E2  | `POST /admin/packages/rescan-many` as non-admin                                                | 401                                                                      |
-| E3  | `POST /admin/packages/rescan-many` `{ "status": ["failed", "flagged"] }`                       | 200: only failed/flagged versions queued                                 |
+| #   | Input                                                                                           | Expected                                                                 |
+| --- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| E1  | `POST /admin/packages/rescan-many` as admin, empty body                                         | 200: rescans up to `DEFAULT_LIMIT` (10) most recently published versions |
+| E2  | `POST /admin/packages/rescan-many` as non-admin                                                 | 401                                                                      |
+| E3  | `POST /admin/packages/rescan-many` `{ "status": ["failed", "flagged"] }`                        | 200: only failed/flagged versions queued                                 |
 | E4  | `POST /admin/packages/rescan-many` `{ "beforeScannedAt": "2026-05-12T10:00:00Z", "limit": 25 }` | 200: rescans up to 25 versions whose latest scan predates the cutoff     |
-| E5  | `POST /admin/packages/rescan-many` `{ "dryRun": true }`                                        | 200: returns matched count + candidate slice, no scans performed         |
-| E6  | `POST /admin/packages/rescan-many` `{ "limit": 9999 }`                                         | 200: silently capped at `MAX_LIMIT` (50)                                 |
+| E5  | `POST /admin/packages/rescan-many` `{ "dryRun": true }`                                         | 200: returns matched count + candidate slice, no scans performed         |
+| E6  | `POST /admin/packages/rescan-many` `{ "limit": 9999 }`                                          | 200: silently capped at `MAX_LIMIT` (50)                                 |

--- a/idd/modules/atom-architecture/INTENT.md
+++ b/idd/modules/atom-architecture/INTENT.md
@@ -115,6 +115,15 @@ packages/
 | E16 | Adapter with `supportedRange: '>=2.4 <3'` + target version `2.5.0` | Compatibility check passes                              |
 | E17 | Adapter with `supportedRange: '>=2.4 <3'` + target version `3.1.0` | Compatibility check fails with version mismatch warning |
 
+### Tool Atom Runtimes & Extension Fallback (issue #453)
+
+| #   | Input                                                                                                                                       | Expected Output                                                                          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| E24 | `{ kind: 'tool', name: 'web-search', mcp: { runtime: 'uvx', package: 'web-search-mcp' } }` + opencode adapter                              | `.opencode/mcp/web-search.json` with `command: ["uvx","web-search-mcp"]`                 |
+| E25 | `{ kind: 'tool', name: 'web-search', mcp: { runtime: 'npx', package: 'my-mcp', args: ['--flag'] } }` + claude-code adapter                  | `.mcp.json` with `command: 'npx'`, `args: ['-y','my-mcp','--flag']`                      |
+| E26 | `{ kind: 'tool', name: 'memory', extensions: { opencode: { command: 'uvx', args: ['mem-mcp'], env: { KEY: 'x' } } } }` + opencode adapter | `.opencode/mcp/memory.json` built from `extensions.opencode`; NO skip warning            |
+| E27 | `{ kind: 'tool', name: 'memory' }` (no `mcp`, no `extensions.<adapter>`) + any adapter                                                      | No files; one `skipped` warning per current behavior — preserves clear-failure semantics |
+
 ### Legacy Normalization
 
 | #   | Input                                                             | Expected Output                                                       |

--- a/idd/modules/atom-architecture/INTENT.md
+++ b/idd/modules/atom-architecture/INTENT.md
@@ -117,12 +117,12 @@ packages/
 
 ### Tool Atom Runtimes & Extension Fallback (issue #453)
 
-| #   | Input                                                                                                                                       | Expected Output                                                                          |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| E24 | `{ kind: 'tool', name: 'web-search', mcp: { runtime: 'uvx', package: 'web-search-mcp' } }` + opencode adapter                              | `.opencode/mcp/web-search.json` with `command: ["uvx","web-search-mcp"]`                 |
-| E25 | `{ kind: 'tool', name: 'web-search', mcp: { runtime: 'npx', package: 'my-mcp', args: ['--flag'] } }` + claude-code adapter                  | `.mcp.json` with `command: 'npx'`, `args: ['-y','my-mcp','--flag']`                      |
+| #   | Input                                                                                                                                     | Expected Output                                                                          |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| E24 | `{ kind: 'tool', name: 'web-search', mcp: { runtime: 'uvx', package: 'web-search-mcp' } }` + opencode adapter                             | `.opencode/mcp/web-search.json` with `command: ["uvx","web-search-mcp"]`                 |
+| E25 | `{ kind: 'tool', name: 'web-search', mcp: { runtime: 'npx', package: 'my-mcp', args: ['--flag'] } }` + claude-code adapter                | `.mcp.json` with `command: 'npx'`, `args: ['-y','my-mcp','--flag']`                      |
 | E26 | `{ kind: 'tool', name: 'memory', extensions: { opencode: { command: 'uvx', args: ['mem-mcp'], env: { KEY: 'x' } } } }` + opencode adapter | `.opencode/mcp/memory.json` built from `extensions.opencode`; NO skip warning            |
-| E27 | `{ kind: 'tool', name: 'memory' }` (no `mcp`, no `extensions.<adapter>`) + any adapter                                                      | No files; one `skipped` warning per current behavior — preserves clear-failure semantics |
+| E27 | `{ kind: 'tool', name: 'memory' }` (no `mcp`, no `extensions.<adapter>`) + any adapter                                                    | No files; one `skipped` warning per current behavior — preserves clear-failure semantics |
 
 ### Legacy Normalization
 

--- a/idd/modules/publish/INTENT.md
+++ b/idd/modules/publish/INTENT.md
@@ -26,40 +26,40 @@ apps/registry/src/lib/skills/audit-score.ts              # Audit score computati
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                                                              | Rationale                                                            | Verified by  |
-| --- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | ------------ |
-| C1  | Auth token required for all publish steps (401 if missing)                                                        | Unauthenticated publish must be impossible                           | BDD scenario |
-| C2  | Manifest must pass skillsJsonSchema validation (name, version, semver)                                            | Malformed skills must be rejected before storage                     | BDD scenario |
-| C3  | Name is normalized to lowercase before persistence                                                                | Case-sensitive name collisions cause install errors                  | BDD scenario |
-| C4  | Scoped names (`@org/skill`) require org membership; unknown org → 404                                             | Org namespace squatting prevention                                   | BDD scenario |
-| C5  | Version conflict on same name+version → 409                                                                       | Immutable publish: re-publishing same version must be blocked        | BDD scenario |
-| C6  | PATCH bump cannot add any new permissions → 400 with violations list                                              | Security contract: small bumps cannot silently expand authority      | BDD scenario |
-| C7  | MINOR bump cannot add network.outbound or subprocess permissions → 400                                            | Dangerous permissions need a MAJOR bump                              | BDD scenario |
-| C8  | MAJOR bump allows any permission change                                                                           | Major signal to users that authority is expanding                    | BDD scenario |
-| C9  | `--dry-run` packs, verifies token, prints summary, does NOT upload                                                | Allows authors to check before real publish                          | BDD scenario |
-| C10 | Step 2 is a direct PUT to signed URL (not proxied through API)                                                    | Avoids proxying large tarballs through Next.js                       | Architecture |
-| C11 | `POST /confirm` only succeeds if version is `pending-upload` status                                               | Idempotency guard: prevents double-confirm                           | BDD scenario |
-| C12 | Scan is triggered synchronously inside confirm; on scan failure → `scan-failed` status but publish still succeeds | Graceful degradation: registry must not go down when scanner is slow | Code review  |
-| C13 | When `publish.build` is set in the manifest, the CLI runs it before packing; non-zero exit aborts publish before any upload                                              | Compiled packages (TS → dist) need a guaranteed pre-pack build step             | BDD scenario |
+| #   | Rule                                                                                                                                                                      | Rationale                                                                       | Verified by  |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------ |
+| C1  | Auth token required for all publish steps (401 if missing)                                                                                                                | Unauthenticated publish must be impossible                                      | BDD scenario |
+| C2  | Manifest must pass skillsJsonSchema validation (name, version, semver)                                                                                                    | Malformed skills must be rejected before storage                                | BDD scenario |
+| C3  | Name is normalized to lowercase before persistence                                                                                                                        | Case-sensitive name collisions cause install errors                             | BDD scenario |
+| C4  | Scoped names (`@org/skill`) require org membership; unknown org → 404                                                                                                     | Org namespace squatting prevention                                              | BDD scenario |
+| C5  | Version conflict on same name+version → 409                                                                                                                               | Immutable publish: re-publishing same version must be blocked                   | BDD scenario |
+| C6  | PATCH bump cannot add any new permissions → 400 with violations list                                                                                                      | Security contract: small bumps cannot silently expand authority                 | BDD scenario |
+| C7  | MINOR bump cannot add network.outbound or subprocess permissions → 400                                                                                                    | Dangerous permissions need a MAJOR bump                                         | BDD scenario |
+| C8  | MAJOR bump allows any permission change                                                                                                                                   | Major signal to users that authority is expanding                               | BDD scenario |
+| C9  | `--dry-run` packs, verifies token, prints summary, does NOT upload                                                                                                        | Allows authors to check before real publish                                     | BDD scenario |
+| C10 | Step 2 is a direct PUT to signed URL (not proxied through API)                                                                                                            | Avoids proxying large tarballs through Next.js                                  | Architecture |
+| C11 | `POST /confirm` only succeeds if version is `pending-upload` status                                                                                                       | Idempotency guard: prevents double-confirm                                      | BDD scenario |
+| C12 | Scan is triggered synchronously inside confirm; on scan failure → `scan-failed` status but publish still succeeds                                                         | Graceful degradation: registry must not go down when scanner is slow            | Code review  |
+| C13 | When `publish.build` is set in the manifest, the CLI runs it before packing; non-zero exit aborts publish before any upload                                               | Compiled packages (TS → dist) need a guaranteed pre-pack build step             | BDD scenario |
 | C14 | When `publish.files` is set (non-empty array), the packer ignores `.tankignore`/`.gitignore` and packs ONLY files matching those globs, plus the manifest + readme always | Explicit allow-list mirrors npm's `files` field; eliminates `.tankignore` traps | BDD scenario |
-| C15 | The `publish` block is stripped from the manifest body sent to `/api/v1/skills` — it is a CLI-only concern                                                               | Server has no business knowing how the client built or selected files           | Code review  |
+| C15 | The `publish` block is stripped from the manifest body sent to `/api/v1/skills` — it is a CLI-only concern                                                                | Server has no business knowing how the client built or selected files           | Code review  |
 
 ---
 
 ## Layer 3: Examples
 
-| #   | Input                                                            | Expected Output                                              |
-| --- | ---------------------------------------------------------------- | ------------------------------------------------------------ |
-| E1  | `tank publish` in a valid skill directory, authenticated         | 3-step flow completes; success message includes name@version |
-| E2  | `tank publish` without token                                     | Error: "Not logged in. Run: tank login"                      |
-| E3  | `tank publish` with `tank.json` missing `version` field          | 400: invalid manifest, fieldErrors listed                    |
-| E4  | `tank publish` scoped `@nonexistent-org/skill`                   | 404: org not found                                           |
-| E5  | `tank publish` version already in registry                       | 409: "Version already exists"                                |
-| E6  | PATCH bump (`1.0.0 → 1.0.1`) that adds `network.outbound`        | 400: permission escalation, violations array                 |
-| E7  | MAJOR bump (`1.0.0 → 2.0.0`) that adds `network.outbound`        | 200: allowed                                                 |
-| E8  | `tank publish --dry-run`                                         | Prints size/file count, does NOT create a version record     |
-| E9  | `tank publish --private`                                         | Skill created with `visibility = 'private'`                  |
-| E10 | Duplicate confirm call (confirm called twice for same versionId) | 400: "Version is already confirmed or published"             |
-| E11 | `tank publish` with `publish.build = "exit 1"` in `tank.json`    | Build hook fails, publish aborts before pack; no upload, exit code non-zero |
-| E12 | `tank publish` with `publish.files = ["dist/**","SKILL.md"]`     | Tarball contains only `dist/**`, `SKILL.md`, and the manifest — even if `.gitignore` excludes `dist/` |
+| #   | Input                                                            | Expected Output                                                                                              |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| E1  | `tank publish` in a valid skill directory, authenticated         | 3-step flow completes; success message includes name@version                                                 |
+| E2  | `tank publish` without token                                     | Error: "Not logged in. Run: tank login"                                                                      |
+| E3  | `tank publish` with `tank.json` missing `version` field          | 400: invalid manifest, fieldErrors listed                                                                    |
+| E4  | `tank publish` scoped `@nonexistent-org/skill`                   | 404: org not found                                                                                           |
+| E5  | `tank publish` version already in registry                       | 409: "Version already exists"                                                                                |
+| E6  | PATCH bump (`1.0.0 → 1.0.1`) that adds `network.outbound`        | 400: permission escalation, violations array                                                                 |
+| E7  | MAJOR bump (`1.0.0 → 2.0.0`) that adds `network.outbound`        | 200: allowed                                                                                                 |
+| E8  | `tank publish --dry-run`                                         | Prints size/file count, does NOT create a version record                                                     |
+| E9  | `tank publish --private`                                         | Skill created with `visibility = 'private'`                                                                  |
+| E10 | Duplicate confirm call (confirm called twice for same versionId) | 400: "Version is already confirmed or published"                                                             |
+| E11 | `tank publish` with `publish.build = "exit 1"` in `tank.json`    | Build hook fails, publish aborts before pack; no upload, exit code non-zero                                  |
+| E12 | `tank publish` with `publish.files = ["dist/**","SKILL.md"]`     | Tarball contains only `dist/**`, `SKILL.md`, and the manifest — even if `.gitignore` excludes `dist/`        |
 | E13 | `tank publish` with both `publish.build` and `publish.files`     | Build runs first; on success, packer applies `files` allow-list; outgoing manifest body has no `publish` key |

--- a/idd/modules/publish/INTENT.md
+++ b/idd/modules/publish/INTENT.md
@@ -40,6 +40,9 @@ apps/registry/src/lib/skills/audit-score.ts              # Audit score computati
 | C10 | Step 2 is a direct PUT to signed URL (not proxied through API)                                                    | Avoids proxying large tarballs through Next.js                       | Architecture |
 | C11 | `POST /confirm` only succeeds if version is `pending-upload` status                                               | Idempotency guard: prevents double-confirm                           | BDD scenario |
 | C12 | Scan is triggered synchronously inside confirm; on scan failure → `scan-failed` status but publish still succeeds | Graceful degradation: registry must not go down when scanner is slow | Code review  |
+| C13 | When `publish.build` is set in the manifest, the CLI runs it before packing; non-zero exit aborts publish before any upload                                              | Compiled packages (TS → dist) need a guaranteed pre-pack build step             | BDD scenario |
+| C14 | When `publish.files` is set (non-empty array), the packer ignores `.tankignore`/`.gitignore` and packs ONLY files matching those globs, plus the manifest + readme always | Explicit allow-list mirrors npm's `files` field; eliminates `.tankignore` traps | BDD scenario |
+| C15 | The `publish` block is stripped from the manifest body sent to `/api/v1/skills` — it is a CLI-only concern                                                               | Server has no business knowing how the client built or selected files           | Code review  |
 
 ---
 
@@ -57,3 +60,6 @@ apps/registry/src/lib/skills/audit-score.ts              # Audit score computati
 | E8  | `tank publish --dry-run`                                         | Prints size/file count, does NOT create a version record     |
 | E9  | `tank publish --private`                                         | Skill created with `visibility = 'private'`                  |
 | E10 | Duplicate confirm call (confirm called twice for same versionId) | 400: "Version is already confirmed or published"             |
+| E11 | `tank publish` with `publish.build = "exit 1"` in `tank.json`    | Build hook fails, publish aborts before pack; no upload, exit code non-zero |
+| E12 | `tank publish` with `publish.files = ["dist/**","SKILL.md"]`     | Tarball contains only `dist/**`, `SKILL.md`, and the manifest — even if `.gitignore` excludes `dist/` |
+| E13 | `tank publish` with both `publish.build` and `publish.files`     | Build runs first; on success, packer applies `files` allow-list; outgoing manifest body has no `publish` key |

--- a/packages/adapters/src/__tests__/tool-runtimes.test.ts
+++ b/packages/adapters/src/__tests__/tool-runtimes.test.ts
@@ -1,0 +1,139 @@
+// Verifies issue #453: non-Node MCP tool atoms compile to real client config.
+//
+// Intent: idd/modules/atom-architecture/INTENT.md — Examples E24-E27.
+//
+// Adapters covered: opencode, claude-code, cursor, windsurf, cline, roo-code.
+import { describe, expect, it } from 'vitest';
+
+import { claudeCodeAdapter } from '~/adapters/claude-code.js';
+import { clineAdapter } from '~/adapters/cline.js';
+import { cursorAdapter } from '~/adapters/cursor.js';
+import { opencodeAdapter } from '~/adapters/opencode.js';
+import { rooCodeAdapter } from '~/adapters/roo-code.js';
+import { windsurfAdapter } from '~/adapters/windsurf.js';
+
+const ALL_ADAPTERS = [
+  {
+    name: 'opencode',
+    adapter: opencodeAdapter,
+    configPath: (toolName: string) => `.opencode/mcp/${toolName}.json`,
+    servers: false
+  },
+  { name: 'claude-code', adapter: claudeCodeAdapter, configPath: () => '.mcp.json', servers: true },
+  { name: 'cursor', adapter: cursorAdapter, configPath: () => '.cursor/mcp.json', servers: true },
+  { name: 'windsurf', adapter: windsurfAdapter, configPath: () => '.windsurf/mcp.json', servers: true },
+  { name: 'cline', adapter: clineAdapter, configPath: () => '.vscode/cline_mcp_settings.json', servers: true },
+  { name: 'roo-code', adapter: rooCodeAdapter, configPath: () => '.vscode/mcp.json', servers: true }
+];
+
+function parseConfig(content: string): Record<string, unknown> {
+  return JSON.parse(content) as Record<string, unknown>;
+}
+
+function readServer(
+  config: Record<string, unknown>,
+  useServersWrapper: boolean,
+  name: string
+): Record<string, unknown> {
+  const root = useServersWrapper ? (config.mcpServers as Record<string, unknown>) : config;
+  return root[name] as Record<string, unknown>;
+}
+
+describe('tool atom runtimes — issue #453', () => {
+  // E24
+  it.each(ALL_ADAPTERS)('$name: mcp.runtime "uvx" produces uvx command', ({ adapter, configPath, servers }) => {
+    const atom = {
+      kind: 'tool' as const,
+      name: 'web-search',
+      mcp: { runtime: 'uvx', package: 'web-search-mcp' }
+    };
+    const out = adapter.compileAtom(atom);
+    expect(out.warnings).toEqual([]);
+    expect(out.files).toHaveLength(1);
+    expect(out.files[0].path).toBe(configPath('web-search'));
+    const cfg = parseConfig(out.files[0].content);
+    const server = readServer(cfg, servers, 'web-search');
+    // opencode flattens `command` to an array; the others use {command, args}
+    if (Array.isArray(server.command)) {
+      expect(server.command).toEqual(['uvx', 'web-search-mcp']);
+    } else {
+      expect(server.command).toBe('uvx');
+      expect(server.args).toEqual(['web-search-mcp']);
+    }
+  });
+
+  // E25 — npx with extra args
+  it.each(ALL_ADAPTERS)('$name: mcp.runtime "npx" produces npx -y command', ({ adapter, configPath, servers }) => {
+    const atom = {
+      kind: 'tool' as const,
+      name: 'tool-x',
+      mcp: { runtime: 'npx', package: 'my-mcp', args: ['--flag'] }
+    };
+    const out = adapter.compileAtom(atom);
+    expect(out.warnings).toEqual([]);
+    expect(out.files[0].path).toBe(configPath('tool-x'));
+    const cfg = parseConfig(out.files[0].content);
+    const server = readServer(cfg, servers, 'tool-x');
+    if (Array.isArray(server.command)) {
+      expect(server.command).toEqual(['npx', '-y', 'my-mcp', '--flag']);
+    } else {
+      expect(server.command).toBe('npx');
+      expect(server.args).toEqual(['-y', 'my-mcp', '--flag']);
+    }
+  });
+
+  // E26 — extensions fallback
+  it.each(ALL_ADAPTERS)('$name: extensions.<adapter> produces MCP config when no mcp block', ({
+    name,
+    adapter,
+    configPath,
+    servers
+  }) => {
+    const atom = {
+      kind: 'tool' as const,
+      name: 'memory',
+      extensions: {
+        [name]: { command: 'uvx', args: ['mem-mcp'], env: { KEY: 'x' } }
+      }
+    };
+    const out = adapter.compileAtom(atom);
+    expect(out.warnings, `expected no warnings for ${name}, got: ${JSON.stringify(out.warnings)}`).toEqual([]);
+    expect(out.files[0].path).toBe(configPath('memory'));
+    const cfg = parseConfig(out.files[0].content);
+    const server = readServer(cfg, servers, 'memory');
+    if (Array.isArray(server.command)) {
+      expect(server.command).toEqual(['uvx', 'mem-mcp']);
+      // opencode uses `environment`, not `env`
+      expect(server.environment).toEqual({ KEY: 'x' });
+    } else {
+      expect(server.command).toBe('uvx');
+      expect(server.args).toEqual(['mem-mcp']);
+      expect(server.env).toEqual({ KEY: 'x' });
+    }
+  });
+
+  // E27 — no mcp, no extensions → preserve skip warning (regression guard)
+  it.each(ALL_ADAPTERS)('$name: still skips tool with no mcp and no extensions for itself', ({ adapter }) => {
+    const atom = {
+      kind: 'tool' as const,
+      name: 'orphan'
+    };
+    const out = adapter.compileAtom(atom);
+    expect(out.files).toEqual([]);
+    expect(out.warnings).toHaveLength(1);
+    expect(out.warnings[0].level).toBe('skipped');
+  });
+
+  it('opencode does not consume extensions.cursor (extension bag is adapter-scoped)', () => {
+    const atom = {
+      kind: 'tool' as const,
+      name: 'memory',
+      extensions: {
+        cursor: { command: 'uvx', args: ['mem-mcp'] }
+      }
+    };
+    const out = opencodeAdapter.compileAtom(atom);
+    expect(out.files).toEqual([]);
+    expect(out.warnings[0].level).toBe('skipped');
+  });
+});

--- a/packages/adapters/src/adapters/_mcp-resolution.ts
+++ b/packages/adapters/src/adapters/_mcp-resolution.ts
@@ -1,0 +1,70 @@
+import type { AtomIR } from '@internals/schemas';
+
+export interface ResolvedMcp {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export function resolveMcpCommand(atom: AtomIR & { kind: 'tool' }, adapterName: string): ResolvedMcp | null {
+  if (atom.mcp) {
+    return resolveFromMcpBlock(atom.mcp);
+  }
+  const fromExtensions = resolveFromExtensions(atom.extensions, adapterName);
+  if (fromExtensions) return fromExtensions;
+  return null;
+}
+
+function resolveFromMcpBlock(mcp: NonNullable<(AtomIR & { kind: 'tool' })['mcp']>): ResolvedMcp | null {
+  const env = mcp.env;
+  if (mcp.command) {
+    return { command: mcp.command, args: mcp.args ?? [], ...(env ? { env } : {}) };
+  }
+  if (!mcp.runtime) return null;
+
+  const args = mcp.args ?? [];
+  switch (mcp.runtime) {
+    case 'uvx':
+      if (!mcp.package) return null;
+      return { command: 'uvx', args: [mcp.package, ...args], ...(env ? { env } : {}) };
+    case 'npx':
+      if (!mcp.package) return null;
+      return { command: 'npx', args: ['-y', mcp.package, ...args], ...(env ? { env } : {}) };
+    case 'bunx':
+      if (!mcp.package) return null;
+      return { command: 'bunx', args: [mcp.package, ...args], ...(env ? { env } : {}) };
+    case 'pipx':
+      if (!mcp.package) return null;
+      return { command: 'pipx', args: ['run', mcp.package, ...args], ...(env ? { env } : {}) };
+    case 'node':
+      if (!mcp.entry) return null;
+      return { command: 'node', args: [mcp.entry, ...args], ...(env ? { env } : {}) };
+    case 'python':
+      if (!mcp.entry) return null;
+      return { command: 'python', args: [mcp.entry, ...args], ...(env ? { env } : {}) };
+    default:
+      return null;
+  }
+}
+
+function resolveFromExtensions(
+  extensions: (AtomIR & { kind: 'tool' })['extensions'],
+  adapterName: string
+): ResolvedMcp | null {
+  if (!extensions) return null;
+  const bag = extensions[adapterName];
+  if (!bag || typeof bag !== 'object') return null;
+  const candidate = bag as Record<string, unknown>;
+  if (typeof candidate.command !== 'string' || candidate.command.length === 0) return null;
+  const args = Array.isArray(candidate.args) ? candidate.args.filter((a): a is string => typeof a === 'string') : [];
+  const env =
+    candidate.env && typeof candidate.env === 'object' && !Array.isArray(candidate.env)
+      ? Object.fromEntries(
+          Object.entries(candidate.env as Record<string, unknown>).filter(([, v]) => typeof v === 'string') as [
+            string,
+            string
+          ][]
+        )
+      : undefined;
+  return { command: candidate.command, args, ...(env ? { env } : {}) };
+}

--- a/packages/adapters/src/adapters/claude-code.ts
+++ b/packages/adapters/src/adapters/claude-code.ts
@@ -1,5 +1,7 @@
 import type { AdapterCapabilities, AtomIR, PlatformAdapter, PlatformOutput } from '@internals/schemas';
 
+import { resolveMcpCommand } from './_mcp-resolution.js';
+
 function emitInstruction(atom: AtomIR & { kind: 'instruction' }): PlatformOutput {
   const globs = atom.globs?.length ? atom.globs : undefined;
 
@@ -101,7 +103,8 @@ function emitAgent(atom: AtomIR & { kind: 'agent' }): PlatformOutput {
 }
 
 function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
-  if (!atom.mcp) {
+  const resolved = resolveMcpCommand(atom, 'claude-code');
+  if (!resolved) {
     return {
       files: [],
       warnings: [{ level: 'skipped', atomKind: 'tool', message: `Tool "${atom.name}" has no MCP config` }]
@@ -111,9 +114,9 @@ function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
   const mcpConfig = {
     mcpServers: {
       [atom.name]: {
-        command: atom.mcp.command,
-        args: atom.mcp.args ?? [],
-        ...(atom.mcp.env ? { env: atom.mcp.env } : {})
+        command: resolved.command,
+        args: resolved.args,
+        ...(resolved.env ? { env: resolved.env } : {})
       }
     }
   };

--- a/packages/adapters/src/adapters/cline.ts
+++ b/packages/adapters/src/adapters/cline.ts
@@ -1,5 +1,7 @@
 import type { AdapterCapabilities, AtomIR, PlatformAdapter, PlatformOutput } from '@internals/schemas';
 
+import { resolveMcpCommand } from './_mcp-resolution.js';
+
 function emitInstruction(atom: AtomIR & { kind: 'instruction' }): PlatformOutput {
   return {
     files: [{ path: `.clinerules/${slugify(atom.content)}.md`, content: `{file:${atom.content}}` }],
@@ -62,7 +64,8 @@ function emitAgent(atom: AtomIR & { kind: 'agent' }): PlatformOutput {
 }
 
 function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
-  if (!atom.mcp) {
+  const resolved = resolveMcpCommand(atom, 'cline');
+  if (!resolved) {
     return {
       files: [],
       warnings: [{ level: 'skipped', atomKind: 'tool', message: `Tool "${atom.name}" has no MCP config` }]
@@ -72,10 +75,10 @@ function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
   const config = {
     mcpServers: {
       [atom.name]: {
-        command: atom.mcp.command,
-        args: atom.mcp.args ?? [],
+        command: resolved.command,
+        args: resolved.args,
         disabled: false,
-        ...(atom.mcp.env ? { env: atom.mcp.env } : {})
+        ...(resolved.env ? { env: resolved.env } : {})
       }
     }
   };

--- a/packages/adapters/src/adapters/cursor.ts
+++ b/packages/adapters/src/adapters/cursor.ts
@@ -1,5 +1,7 @@
 import type { AdapterCapabilities, AtomIR, PlatformAdapter, PlatformOutput } from '@internals/schemas';
 
+import { resolveMcpCommand } from './_mcp-resolution.js';
+
 function emitInstruction(atom: AtomIR & { kind: 'instruction' }): PlatformOutput {
   const globs = atom.globs?.length ? atom.globs.join(', ') : undefined;
   const alwaysApply = !globs && atom.scope !== 'directory';
@@ -103,7 +105,8 @@ function emitAgent(atom: AtomIR & { kind: 'agent' }): PlatformOutput {
 }
 
 function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
-  if (!atom.mcp) {
+  const resolved = resolveMcpCommand(atom, 'cursor');
+  if (!resolved) {
     return {
       files: [],
       warnings: [{ level: 'skipped', atomKind: 'tool', message: `Tool "${atom.name}" has no MCP config` }]
@@ -113,9 +116,9 @@ function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
   const config = {
     mcpServers: {
       [atom.name]: {
-        command: atom.mcp.command,
-        args: atom.mcp.args ?? [],
-        ...(atom.mcp.env ? { env: atom.mcp.env } : {})
+        command: resolved.command,
+        args: resolved.args,
+        ...(resolved.env ? { env: resolved.env } : {})
       }
     }
   };

--- a/packages/adapters/src/adapters/opencode.ts
+++ b/packages/adapters/src/adapters/opencode.ts
@@ -1,5 +1,7 @@
 import type { AdapterCapabilities, AtomIR, PlatformAdapter, PlatformOutput } from '@internals/schemas';
 
+import { resolveMcpCommand } from './_mcp-resolution.js';
+
 function emitInstruction(atom: AtomIR & { kind: 'instruction' }): PlatformOutput {
   return {
     files: [
@@ -103,7 +105,8 @@ function emitAgent(atom: AtomIR & { kind: 'agent' }): PlatformOutput {
 }
 
 function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
-  if (!atom.mcp) {
+  const resolved = resolveMcpCommand(atom, 'opencode');
+  if (!resolved) {
     return {
       files: [],
       warnings: [
@@ -119,8 +122,8 @@ function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
   const config = {
     [atom.name]: {
       type: 'local' as const,
-      command: [atom.mcp.command, ...(atom.mcp.args ?? [])],
-      ...(atom.mcp.env ? { environment: atom.mcp.env } : {})
+      command: [resolved.command, ...resolved.args],
+      ...(resolved.env ? { environment: resolved.env } : {})
     }
   };
 

--- a/packages/adapters/src/adapters/roo-code.ts
+++ b/packages/adapters/src/adapters/roo-code.ts
@@ -1,5 +1,7 @@
 import type { AdapterCapabilities, AtomIR, PlatformAdapter, PlatformOutput } from '@internals/schemas';
 
+import { resolveMcpCommand } from './_mcp-resolution.js';
+
 function emitInstruction(atom: AtomIR & { kind: 'instruction' }): PlatformOutput {
   return {
     files: [{ path: `.roo/rules/${slugify(atom.content)}.md`, content: `{file:${atom.content}}` }],
@@ -48,7 +50,8 @@ function emitAgent(atom: AtomIR & { kind: 'agent' }): PlatformOutput {
 }
 
 function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
-  if (!atom.mcp) {
+  const resolved = resolveMcpCommand(atom, 'roo-code');
+  if (!resolved) {
     return {
       files: [],
       warnings: [{ level: 'skipped', atomKind: 'tool', message: `Tool "${atom.name}" has no MCP config` }]
@@ -58,10 +61,10 @@ function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
   const config = {
     mcpServers: {
       [atom.name]: {
-        command: atom.mcp.command,
-        args: atom.mcp.args ?? [],
+        command: resolved.command,
+        args: resolved.args,
         disabled: false,
-        ...(atom.mcp.env ? { env: atom.mcp.env } : {})
+        ...(resolved.env ? { env: resolved.env } : {})
       }
     }
   };

--- a/packages/adapters/src/adapters/windsurf.ts
+++ b/packages/adapters/src/adapters/windsurf.ts
@@ -1,5 +1,7 @@
 import type { AdapterCapabilities, AtomIR, PlatformAdapter, PlatformOutput } from '@internals/schemas';
 
+import { resolveMcpCommand } from './_mcp-resolution.js';
+
 function emitInstruction(atom: AtomIR & { kind: 'instruction' }): PlatformOutput {
   return {
     files: [{ path: `.windsurf/rules/${slugify(atom.content)}.md`, content: `{file:${atom.content}}` }],
@@ -80,7 +82,8 @@ function emitAgent(atom: AtomIR & { kind: 'agent' }): PlatformOutput {
 }
 
 function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
-  if (!atom.mcp) {
+  const resolved = resolveMcpCommand(atom, 'windsurf');
+  if (!resolved) {
     return {
       files: [],
       warnings: [{ level: 'skipped', atomKind: 'tool', message: `Tool "${atom.name}" has no MCP config` }]
@@ -90,9 +93,9 @@ function emitTool(atom: AtomIR & { kind: 'tool' }): PlatformOutput {
   const config = {
     mcpServers: {
       [atom.name]: {
-        command: atom.mcp.command,
-        args: atom.mcp.args ?? [],
-        ...(atom.mcp.env ? { env: atom.mcp.env } : {})
+        command: resolved.command,
+        args: resolved.args,
+        ...(resolved.env ? { env: resolved.env } : {})
       }
     }
   };

--- a/packages/adapters/vitest.config.ts
+++ b/packages/adapters/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~/': new URL('./src/', import.meta.url).pathname
+    }
+  },
+  test: {
+    environment: 'node',
+    passWithNoTests: true
+  }
+});

--- a/packages/cli/src/__tests__/publish-lifecycle.test.ts
+++ b/packages/cli/src/__tests__/publish-lifecycle.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runBuildHook } from '~/lib/build-hook.js';
+import { pack } from '~/lib/packer.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-lifecycle-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFile(rel: string, content: string): void {
+  const full = path.join(tmpDir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe('runBuildHook — issue #454 (C13/E11/E13)', () => {
+  it('resolves when the command exits 0', async () => {
+    await expect(runBuildHook(tmpDir, 'node -e "process.exit(0)"')).resolves.toBeUndefined();
+  });
+
+  it('rejects when the command exits non-zero, surfacing exit code', async () => {
+    await expect(runBuildHook(tmpDir, 'node -e "process.exit(7)"')).rejects.toThrow(/exited with code 7/);
+  });
+
+  it('runs the command in the given directory', async () => {
+    writeFile('marker.txt', 'hello');
+    await expect(
+      runBuildHook(tmpDir, "node -e \"require('node:fs').accessSync('marker.txt')\"")
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('pack({ files }) — issue #454 (C14/E12)', () => {
+  const manifest = JSON.stringify({ name: '@test-org/lc-skill', version: '1.0.0' });
+
+  it('with `files` allow-list includes ONLY matching files plus the manifest', async () => {
+    writeFile('tank.json', manifest);
+    writeFile('SKILL.md', '# Skill');
+    writeFile('dist/index.js', "console.log('built');");
+    writeFile('dist/sub/x.js', 'x');
+    writeFile('src/index.ts', 'export {};');
+    writeFile('node_modules/foo/index.js', 'noop');
+    writeFile('.gitignore', 'dist/\nnode_modules/\n');
+
+    const result = await pack(tmpDir, { files: ['dist/**', 'SKILL.md'] });
+
+    const f = new Set(result.files);
+    expect(f.has('tank.json')).toBe(true);
+    expect(f.has('SKILL.md')).toBe(true);
+    expect(f.has('dist/index.js')).toBe(true);
+    expect(f.has('dist/sub/x.js')).toBe(true);
+    expect(f.has('src/index.ts')).toBe(false);
+    expect(f.has('node_modules/foo/index.js')).toBe(false);
+  });
+
+  it('with `files` still respects security baseline (node_modules, .git always excluded)', async () => {
+    writeFile('tank.json', manifest);
+    writeFile('node_modules/foo/index.js', 'noop');
+    writeFile('.git/HEAD', 'ref:');
+    writeFile('dist/index.js', 'ok');
+
+    const result = await pack(tmpDir, { files: ['**/*'] });
+
+    expect(result.files).not.toContain('node_modules/foo/index.js');
+    expect(result.files).not.toContain('.git/HEAD');
+    expect(result.files).toContain('dist/index.js');
+  });
+
+  it('without `files` preserves legacy .gitignore behavior (regression guard)', async () => {
+    writeFile('tank.json', manifest);
+    writeFile('SKILL.md', '# Skill');
+    writeFile('dist/index.js', 'built');
+    writeFile('.gitignore', 'dist/\n');
+
+    const result = await pack(tmpDir);
+
+    expect(result.files).not.toContain('dist/index.js');
+    expect(result.files).toContain('tank.json');
+    expect(result.files).toContain('SKILL.md');
+  });
+});

--- a/packages/cli/src/__tests__/publish.test.ts
+++ b/packages/cli/src/__tests__/publish.test.ts
@@ -128,7 +128,7 @@ describe('publishCommand', () => {
     await publishCommand({ directory: tmpDir, configDir });
 
     // Verify pack was called with the directory
-    expect(mockPack).toHaveBeenCalledWith(tmpDir);
+    expect(mockPack).toHaveBeenCalledWith(tmpDir, {});
 
     // Verify 3 fetch calls were made
     expect(mockFetch).toHaveBeenCalledTimes(3);
@@ -171,7 +171,7 @@ describe('publishCommand', () => {
 
     await publishCommand({ directory: tmpDir, configDir, dryRun: true });
 
-    expect(mockPack).toHaveBeenCalledWith(tmpDir);
+    expect(mockPack).toHaveBeenCalledWith(tmpDir, {});
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, opts] = mockFetch.mock.calls[0];

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { MANIFEST_FILENAME } from '@internals/schemas';
 import ora from 'ora';
 
+import { runBuildHook } from '~/lib/build-hook.js';
 import { getConfig } from '~/lib/config.js';
 import { logger } from '~/lib/logger.js';
 import { resolveManifestPath } from '~/lib/manifest.js';
@@ -74,16 +75,24 @@ export async function publishCommand(options: PublishOptions = {}): Promise<void
 
   const name = manifest.name as string;
   const version = manifest.version as string;
+  const publishConfig = (manifest.publish as { build?: string; files?: string[] } | undefined) ?? undefined;
 
-  // 3. Pack
+  if (publishConfig?.build) {
+    logger.info(`Running build: ${publishConfig.build}`);
+    await runBuildHook(directory, publishConfig.build);
+  }
+
   const spinner = ora('Packing...').start();
   let packResult: Awaited<ReturnType<typeof pack>>;
   try {
-    packResult = await pack(directory);
+    packResult = await pack(directory, publishConfig?.files ? { files: publishConfig.files } : {});
   } catch (err) {
     spinner.fail('Packing failed');
     throw err;
   }
+
+  const outboundManifest: Record<string, unknown> = { ...manifest };
+  delete outboundManifest.publish;
 
   const { tarball, integrity, fileCount, totalSize, readme, files } = packResult;
 
@@ -132,7 +141,7 @@ export async function publishCommand(options: PublishOptions = {}): Promise<void
   const step1Res = await fetch(`${config.registry}/api/v1/skills`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ manifest, readme, files })
+    body: JSON.stringify({ manifest: outboundManifest, readme, files })
   });
 
   if (!step1Res.ok) {

--- a/packages/cli/src/lib/build-hook.ts
+++ b/packages/cli/src/lib/build-hook.ts
@@ -1,0 +1,27 @@
+import { spawn } from 'node:child_process';
+
+export function runBuildHook(directory: string, command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, {
+      cwd: directory,
+      shell: true,
+      stdio: 'inherit'
+    });
+
+    child.on('error', (err) => {
+      reject(new Error(`Build hook failed to start: ${err.message}`));
+    });
+
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      if (signal) {
+        reject(new Error(`Build hook terminated by signal ${signal}`));
+        return;
+      }
+      reject(new Error(`Build hook exited with code ${code ?? 'unknown'}`));
+    });
+  });
+}

--- a/packages/cli/src/lib/packer.ts
+++ b/packages/cli/src/lib/packer.ts
@@ -22,25 +22,18 @@ const IGNORE_FILES = ['.tankignore', '.gitignore'];
 
 export interface PackResult {
   tarball: Buffer;
-  integrity: string; // "sha512-{base64}"
+  integrity: string;
   fileCount: number;
   totalSize: number;
   readme: string;
   files: string[];
 }
 
-/**
- * Pack a skill directory into a .tgz tarball with integrity hashing.
- *
- * Validates:
- * - tank.json (or skills.json) exists and is valid
- * - No symlinks or hardlinks
- * - No path traversal (.. components)
- * - No absolute paths
- * - File count <= 1000
- * - Tarball size <= 50MB
- */
-export async function pack(directory: string): Promise<PackResult> {
+export interface PackOptions {
+  files?: string[];
+}
+
+export async function pack(directory: string, options: PackOptions = {}): Promise<PackResult> {
   const absDir = path.resolve(directory);
 
   // 1. Verify directory exists
@@ -102,11 +95,10 @@ export async function pack(directory: string): Promise<PackResult> {
     }
   }
 
-  // 4. Build ignore filter
-  const ig = buildIgnoreFilter(absDir);
-
-  // 5. Collect files with validation
-  const files = collectFiles(absDir, absDir, ig);
+  const files =
+    options.files && options.files.length > 0
+      ? collectFromAllowList(absDir, options.files, manifestFilename)
+      : collectFiles(absDir, absDir, buildIgnoreFilter(absDir));
 
   // 6. Enforce file count limit
   if (files.length > MAX_FILE_COUNT) {
@@ -232,9 +224,18 @@ export async function packForScan(directory: string): Promise<PackResult> {
   };
 }
 
-/**
- * Build an ignore filter from .tankignore, .gitignore, or defaults.
- */
+function collectFromAllowList(baseDir: string, globs: string[], manifestFilename: string): string[] {
+  const securityFilter = ignore().add(ALWAYS_IGNORED);
+  const allowMatcher = ignore().add(globs);
+  const all = collectFiles(baseDir, baseDir, securityFilter);
+
+  const always = new Set<string>([manifestFilename]);
+  if (fs.existsSync(path.join(baseDir, 'SKILL.md'))) always.add('SKILL.md');
+  if (fs.existsSync(path.join(baseDir, 'README.md'))) always.add('README.md');
+
+  return all.filter((rel) => always.has(rel) || allowMatcher.ignores(rel));
+}
+
 function buildIgnoreFilter(dir: string): ReturnType<typeof ignore> {
   const ig = ignore();
 

--- a/packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts
+++ b/packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { toolIRSchema } from '~/schemas/atoms/tool.js';
+import { publishManifestSchema } from '~/schemas/skills-json.js';
+
+describe('toolIRSchema — runtime variants (issue #453)', () => {
+  it('accepts mcp.runtime "uvx" with package', () => {
+    const r = toolIRSchema.safeParse({
+      kind: 'tool',
+      name: 'web-search',
+      mcp: { runtime: 'uvx', package: 'web-search-mcp' }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts mcp.runtime "npx" with package and args', () => {
+    const r = toolIRSchema.safeParse({
+      kind: 'tool',
+      name: 'tool-x',
+      mcp: { runtime: 'npx', package: 'my-mcp', args: ['--flag'] }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('still accepts legacy {command, args}', () => {
+    const r = toolIRSchema.safeParse({
+      kind: 'tool',
+      name: 'legacy',
+      mcp: { command: 'uvx', args: ['my-mcp'] }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('still accepts legacy {runtime: "node", entry}', () => {
+    const r = toolIRSchema.safeParse({
+      kind: 'tool',
+      name: 'node-tool',
+      mcp: { runtime: 'node', entry: 'dist/index.js' }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a tool with only extensions (no mcp)', () => {
+    const r = toolIRSchema.safeParse({
+      kind: 'tool',
+      name: 'memory',
+      extensions: { opencode: { command: 'uvx', args: ['mem-mcp'] } }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects mcp with neither command nor (runtime + package/entry)', () => {
+    const r = toolIRSchema.safeParse({
+      kind: 'tool',
+      name: 'broken',
+      mcp: { args: ['x'] }
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('publishManifestSchema — publish lifecycle block (issue #454)', () => {
+  const base = { name: '@org/p', version: '1.0.0' };
+
+  it('accepts manifest with publish.build', () => {
+    const r = publishManifestSchema.safeParse({ ...base, publish: { build: 'npm run build' } });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts manifest with publish.files', () => {
+    const r = publishManifestSchema.safeParse({ ...base, publish: { files: ['dist/**'] } });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts manifest with both publish.build and publish.files', () => {
+    const r = publishManifestSchema.safeParse({
+      ...base,
+      publish: { build: 'tsc', files: ['dist/**', 'README.md'] }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts manifest with NO publish block (backwards compatible)', () => {
+    const r = publishManifestSchema.safeParse(base);
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects unknown keys inside publish block', () => {
+    const r = publishManifestSchema.safeParse({ ...base, publish: { rogue: 'x' } });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects non-string entries in publish.files', () => {
+    const r = publishManifestSchema.safeParse({ ...base, publish: { files: ['ok', 42] } });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/internals-schemas/src/schemas/atoms/tool.ts
+++ b/packages/internals-schemas/src/schemas/atoms/tool.ts
@@ -8,12 +8,13 @@ export const mcpServerConfigSchema = z
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
     runtime: z.string().min(1).optional(),
-    entry: z.string().min(1).optional()
+    entry: z.string().min(1).optional(),
+    package: z.string().min(1).optional()
   })
   .strict()
   .refine(
-    (data) => data.command || (data.runtime && data.entry),
-    'MCP config must have either "command" or both "runtime" and "entry"'
+    (data) => Boolean(data.command) || Boolean(data.runtime && (data.entry || data.package)),
+    'MCP config must have either "command" or "runtime" plus one of "entry"/"package"'
   );
 
 export const toolIRSchema = z

--- a/packages/internals-schemas/src/schemas/skills-json.ts
+++ b/packages/internals-schemas/src/schemas/skills-json.ts
@@ -37,16 +37,27 @@ export const skillsJsonSchema = z.object(baseManifestFields).strict();
 
 export type SkillsJson = z.infer<typeof skillsJsonSchema>;
 
+export const publishConfigSchema = z
+  .object({
+    build: z.string().min(1, 'publish.build must be a non-empty shell command').optional(),
+    files: z.array(z.string().min(1)).optional()
+  })
+  .strict();
+
+export type PublishConfig = z.infer<typeof publishConfigSchema>;
+
 /**
  * Publish manifest schema — accepts both legacy skills.json AND atom-enriched tank.json.
  * The `atoms` and `includes` fields are passed through as opaque JSON arrays,
  * validated only at surface level. Full atom IR validation happens at build time.
+ * The `publish` block is a CLI-only lifecycle config (build hook + files allow-list).
  */
 export const publishManifestSchema = z
   .object({
     ...baseManifestFields,
     atoms: z.array(z.record(z.string(), z.unknown())).optional(),
-    includes: z.array(z.string()).optional()
+    includes: z.array(z.string()).optional(),
+    publish: publishConfigSchema.optional()
   })
   .strict();
 

--- a/packages/proxy/src/__tests__/shadow-registry.test.ts
+++ b/packages/proxy/src/__tests__/shadow-registry.test.ts
@@ -15,6 +15,8 @@ let file: string;
 beforeEach(() => {
   dir = mkdtempSync(path.join(tmpdir(), 'tank-shadow-reg-'));
   file = path.join(dir, 'registry.jsonl');
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-20T12:00:00Z'));
 });
 
 afterEach(() => {


### PR DESCRIPTION
Fixes the two linked publishing issues blocking non-Node MCP authors.

## Closes

- Closes #453 — tool atom `extensions` field silently ignored; no runtime support for non-Node MCP servers (Python/uvx)
- Closes #454 — `build` and `publish` lifecycle hooks in `tank.json` for pre-publish compilation

## Issue #453 — Non-Node MCP runtimes

Two complementary paths, both shipped in this PR:

**Canonical `mcp.runtime`** — first-class support for Python/uvx and friends:

```jsonc
{
  "kind": "tool",
  "name": "web-search",
  "mcp": { "runtime": "uvx", "package": "web-search-mcp" }
}
```

Supported runtimes: `uvx`, `npx` (auto-injects `-y`), `bunx`, `pipx`, `node`, `python`. Adapters map this to `{command, args, env}` per client (`.opencode/mcp/*.json`, `.mcp.json`, `.cursor/mcp.json`, etc.).

**`extensions.<adapterName>` fallback** — the documented adapter-scoped escape hatch now actually does something:

```jsonc
{
  "kind": "tool",
  "name": "memory",
  "extensions": {
    "opencode":    { "command": "uvx", "args": ["memory-mcp"], "env": { "X": "1" } },
    "claude-code": { "command": "uvx", "args": ["memory-mcp"] }
  }
}
```

All six adapters (opencode, claude-code, cursor, windsurf, cline, roo-code) now emit real MCP config for non-Node tools instead of warning `"has no MCP config — cannot register"`.

## Issue #454 — Publish lifecycle

New optional `publish` block in `tank.json`:

```jsonc
{
  "name": "@my/mcp",
  "version": "1.0.0",
  "publish": {
    "build": "npm run build",
    "files": ["dist/**", "SKILL.md", "tank.json"]
  }
}
```

- `publish.build` — shell command run **before** packing with `stdio: inherit`. Non-zero exit aborts publish before any upload.
- `publish.files` — explicit allow-list of globs. Overrides `.tankignore`/`.gitignore`/defaults. Security baseline (`node_modules`, `.git`) is still always excluded. Manifest + `SKILL.md`/`README.md` are always included.
- Both fields optional → fully backwards compatible.
- The `publish` block is stripped from the manifest body sent to `/api/v1/skills` (CLI-only concern).

## End-to-end smoke (per bulletproof methodology)

Fixture using BOTH issues:

```jsonc
// tank.json
{
  "name": "@smoke/python-mcp", "version": "1.0.0",
  "atoms": [
    { "kind": "tool", "name": "smoke-search", "mcp": { "runtime": "uvx", "package": "smoke-search-mcp" } },
    { "kind": "tool", "name": "memory", "extensions": { "opencode": { "command": "uvx", "args": ["memory-mcp"] } } }
  ],
  "publish": {
    "build": "mkdir -p dist && echo 'console.log(1)' > dist/main.js && echo BUILD_OK",
    "files": ["dist/**", "SKILL.md"]
  }
}
```

`tank publish --dry-run` against this fixture (with `dist/` in `.gitignore` and a stray `src.ts`):

```
ℹ Running build: mkdir -p dist && echo 'console.log(1)' > dist/main.js && echo 'BUILD_OK'
BUILD_OK
ℹ size:    727 B (3 files)
✓ Dry run complete — no files were uploaded.
```

Tarball file list: `["tank.json", "dist/main.js", "SKILL.md"]` — `dist/main.js` included despite `.gitignore`; `src.ts` excluded automatically.

Adapter output for the uvx tool (real compileAtom call):

```jsonc
// .opencode/mcp/smoke-search.json
{ "smoke-search": { "type": "local", "command": ["uvx", "smoke-search-mcp"] } }

// .mcp.json (Claude Code)
{ "mcpServers": { "smoke-search": { "command": "uvx", "args": ["smoke-search-mcp"] } } }
```

## Test summary

- `packages/internals-schemas`: **98/98** passing — new tool-runtime + publish-block cases in `__tests__/atoms/tool-runtimes.test.ts`.
- `packages/adapters`: **25/25** passing — new `__tests__/tool-runtimes.test.ts` covering all six adapters × 4 scenarios + sanity.
- `packages/cli`: **549/549** passing — new `__tests__/publish-lifecycle.test.ts` exercises real `spawn()` for the build hook and real filesystem for the files allow-list (no mocks, per bulletproof).
- `tsc --noEmit` clean across all three packages.
- `biome check` clean on all new/changed files (pre-existing warnings in unrelated files untouched).

## IDD/BDD artifacts

- `idd/modules/atom-architecture/INTENT.md` — examples E24–E27.
- `idd/modules/publish/INTENT.md` — constraints C13–C15, examples E11–E13.
- `bdd/features/system/atom-architecture/tool-runtimes.feature`
- `bdd/features/system/publish/lifecycle-hooks.feature`
- `bdd/qa/resolutions/2026-05-20-mcp-publish-453-454.md`

## Files changed

```
packages/internals-schemas/src/schemas/atoms/tool.ts          (+5 -2)
packages/internals-schemas/src/schemas/skills-json.ts          (+12 -1)
packages/adapters/src/adapters/_mcp-resolution.ts              (+71 new)
packages/adapters/src/adapters/{opencode,claude-code,cursor,windsurf,cline,roo-code}.ts  (each ~+5 -8)
packages/cli/src/lib/build-hook.ts                             (+27 new)
packages/cli/src/lib/packer.ts                                 (~+20 -10)
packages/cli/src/commands/publish.ts                           (+15 -3)
```

Two commits, one per issue, for clean review.
