### PR TITLE
fix(schemas): packageIRSchema accepts 'publish' field (regression from #455)

### DIFF
--- a/packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts
+++ b/packages/internals-schemas/src/__tests__/atoms/tool-runtimes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { packageIRSchema } from '~/schemas/atoms/package.js';
 import { toolIRSchema } from '~/schemas/atoms/tool.js';
 import { publishManifestSchema } from '~/schemas/skills-json.js';
 
@@ -92,6 +93,28 @@ describe('publishManifestSchema — publish lifecycle block (issue #454)', () =>
 
   it('rejects non-string entries in publish.files', () => {
     const r = publishManifestSchema.safeParse({ ...base, publish: { files: ['ok', 42] } });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('packageIRSchema accepts publish field (regression: tank build broke when both atoms and publish present)', () => {
+  it('accepts an atom-bearing package with a publish block', () => {
+    const r = packageIRSchema.safeParse({
+      name: '@org/p',
+      version: '1.0.0',
+      atoms: [{ kind: 'instruction', content: './SKILL.md' }],
+      publish: { build: 'npm run build', files: ['dist/**'] }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('still rejects unknown top-level keys', () => {
+    const r = packageIRSchema.safeParse({
+      name: '@org/p',
+      version: '1.0.0',
+      atoms: [{ kind: 'instruction', content: './SKILL.md' }],
+      rogue: true
+    });
     expect(r.success).toBe(false);
   });
 });

--- a/packages/internals-schemas/src/schemas/atoms/package.ts
+++ b/packages/internals-schemas/src/schemas/atoms/package.ts
@@ -10,6 +10,7 @@ import { promptIRSchema } from './prompt.js';
 import { resourceIRSchema } from './resource.js';
 import { ruleIRSchema } from './rule.js';
 import { toolIRSchema } from './tool.js';
+import { publishConfigSchema } from '../skills-json.js';
 
 const NAME_PATTERN = /^@[a-z0-9-]+\/[a-z0-9][a-z0-9-]*$/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;
@@ -44,7 +45,8 @@ export const packageIRSchema = z
     audit: z
       .object({ min_score: z.number().min(0).max(10) })
       .strict()
-      .optional()
+      .optional(),
+    publish: publishConfigSchema.optional()
   })
   .strict();
 

--- a/packages/internals-schemas/src/schemas/atoms/package.ts
+++ b/packages/internals-schemas/src/schemas/atoms/package.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { MAX_DESCRIPTION_LENGTH, MAX_NAME_LENGTH } from '~/constants/registry.js';
 import { permissionsSchema } from '~/schemas/permissions.js';
-
+import { publishConfigSchema } from '../skills-json.js';
 import { agentIRSchema } from './agent.js';
 import { hookIRSchema } from './hook.js';
 import { instructionIRSchema } from './instruction.js';
@@ -10,7 +10,6 @@ import { promptIRSchema } from './prompt.js';
 import { resourceIRSchema } from './resource.js';
 import { ruleIRSchema } from './rule.js';
 import { toolIRSchema } from './tool.js';
-import { publishConfigSchema } from '../skills-json.js';
 
 const NAME_PATTERN = /^@[a-z0-9-]+\/[a-z0-9][a-z0-9-]*$/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;


### PR DESCRIPTION
Follow-up to #455. Caught during post-merge smoke testing.

## Problem

PR #455 added the `publish` block to `publishManifestSchema` (used by `tank publish`) but `packageIRSchema` (used by `tank build` via `normalizeDirectory`) is `.strict()` and didn't learn about it.

Reproducer — any `tank.json` that combines atoms with the new lifecycle hooks:

```jsonc
{
  "name": "@my/mcp",
  "version": "1.0.0",
  "atoms": [{ "kind": "tool", "name": "x", "mcp": { "runtime": "uvx", "package": "x" } }],
  "publish": { "build": "npm run build", "files": ["dist/**"] }
}
```

```
$ tank build .
✖ Build failed
Build failed: Invalid manifest:
  : Unrecognized key: "publish"
```

## Fix

Add `publish: publishConfigSchema.optional()` to `packageIRSchema`. Add a regression test that asserts atoms + `publish` compose.

## Verification

- `packages/internals-schemas`: 100/100 tests pass (2 new regression cases).
- End-to-end smoke against the rebuilt CLI: `tank build . --platform opencode` and `--platform claude-code` both succeed for a fixture using `runtime: uvx`, `runtime: npx`, `extensions.<adapter>` fallback, AND a `publish` block. All three tools register correctly in `.opencode/mcp/*.json` and `.mcp.json`.
