### PR TITLE
chore(ci): switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/cli-nightly.yml
+++ b/.github/workflows/cli-nightly.yml
@@ -6,10 +6,21 @@ on:
   push:
     branches: [main]
     paths: ["packages/**"]
+    tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "nightly (default) or release (publishes versioned tag without -nightly suffix)"
+        required: false
+        default: nightly
+        type: choice
+        options:
+          - nightly
+          - release
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -23,6 +34,12 @@ jobs:
           registry-url: https://registry.npmjs.org
       - uses: extractions/setup-just@v2
       - run: bun install --frozen-lockfile
-      - run: just ci-publish-npm-nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm install -g npm@latest
+
+      - name: Publish nightly
+        if: github.event_name != 'push' || startsWith(github.ref, 'refs/heads/')
+        run: just ci-publish-npm-nightly
+
+      - name: Publish release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: just ci-publish-npm "${GITHUB_REF_NAME#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,21 +96,11 @@ jobs:
           generate_release_notes: true
           files: release/*
 
-  publish-npm:
-    runs-on: ubuntu-22.04
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-      - uses: extractions/setup-just@v2
-      - run: bun install --frozen-lockfile
-      - run: just ci-publish-npm "${GITHUB_REF_NAME#v}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # npm publish lives in cli-nightly.yml (tag-push trigger). DO NOT add an
+  # `npm publish` job here: npm Trusted Publishing binds each package to ONE
+  # workflow filename, and cli-nightly.yml is the registered publisher for
+  # @tankpkg/cli, @tankpkg/mcp-server, @tankpkg/sdk. Adding a publish job
+  # here would silently 404 on every release.
 
   update-homebrew:
     runs-on: ubuntu-22.04

--- a/justfile
+++ b/justfile
@@ -441,9 +441,9 @@ ci-publish-npm-nightly:
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build cli
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build mcp
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build sdk
-    (cd packages/cli && npm publish --no-git-checks --access public --tag nightly)
-    (cd packages/mcp-server && npm publish --no-git-checks --access public --tag nightly)
-    (cd packages/sdk && npm publish --no-git-checks --access public --tag nightly)
+    (cd packages/cli && npm publish --no-git-checks --access public --tag nightly --provenance)
+    (cd packages/mcp-server && npm publish --no-git-checks --access public --tag nightly --provenance)
+    (cd packages/sdk && npm publish --no-git-checks --access public --tag nightly --provenance)
 
 [group('ci')]
 ci-publish-npm VERSION:
@@ -451,9 +451,9 @@ ci-publish-npm VERSION:
     set -euo pipefail
     just ci-build-cli {{VERSION}}
     (cd packages/sdk && bun run build)
-    (cd packages/cli && npm publish --no-git-checks --access public)
-    (cd packages/mcp-server && npm publish --no-git-checks --access public)
-    (cd packages/sdk && npm publish --no-git-checks --access public)
+    (cd packages/cli && npm publish --no-git-checks --access public --provenance)
+    (cd packages/mcp-server && npm publish --no-git-checks --access public --provenance)
+    (cd packages/sdk && npm publish --no-git-checks --access public --provenance)
 
 [group('ci')]
 ci-build-pypi-sdk VERSION:


### PR DESCRIPTION
Replaces the broken `NPM_TOKEN` flow with npm Trusted Publishing (OIDC). No long-lived secret to rotate or leak.

## Why

PR #455's nightly run failed with `npm error 404 PUT /@tankpkg%2fcli` because the `NPM_TOKEN` secret in CI is broken (expired/revoked). When attempting to mint a new granular token, npm itself recommended against long-lived tokens:

> *"There are security risks with this option. For automation or CI/CD uses, please use Trusted Publishing instead."*

This switches to OIDC. GitHub Actions issues a short-lived token at runtime, validated by npm against a configured `(repo, workflow filename, environment)` tuple per package. No secret stored anywhere.

## The "only one workflow per package" constraint

Per [npm's Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers):

> *"Each package can only have one trusted publisher connection at a time."*

So instead of registering both `cli-nightly.yml` AND `release.yml` (impossible), this PR consolidates: `cli-nightly.yml` becomes the single npm-publishing workflow, triggered by **both** the nightly cron AND tag pushes. The publish job branches on the trigger type to call either `ci-publish-npm-nightly` or `ci-publish-npm <version>` accordingly. `release.yml` keeps everything else (build, GitHub Release, Homebrew, .deb, PyPI) — it just loses the npm publish job.

A load-bearing comment in `release.yml` warns future maintainers not to re-add an `npm publish` step there.

## Required npm UI work (one-time, you do this manually)

For each of the three packages, go to `https://www.npmjs.com/package/<name>/access` → **Trusted Publisher** section and add:

| Field | Value |
|---|---|
| Publisher | GitHub Actions |
| Organization or user | `tankpkg` |
| Repository | `tank` |
| Workflow filename | `cli-nightly.yml` |
| Environment name | *(empty)* |

Packages:
- ✅ `@tankpkg/cli` (already done per your screenshot)
- ⬜ `@tankpkg/mcp-server`
- ⬜ `@tankpkg/sdk`

Then for each package, set **Publishing access** → *"Require two-factor authentication and disallow tokens"*. Trusted publishers are explicitly compatible with this (per npm's UI: *"will continue to work regardless of which option you select"*), and it kills the legacy token path entirely.

## Code changes

- `.github/workflows/cli-nightly.yml` — add `id-token: write`, add `push.tags: ["v*"]` trigger, add `workflow_dispatch.inputs.mode`, split publish step by trigger (nightly vs release). Drop `NODE_AUTH_TOKEN`. Upgrade npm to latest (≥11.5 has OIDC autodetection).
- `.github/workflows/release.yml` — drop the `publish-npm` job; add a load-bearing warning comment.
- `justfile` — add `--provenance` to every `npm publish` call so packages carry signed build provenance attestations (visible as a badge on npmjs.com).

## Cleanup after merge

Once the npm UI is configured for all 3 packages AND the first nightly + first tagged release both succeed:

```bash
gh secret delete NPM_TOKEN --repo tankpkg/tank
```

This permanently kills the legacy publish path. Trusted Publishing becomes the only way `@tankpkg/*` packages can be published.

## References

- npm Trusted Publishing docs: https://docs.npmjs.com/trusted-publishers
- npm provenance docs: https://docs.npmjs.com/generating-provenance-statements
- The "one workflow per package" troubleshooting note: https://docs.npmjs.com/trusted-publishers#troubleshooting
