### PR TITLE
fix(packages): add repository.url so npm OIDC provenance verification passes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,16 @@
   "version": "0.15.7",
   "description": "Security-first package manager for AI agent skills",
   "type": "module",
+  "homepage": "https://github.com/tankpkg/tank",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tankpkg/tank.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/tankpkg/tank/issues"
+  },
+  "license": "MIT",
   "bin": {
     "tank": "dist/bin/tank.js"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -3,6 +3,16 @@
   "version": "0.15.7",
   "description": "MCP server for Tank - scan and publish AI agent skills from your editor",
   "type": "module",
+  "homepage": "https://github.com/tankpkg/tank",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tankpkg/tank.git",
+    "directory": "packages/mcp-server"
+  },
+  "bugs": {
+    "url": "https://github.com/tankpkg/tank/issues"
+  },
+  "license": "MIT",
   "bin": {
     "tank-mcp": "dist/index.js"
   },
@@ -45,11 +55,5 @@
     "claude",
     "cursor",
     "copilot"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tankpkg/tank.git",
-    "directory": "packages/mcp-server"
-  },
-  "license": "MIT"
+  ]
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,16 @@
   "version": "0.15.7",
   "description": "Official TypeScript SDK for the Tank registry — search, download, install, and audit AI agent skills programmatically",
   "type": "module",
+  "homepage": "https://github.com/tankpkg/tank",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tankpkg/tank.git",
+    "directory": "packages/sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/tankpkg/tank/issues"
+  },
+  "license": "MIT",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes the post-#457 OIDC publish failure.

## What happened

PR #457 set up Trusted Publishing. The first run got far enough to:
- ✅ Auth via OIDC (no more 404)
- ✅ Sign provenance bundle via Sigstore
- ✅ Push the provenance to the transparency log (log index [1586692889](https://search.sigstore.dev/?logIndex=1586692889))
- ❌ Then npm rejected the publish with 422:

> Error verifying sigstore provenance bundle: Failed to validate repository information: `package.json: "repository.url" is ""`, expected to match `https://github.com/tankpkg/tank` from provenance

## Root cause

`@tankpkg/cli` and `@tankpkg/sdk` had no `repository` field at all in their `package.json`. `@tankpkg/mcp-server` had one (and that's why it didn't error first — the publish order is cli → mcp-server → sdk and cli failed first).

npm's docs are explicit on this:

> *"To publish from GitHub, your package's `repository.url` field in `package.json` must exactly match your GitHub repository."*

## Fix

Adds `repository`, `homepage`, `bugs`, `license` to all three packages, plus removes a pre-existing duplicate `repository`/`license` block in mcp-server's package.json (caught by biome lint).

All three packages now have a consistent block:

```jsonc
"homepage": "https://github.com/tankpkg/tank",
"repository": {
  "type": "git",
  "url": "https://github.com/tankpkg/tank.git",
  "directory": "packages/<name>"
},
"bugs": { "url": "https://github.com/tankpkg/tank/issues" },
"license": "MIT",
```

## Verification plan

After merge, re-trigger `CLI Nightly` via workflow_dispatch and confirm:
1. The publish step shows `Provenance statement published to transparency log` (it already did pre-fix).
2. The publish step ends with `+ @tankpkg/cli@0.0.0-nightly.<date>.<sha>` instead of 422.
3. `npm view @tankpkg/cli@nightly` shows the new version.
4. `npm i -g @tankpkg/cli@nightly` works.