### PR TITLE
fix(release): make @tankpkg/{cli,mcp-server,sdk} install standalone from npm

### DIFF
--- a/justfile
+++ b/justfile
@@ -438,9 +438,12 @@ ci-publish-npm-nightly:
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build internals-schemas
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build internals-helpers
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build adapters
+    TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build sdk
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build cli
     TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build mcp
-    TANK_REGISTRY_URL=https://nightly.tankpkg.dev just build sdk
+    bash scripts/justfile/rewrite-workspace-deps.sh packages/cli "${NIGHTLY_VERSION}"
+    bash scripts/justfile/rewrite-workspace-deps.sh packages/mcp-server "${NIGHTLY_VERSION}"
+    bash scripts/justfile/rewrite-workspace-deps.sh packages/sdk "${NIGHTLY_VERSION}"
     (cd packages/cli && npm publish --no-git-checks --access public --tag nightly --provenance)
     (cd packages/mcp-server && npm publish --no-git-checks --access public --tag nightly --provenance)
     (cd packages/sdk && npm publish --no-git-checks --access public --tag nightly --provenance)
@@ -451,6 +454,9 @@ ci-publish-npm VERSION:
     set -euo pipefail
     just ci-build-cli {{VERSION}}
     (cd packages/sdk && bun run build)
+    bash scripts/justfile/rewrite-workspace-deps.sh packages/cli "{{VERSION}}"
+    bash scripts/justfile/rewrite-workspace-deps.sh packages/mcp-server "{{VERSION}}"
+    bash scripts/justfile/rewrite-workspace-deps.sh packages/sdk "{{VERSION}}"
     (cd packages/cli && npm publish --no-git-checks --access public --provenance)
     (cd packages/mcp-server && npm publish --no-git-checks --access public --provenance)
     (cd packages/sdk && npm publish --no-git-checks --access public --provenance)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -33,23 +33,15 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
-    "@internals/helpers": "workspace:*",
     "tar": "^7.5.11",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@internals/helpers": "workspace:*",
     "@internals/schemas": "workspace:*",
     "@types/node": "^25.5.0",
     "@types/tar": "^7.0.87",
     "tsdown": "^0.21.3",
     "vitest": "^4"
-  },
-  "peerDependencies": {
-    "@internals/schemas": "workspace:*"
-  },
-  "peerDependenciesMeta": {
-    "@internals/schemas": {
-      "optional": true
-    }
   }
 }

--- a/scripts/justfile/rewrite-workspace-deps.sh
+++ b/scripts/justfile/rewrite-workspace-deps.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rewrite "workspace:*" in dependencies / optionalDependencies / peerDependencies
+# to a concrete VERSION inside packages/$PKG/package.json.
+#
+# Usage: rewrite-workspace-deps.sh <pkg-dir> <version>
+# Example: rewrite-workspace-deps.sh packages/cli 0.0.0-nightly.20260520.abc1234
+#
+# npm publish does NOT automatically rewrite workspace: protocol specs when run
+# from a sub-directory (only from the workspace root). We do it explicitly to
+# keep the published package.json semver-compatible for end-users.
+
+PKG_DIR="${1:?pkg-dir required}"
+VERSION="${2:?version required}"
+PKG_JSON="${PKG_DIR}/package.json"
+
+if [[ ! -f "${PKG_JSON}" ]]; then
+  echo "rewrite-workspace-deps: ${PKG_JSON} not found" >&2
+  exit 1
+fi
+
+jq --arg v "${VERSION}" '
+  def rewrite(deps):
+    if (deps | type) == "object"
+      then (deps | with_entries(
+        if (.value | type) == "string" and (.value | startswith("workspace:"))
+          then .value = $v
+          else .
+        end
+      ))
+      else deps
+    end;
+  .dependencies = rewrite(.dependencies)
+  | .optionalDependencies = rewrite(.optionalDependencies)
+  | .peerDependencies = rewrite(.peerDependencies)
+' "${PKG_JSON}" > "${PKG_JSON}.tmp" && mv "${PKG_JSON}.tmp" "${PKG_JSON}"
+
+echo "rewrite-workspace-deps: ${PKG_JSON} dependencies pinned to ${VERSION}"


### PR DESCRIPTION
Closes the standalone-install gap that blocked the post-#455/#456 nightly smoke test.

## Problem

`npm i -g @tankpkg/cli@nightly` succeeded, but `tank --version` immediately crashed:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@tankpkg/sdk' 
  imported from .../@tankpkg/cli/dist/bin/tank.js
```

And `npm i @tankpkg/sdk` failed entirely:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

## Root cause (two-part)

1. **`ci-publish-npm-nightly` built cli before sdk.** tsdown's `alwaysBundle` only inlines workspace packages whose dist exists at build time. With no dist for sdk yet, tsdown treated the import as external — the bundled `tank.js` carried a literal `import { ... } from "@tankpkg/sdk"` that breaks any standalone install.

2. **`@tankpkg/sdk` had `@internals/helpers` (private, never published) in runtime dependencies.** Even if cli inlined sdk correctly, sdk itself was unpublishable in any usable form. The `peerDependencies` + `peerDependenciesMeta` block for `@internals/schemas` was also dead weight (always-bundled by tsdown).

## Fix

| Change | File | Why |
|---|---|---|
| Reorder build: `sdk` before `cli` and `mcp-server` | `justfile` (`ci-publish-npm-nightly`) | Lets tsdown's `alwaysBundle` inline sdk into cli's bundle. Zero external `@tankpkg/sdk` refs after rebuild. |
| Move `@internals/helpers` to devDependencies; drop pointless peer config | `packages/sdk/package.json` | tsdown inlines it; verified zero external `@internals/*` refs in the rebuilt dist. |
| Add `scripts/justfile/rewrite-workspace-deps.sh` + call from both publish recipes | `justfile`, new script | Defense in depth — if a future contributor accidentally adds a published-pkg → workspace runtime dep, the rewrite pins it to the concrete version at publish time instead of EUNSUPPORTEDPROTOCOL-ing real users. |

## Verification (against locally-rebuilt CLI matching this branch)

```bash
$ cd packages/cli && npm pack
tankpkg-cli-0.15.7.tgz

$ npm install -g ./tankpkg-cli-0.15.7.tgz
$ tank --version
0.15.7

$ tank build . --platform opencode --out /tmp/check    # in fixture dir
✔ Built 4 files for opencode
  .opencode/mcp/uvx-search.json   ← #453: mcp.runtime: uvx works
  .opencode/mcp/npx-helper.json   ← #453: mcp.runtime: npx with -y prefix
  .opencode/mcp/ext-tool.json     ← #453: extensions.<adapter> fallback works
  .opencode/instructions/SKILL-md.md

$ tank publish --dry-run                              # in fixture dir
ℹ Running build: rm -rf dist && mkdir -p dist && echo 'console.log("built ok")' > dist/main.js && echo BUILD_OK   ← #454: build hook ran
BUILD_OK
ℹ size: 924 B (3 files)                                ← #454: only allow-listed files (no src/)
✓ Dry run complete — no files were uploaded.
```

The packed tarball at `packages/cli/tankpkg-cli-0.15.7.tgz` was inspected — its `package.json` has zero `workspace:*` entries in dependencies. All three packages (`cli`, `mcp-server`, `sdk`) now have **zero** `@tankpkg/*` or `@internals/*` in runtime `dependencies`. They're all fully self-contained.

## After merge

Next push to main re-triggers `CLI Nightly` automatically (packages/** changed). The published `@tankpkg/cli@nightly` will then install cleanly from public npm, completing the bulletproof verification chain for issues #453/#454.