### PR TITLE
feat: conversion improvements (closes #462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Conversion Improvements (Issue #462)
+
+End-to-end overhaul of the discovery → install funnel, driven by analytics showing 73% of homepage visitors never reach docs and 41% of traffic lands directly on `/skills`.
+
+**Homepage**
+- Hero now shows 4 scannable differentiator pills (Scanning · Vault · Permissions · Integrity) linking to their respective sections
+- Hero CTAs upgraded from tiny muted links to proper `<Button>` elements (Browse Packages, View Docs)
+- Hero stats row: package count · GitHub stars · MIT license (auto-hides on empty registries)
+- Sticky section nav appears after scrolling past hero (Stripe Docs / Linear pattern)
+- Section order reflows so Vault and Atoms appear in the first 5 sections (was buried at positions 8–10)
+- "Built with Tank" section featuring real production users (prompt2bot, Skills-IL)
+- "Recently published" feed showing the 6 newest verified packages
+- "Stay in the loop" community section linking to GitHub stars, releases, discussions, contributing
+
+**Skills list**
+- Dismissible value-proposition banner explaining the 6-stage security pipeline (localStorage persisted)
+- "Getting Started" CLI flow card in the desktop filter sidebar
+- Every skill card now shows a copyable `tank install -g <name>` snippet
+- Empty-state recovery: "No results for 'foo'" now includes copyable `tank search foo`, browse-all link, and publish guide link
+
+**Skill detail**
+- Install command (`tank install -g <name>`) now visible on desktop (was mobile-only)
+- "Trust summary" card above the tabs shows scan verdict at a glance
+- "View details →" button on the trust card jumps to the security tab
+- 404 page shows fuzzy-matched suggestions (`pg_trgm` similarity > 0.2) when a skill name doesn't exist
+
+**Docs**
+- Bottom CTA on every doc page: copyable install command + "Browse Packages" button
+- Command palette adds a "Learn" group with "What is Tank?" / "How does scanning work?" / "How does the Vault work?"
+
+**CLI**
+- `tank install` now accepts multiple targets in one invocation (`tank install -g @org/a @org/b@^1.0.0 https://x.com/c.tgz`)
+- npm-style `name@version` spec syntax
+- Back-compat shim preserves legacy `tank install @org/skill ^1.0.0` positional form
+- One failing target no longer aborts the rest; aggregated exit code
+- Failed install with "not found" now prints "Did you mean:" with fuzzy suggestions
+- `tank telemetry on|off|status` subcommand for managing opt-in usage analytics
+- First-run consent prompt on `tank init` and `tank login` (TTY only, never twice)
+- `tank doctor` now reports current telemetry state
+- All telemetry strictly opt-in; respects `TANK_TELEMETRY` env var and `TANK_MODE=selfhosted`
+
+**Infrastructure**
+- OG images now serve as PNG (was SVG — many social platforms don't render SVG previews)
+- Lazy-loaded `node:fs/promises` import in `@internals/helpers` so the package can be safely imported in browser bundles
+
 #### Universal Atom Architecture (Issue #352)
 
 Multi-atom skill packages that compile to native AI agent configs. Write once in `tank.json`, build for any platform.

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -28,6 +28,7 @@
     "@internals/helpers": "workspace:*",
     "@internals/schemas": "workspace:*",
     "@monaco-editor/react": "^4.7.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@shikijs/rehype": "^4.0.2",
     "@supabase/supabase-js": "^2.99.3",
     "@tanstack/react-form": "^1.28.5",

--- a/apps/registry/public/docs/cli.md
+++ b/apps/registry/public/docs/cli.md
@@ -106,28 +106,90 @@ tank publish
 
 ## tank install
 
-Install a skill from the Tank registry, a URL, or all skills from lockfile
+Install one or more skills from the Tank registry, URLs, or all skills from lockfile.
 
 **Aliases:** `i`
 
 ```bash
-tank install [name] [version-range]
+tank install [targets...]
 ```
+
+### Examples
+
+```bash
+# Install a single skill
+tank install @org/skill
+
+# Install with a version range (npm-style spec)
+tank install @org/skill@^1.0.0
+
+# Install multiple skills in one command
+tank install -g @org/a @org/b@^1.0.0 https://github.com/owner/repo
+
+# Install all skills from tank.lock
+tank install
+```
+
+If one target fails, others still attempt to install. The exit code is non-zero
+if any failed. When a name isn't found, the CLI prints "Did you mean:" with
+fuzzy-matched suggestions.
 
 ### Arguments
 
 | Name | Description | Required |
 |------|-------------|----------|
-| `name` | Skill name or URL (e.g., @org/skill-name or https://github.com/owner/repo). Omit to install from lockfile. | No |
-| `version-range` | Semver range (default: *) | No |
+| `targets` | One or more skill specs (`@org/skill`, `@org/skill@^1.0.0`) or URLs. Omit to install from lockfile. | No |
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
-| `-g, --global` | Install skill globally (available to all projects) |
+| `-g, --global` | Install skill(s) globally (available to all projects) |
 | `-y, --yes` | Auto-accept flagged scan verdicts |
 | `--dangerously-no-tank-proxy` | Skip wrapping MCP servers with the tank proxy (no scanning, no enforcement) |
+
+### Back-compat: legacy positional form
+
+The previous syntax `tank install @org/skill ^1.0.0` (positional version range)
+is still supported via a back-compat shim. The shim detects this form and
+rewrites it as `@org/skill@^1.0.0` internally.
+
+
+## tank telemetry
+
+Manage anonymous, opt-in usage telemetry.
+
+Telemetry is **disabled by default** and **never silently enabled**. The CLI
+asks once on first `tank init` or `tank login` (interactive only — never in
+CI). Decisions are persisted to `~/.tank/config.json` and never re-prompted.
+
+```bash
+tank telemetry <action>
+```
+
+### Examples
+
+```bash
+tank telemetry on       # opt in
+tank telemetry off      # opt out
+tank telemetry status   # show current state and reason
+```
+
+### Behavior
+
+- **Strictly opt-in.** No telemetry is sent until you run `tank telemetry on`
+  or accept the first-run prompt.
+- **No sensitive data.** Events contain command names, CLI version, OS
+  platform, and a random per-install UUID. Package names, file paths, repo
+  URLs, and API keys are never sent.
+- **Fire-and-forget.** Telemetry never blocks a command. Network failures are
+  swallowed silently with a 2-second timeout.
+- **Disabled on-prem.** `TANK_MODE=selfhosted` hard-disables telemetry.
+- **Env override.** `TANK_TELEMETRY=0` forces off; `TANK_TELEMETRY=1` forces
+  on — even if config says otherwise.
+
+To see what gets sent in production, run `tank doctor` — the diagnostics
+report includes the current telemetry state and reason.
 
 
 ## tank remove

--- a/apps/registry/src/api/routes/og.ts
+++ b/apps/registry/src/api/routes/og.ts
@@ -1,3 +1,4 @@
+import { Resvg } from '@resvg/resvg-js';
 import { Hono } from 'hono';
 import type { ReactNode } from 'react';
 import satori from 'satori';
@@ -14,13 +15,18 @@ async function loadFonts() {
   return font.byteLength > 0 ? [{ name: 'Geist', data: font, weight: 400 as const, style: 'normal' as const }] : [];
 }
 
-function svgResponse(svg: string) {
-  return new Response(svg, {
+function svgToPngResponse(svg: string) {
+  const png = new Resvg(svg, { fitTo: { mode: 'width', value: 1200 } }).render().asPng();
+  return new Response(png as unknown as BodyInit, {
     headers: {
-      'Content-Type': 'image/svg+xml',
+      'Content-Type': 'image/png',
       'Cache-Control': 'public, max-age=86400, s-maxage=86400'
     }
   });
+}
+
+function svgResponse(svg: string) {
+  return svgToPngResponse(svg);
 }
 
 export const ogRoutes = new Hono()

--- a/apps/registry/src/components/command-menu.tsx
+++ b/apps/registry/src/components/command-menu.tsx
@@ -8,11 +8,13 @@ import {
   CloudIcon,
   FileTextIcon,
   GithubIcon,
+  HelpCircleIcon,
   KeyIcon,
   LayoutDashboardIcon,
   LogInIcon,
   PackageSearchIcon,
   RocketIcon,
+  ScanIcon,
   ServerIcon,
   ShieldCheckIcon,
   TerminalIcon,
@@ -51,6 +53,12 @@ const DOC_PAGES = [
   { title: 'Self-Hosting', slug: 'self-hosting', icon: ServerIcon },
   { title: 'Self-Host Quickstart', slug: 'self-host-quickstart', icon: KeyIcon },
   { title: 'Documentation Home', slug: '', icon: BookIcon }
+] as const;
+
+const LEARN = [
+  { title: 'What is Tank?', href: '/docs/overview', icon: HelpCircleIcon },
+  { title: 'How does scanning work?', href: '/docs/security', icon: ScanIcon },
+  { title: 'How does the Vault work?', href: '/docs/vault', icon: ShieldCheckIcon }
 ] as const;
 
 const QUICK_LINKS = [
@@ -155,6 +163,17 @@ export function CommandMenu() {
             ))}
           </CommandGroup>
         )}
+
+        <CommandGroup heading="Learn">
+          {LEARN.map((item) => (
+            <CommandItem key={item.href} value={`learn-${item.title}`} onSelect={() => handleNavigate(item.href)}>
+              <item.icon className="text-tank" />
+              <span>{item.title}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        <CommandSeparator />
 
         <CommandGroup heading="Documentation">
           {DOC_PAGES.map((doc) => (

--- a/apps/registry/src/components/docs-bottom-cta.tsx
+++ b/apps/registry/src/components/docs-bottom-cta.tsx
@@ -1,0 +1,28 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowRight } from 'lucide-react';
+import { InstallSnippet } from '~/components/skills/install-snippet';
+import { Button } from '~/components/ui/button';
+
+export function DocsBottomCta() {
+  return (
+    <div data-testid="docs-bottom-cta" className="not-prose mt-12 pt-6 border-t border-border/50">
+      <div className="rounded-lg border border-tank/15 bg-tank/[0.02] px-5 py-4">
+        <p className="text-sm font-medium mb-2 text-foreground">Ready to try?</p>
+        <p className="text-xs text-muted-foreground mb-3">
+          Install the CLI and start adding secure, verified packages to your AI agent.
+        </p>
+        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+          <div className="w-full sm:w-auto sm:flex-1 min-w-0">
+            <InstallSnippet skillName="@org/package" testId="docs-bottom-install" />
+          </div>
+          <Button size="sm" asChild>
+            <Link to="/skills" search={{} as never} className="!text-primary-foreground !no-underline">
+              Browse Packages
+              <ArrowRight className="ml-1.5 w-3.5 h-3.5" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/registry/src/components/home/atoms-section.tsx
+++ b/apps/registry/src/components/home/atoms-section.tsx
@@ -15,7 +15,7 @@ const PLATFORMS = ['Claude Code', 'Cursor', 'OpenCode', 'Windsurf', 'Cline', 'Ro
 
 export function AtomsSection() {
   return (
-    <section className="relative z-[1] border-t border-border" aria-label="Atoms architecture">
+    <section id="atoms" className="relative z-[1] border-t border-border" aria-label="Atoms architecture">
       <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
         <motion.div
           className="text-center mb-12"

--- a/apps/registry/src/components/home/built-with-tank.tsx
+++ b/apps/registry/src/components/home/built-with-tank.tsx
@@ -1,0 +1,114 @@
+import { ArrowUpRight, ScanLine, Sparkles } from 'lucide-react';
+import { motion } from 'motion/react';
+
+interface Product {
+  name: string;
+  href: string;
+  tagline: string;
+  use: string;
+  icon: typeof ScanLine;
+  faviconUrl: string;
+}
+
+const PRODUCTS: Product[] = [
+  {
+    name: 'prompt2bot',
+    href: 'https://prompt2bot.com',
+    tagline: 'Turn a single prompt into a working AI agent.',
+    use: 'Uses the Tank SDK to load and verify skills dynamically at runtime.',
+    icon: Sparkles,
+    faviconUrl: 'https://www.google.com/s2/favicons?domain=prompt2bot.com&sz=64'
+  },
+  {
+    name: 'Skills-IL',
+    href: 'https://agentskills.co.il',
+    tagline: 'Hebrew-language skills marketplace for AI agents.',
+    use: 'Uses Tank as the security scanner for every published skill.',
+    icon: ScanLine,
+    faviconUrl: 'https://www.google.com/s2/favicons?domain=agentskills.co.il&sz=64'
+  }
+];
+
+export function BuiltWithTank() {
+  return (
+    <section
+      id="built-with"
+      data-testid="built-with-tank"
+      className="relative z-[1] border-t border-border"
+      aria-label="Built with Tank">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-12"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <p className="text-[11px] font-semibold uppercase tracking-[2px] text-tank mb-3">In Production</p>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">
+            Built with <span className="text-tank">Tank</span>
+          </h2>
+          <p className="text-muted-foreground text-[15px] max-w-lg mx-auto">
+            Real products use Tank to package, scan, and load AI agent skills in production.
+          </p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {PRODUCTS.map((product, i) => (
+            <motion.a
+              key={product.name}
+              href={product.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="built-with-card"
+              className="group rounded-lg border border-border bg-card/30 hover:bg-card/60 hover:border-tank/30 transition-colors p-6 flex flex-col gap-3 no-underline"
+              initial={{ opacity: 0, y: 15 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.08, duration: 0.25 }}>
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="flex-none size-9 rounded-md overflow-hidden border border-border bg-background">
+                    <img
+                      src={product.faviconUrl}
+                      alt=""
+                      aria-hidden="true"
+                      className="size-full object-cover"
+                      loading="lazy"
+                    />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="font-display text-lg font-semibold tracking-tight truncate">{product.name}</p>
+                    <p className="text-xs text-muted-foreground truncate">{product.tagline}</p>
+                  </div>
+                </div>
+                <ArrowUpRight className="size-4 text-muted-foreground group-hover:text-tank transition-colors shrink-0 mt-1" />
+              </div>
+
+              <div className="flex items-start gap-2 pt-3 border-t border-border/50">
+                <product.icon className="size-3.5 text-tank shrink-0 mt-0.5" />
+                <p className="text-[13px] text-muted-foreground leading-relaxed">{product.use}</p>
+              </div>
+            </motion.a>
+          ))}
+        </div>
+
+        <motion.p
+          className="text-center text-[12px] text-muted-foreground/60 mt-8"
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ delay: 0.3, duration: 0.3 }}>
+          Building something with Tank?{' '}
+          <a
+            href="https://github.com/tankpkg/tank/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-tank hover:underline">
+            Tell us
+          </a>{' '}
+          and we'll feature you here.
+        </motion.p>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/src/components/home/community.tsx
+++ b/apps/registry/src/components/home/community.tsx
@@ -1,0 +1,85 @@
+import { Bell, GitFork, Github, MessageCircle } from 'lucide-react';
+import { motion } from 'motion/react';
+
+interface CommunityProps {
+  starCount: number | null;
+  discordInviteUrl?: string;
+}
+
+export function Community({ starCount, discordInviteUrl }: CommunityProps) {
+  return (
+    <section
+      id="community"
+      data-testid="community"
+      className="relative z-[1] border-t border-border"
+      aria-label="Community">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-10"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <p className="text-[11px] font-semibold uppercase tracking-[2px] text-tank mb-3">Community</p>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">Stay in the loop</h2>
+          <p className="text-muted-foreground text-[15px]">
+            Tank is open source. Follow along, ask questions, ship improvements.
+          </p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <CommunityCard
+            icon={Github}
+            href="https://github.com/tankpkg/tank"
+            label="Star on GitHub"
+            sub={starCount ? `${starCount.toLocaleString()} stars` : 'Show support'}
+          />
+          <CommunityCard
+            icon={Bell}
+            href="https://github.com/tankpkg/tank/releases"
+            label="Watch releases"
+            sub="Subscribe to new versions"
+          />
+          <CommunityCard
+            icon={MessageCircle}
+            href="https://github.com/tankpkg/tank/discussions"
+            label="Discussions"
+            sub="Ask questions, share ideas"
+          />
+          {discordInviteUrl ? (
+            <CommunityCard icon={MessageCircle} href={discordInviteUrl} label="Discord" sub="Chat in real time" />
+          ) : (
+            <CommunityCard
+              icon={GitFork}
+              href="https://github.com/tankpkg/tank/blob/main/CONTRIBUTING.md"
+              label="Contribute"
+              sub="Help build Tank"
+            />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface CommunityCardProps {
+  icon: typeof Github;
+  href: string;
+  label: string;
+  sub: string;
+}
+
+function CommunityCard({ icon: Icon, href, label, sub }: CommunityCardProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid="community-card"
+      className="group rounded-lg border border-border bg-card/30 hover:bg-card/60 hover:border-tank/30 transition-colors p-4 no-underline flex flex-col gap-2">
+      <Icon className="size-5 text-tank" />
+      <p className="font-medium text-sm group-hover:text-foreground transition-colors">{label}</p>
+      <p className="text-xs text-muted-foreground">{sub}</p>
+    </a>
+  );
+}

--- a/apps/registry/src/components/home/comparison-table.tsx
+++ b/apps/registry/src/components/home/comparison-table.tsx
@@ -105,7 +105,7 @@ function StatusIcon({ status }: { status: 'yes' | 'partial' | 'no' }) {
 
 export function ComparisonTable() {
   return (
-    <section className="relative z-[1] border-t border-border" aria-label="Feature comparison">
+    <section id="comparison-table" className="relative z-[1] border-t border-border" aria-label="Feature comparison">
       <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
         <motion.div
           className="text-center mb-12"

--- a/apps/registry/src/components/home/faq-section.tsx
+++ b/apps/registry/src/components/home/faq-section.tsx
@@ -5,7 +5,7 @@ import { faqItems } from '~/consts/homepage';
 
 export function FaqSection() {
   return (
-    <section className="relative z-[1] border-t border-border" aria-label="FAQ">
+    <section id="faq" className="relative z-[1] border-t border-border" aria-label="FAQ">
       <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
         <motion.div
           className="text-center mb-12"

--- a/apps/registry/src/components/home/features-grid.tsx
+++ b/apps/registry/src/components/home/features-grid.tsx
@@ -6,7 +6,7 @@ import { features } from '~/consts/homepage';
 
 export function FeaturesGrid() {
   return (
-    <section className="relative z-[1] border-t border-border" aria-label="Security features">
+    <section id="features" className="relative z-[1] border-t border-border" aria-label="Security features">
       <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
         <motion.div
           className="text-center mb-12"

--- a/apps/registry/src/components/home/hero-section.tsx
+++ b/apps/registry/src/components/home/hero-section.tsx
@@ -1,20 +1,29 @@
 import { Link } from '@tanstack/react-router';
-import { Shield } from 'lucide-react';
+import { ArrowRight, Lock, Scan, Shield, Vault } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useCallback } from 'react';
 
 import { InstallSelector } from '~/components/home/install-selector';
+import { Button } from '~/components/ui/button';
 import { GITHUB_ICON_PATH } from '~/consts/brand';
 
 const spring = { type: 'spring' as const, stiffness: 400, damping: 30 };
 const controlBars = ['left', 'center', 'right'] as const;
 
+const DIFFERENTIATOR_PILLS = [
+  { label: '6-Stage Scanning', icon: Scan, href: '#how-it-works' },
+  { label: 'Credential Vault', icon: Vault, href: '#vault' },
+  { label: 'Permission Budgets', icon: Shield, href: '#why-tank' },
+  { label: 'SHA-512 Integrity', icon: Lock, href: '#features' }
+];
+
 interface HeroSectionProps {
   starCount: number | null;
+  publicSkillCount?: number;
   selfhostedAppUrl?: string;
 }
 
-export function HeroSection({ starCount, selfhostedAppUrl }: HeroSectionProps) {
+export function HeroSection({ starCount, publicSkillCount, selfhostedAppUrl }: HeroSectionProps) {
   const videoRef = useCallback((el: HTMLVideoElement | null) => {
     if (!el) return;
     el.playbackRate = 0.9;
@@ -63,44 +72,90 @@ export function HeroSection({ starCount, selfhostedAppUrl }: HeroSectionProps) {
               agents.
             </motion.p>
 
+            {/* Differentiator pills — scannable value props */}
+            <motion.div
+              className="mt-5 flex flex-wrap items-center justify-center lg:justify-start gap-2"
+              data-testid="hero-differentiator-pills"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.2, delay: 0.12 }}>
+              {DIFFERENTIATOR_PILLS.map((pill) => (
+                <a
+                  key={pill.label}
+                  href={pill.href}
+                  data-testid="hero-differentiator-pill"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-border bg-card/50 hover:bg-card hover:border-tank/30 transition-colors text-[12px] font-medium text-muted-foreground hover:text-foreground no-underline">
+                  <pill.icon className="w-3 h-3 text-tank" />
+                  {pill.label}
+                </a>
+              ))}
+            </motion.div>
+
+            {/* Stats row — social proof. Hidden entirely on an empty registry to avoid a "ghost town" impression. */}
+            {((publicSkillCount && publicSkillCount > 0) || (starCount && starCount > 0)) && (
+              <motion.div
+                className="mt-3 flex items-center justify-center lg:justify-start gap-4 text-[13px] text-muted-foreground/50"
+                data-testid="hero-stats"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.2, delay: 0.14 }}>
+                {publicSkillCount !== undefined && publicSkillCount > 0 && (
+                  <>
+                    <span>
+                      <span className="text-foreground/80 font-semibold">{publicSkillCount.toLocaleString()}</span>{' '}
+                      packages scanned
+                    </span>
+                    <span className="text-border">·</span>
+                  </>
+                )}
+                {starCount !== null && starCount > 0 && (
+                  <>
+                    <span>
+                      <span className="text-foreground/80 font-semibold">{starCount.toLocaleString()}</span> GitHub
+                      stars
+                    </span>
+                    <span className="text-border">·</span>
+                  </>
+                )}
+                <span>MIT Licensed</span>
+              </motion.div>
+            )}
+
             {/* Install method selector — biggest CTA */}
             <motion.div
-              className="mt-8 max-w-[560px] lg:mx-0 mx-auto w-full"
+              className="mt-6 max-w-[560px] lg:mx-0 mx-auto w-full"
               initial={{ opacity: 0, y: 10, scale: 0.98 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               transition={{ ...spring, delay: 0.15 }}>
               <InstallSelector appUrl={selfhostedAppUrl} />
             </motion.div>
 
-            {/* Secondary links */}
+            {/* CTAs — proper Buttons instead of tiny text links */}
             <motion.div
-              className="mt-6 flex items-center justify-center lg:justify-start gap-4 text-[13px]"
+              className="mt-4 flex items-center justify-center lg:justify-start gap-3"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.2, delay: 0.2 }}>
-              <Link
-                to="/docs/$"
-                params={{ _splat: '' }}
-                className="text-muted-foreground/60 hover:text-foreground transition-colors">
-                View Docs
-              </Link>
-              <span className="text-muted-foreground/20">·</span>
-              <Link
-                to="/skills"
-                search={{} as never}
-                className="text-muted-foreground/60 hover:text-foreground transition-colors">
-                Browse Packages
-              </Link>
-              <span className="text-muted-foreground/20">·</span>
+              <Button size="lg" asChild data-testid="home-primary-cta">
+                <Link to="/skills" search={{} as never}>
+                  Browse Packages
+                  <ArrowRight className="ml-2 w-4 h-4" />
+                </Link>
+              </Button>
+              <Button variant="outline" size="lg" data-testid="home-secondary-cta" asChild>
+                <Link to="/docs/$" params={{ _splat: '' }}>
+                  View Docs
+                </Link>
+              </Button>
               <a
                 href="https://github.com/tankpkg/tank"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-muted-foreground/60 hover:text-foreground transition-colors">
-                <svg className="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path fillRule="evenodd" d={GITHUB_ICON_PATH} clipRule="evenodd" />
                 </svg>
-                Star on GitHub{starCount !== null ? ` (${starCount})` : ''}
+                Star{starCount !== null ? ` ${starCount}` : ''}
               </a>
             </motion.div>
           </div>

--- a/apps/registry/src/components/home/how-it-works.tsx
+++ b/apps/registry/src/components/home/how-it-works.tsx
@@ -42,7 +42,7 @@ const STEPS = [
 
 export function HowItWorks() {
   return (
-    <section className="relative z-[1]" aria-label="How Tank works">
+    <section id="how-it-works" className="relative z-[1]" aria-label="How Tank works">
       <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
         <motion.div
           className="text-center mb-12"

--- a/apps/registry/src/components/home/recently-published.tsx
+++ b/apps/registry/src/components/home/recently-published.tsx
@@ -1,0 +1,91 @@
+import { encodeSkillName } from '@internals/helpers';
+import { Link } from '@tanstack/react-router';
+import { ArrowRight, ShieldCheck } from 'lucide-react';
+import { motion } from 'motion/react';
+
+import type { RecentSkill } from '~/query/skills';
+
+interface RecentlyPublishedProps {
+  skills: RecentSkill[];
+}
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const diffMs = Date.now() - then;
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.floor(day / 30);
+  return `${mo}mo ago`;
+}
+
+export function RecentlyPublished({ skills }: RecentlyPublishedProps) {
+  if (skills.length === 0) return null;
+
+  return (
+    <section
+      id="recently-published"
+      data-testid="recently-published"
+      className="relative z-[1] border-t border-border"
+      aria-label="Recently published packages">
+      <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
+        <motion.div
+          className="text-center mb-10"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.3 }}>
+          <p className="text-[11px] font-semibold uppercase tracking-[2px] text-tank mb-3">Fresh</p>
+          <h2 className="text-2xl sm:text-3xl font-display font-bold tracking-tight mb-3">Recently published</h2>
+          <p className="text-muted-foreground text-[15px]">The newest verified packages on Tank.</p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {skills.map((skill, i) => (
+            <motion.div
+              key={skill.name}
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.04, duration: 0.2 }}>
+              <Link
+                to="/skills/$"
+                params={{ _splat: encodeSkillName(skill.name) }}
+                data-testid="recent-skill-card"
+                className="block rounded-lg border border-border bg-card/30 hover:bg-card/60 hover:border-tank/30 transition-colors p-4 no-underline h-full">
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <p className="font-mono text-[13px] font-semibold text-foreground truncate">{skill.name}</p>
+                  {skill.scanVerdict === 'pass' && (
+                    <ShieldCheck className="size-3.5 text-tank shrink-0 mt-0.5" aria-label="Verified" />
+                  )}
+                </div>
+                {skill.description && (
+                  <p className="text-[12px] text-muted-foreground line-clamp-2 mb-2">{skill.description}</p>
+                )}
+                <p className="text-[11px] text-muted-foreground/60">
+                  by {skill.publisher} · {timeAgo(skill.publishedAt)}
+                </p>
+              </Link>
+            </motion.div>
+          ))}
+        </div>
+
+        <div className="mt-8 text-center">
+          <Link
+            to="/skills"
+            search={{} as never}
+            className="inline-flex items-center gap-1.5 text-sm text-tank hover:underline font-medium">
+            Browse all packages
+            <ArrowRight className="size-4" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/registry/src/components/home/sticky-section-nav.tsx
+++ b/apps/registry/src/components/home/sticky-section-nav.tsx
@@ -71,9 +71,7 @@ export function StickySectionNav() {
               key={section.id}
               href={`#${section.id}`}
               className={`shrink-0 rounded-md px-3 py-1.5 text-[13px] font-medium transition-colors whitespace-nowrap ${
-                activeSection === section.id
-                  ? 'bg-tank/10 text-tank'
-                  : 'text-muted-foreground hover:text-foreground'
+                activeSection === section.id ? 'bg-tank/10 text-tank' : 'text-muted-foreground hover:text-foreground'
               }`}>
               {section.label}
             </a>

--- a/apps/registry/src/components/home/sticky-section-nav.tsx
+++ b/apps/registry/src/components/home/sticky-section-nav.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+
+interface Section {
+  id: string;
+  label: string;
+}
+
+const SECTIONS: Section[] = [
+  { id: 'built-with', label: 'In Production' },
+  { id: 'why-tank', label: 'Why Tank' },
+  { id: 'vault', label: 'Vault' },
+  { id: 'how-it-works', label: 'How It Works' },
+  { id: 'atoms', label: 'Atoms' },
+  { id: 'comparison-table', label: 'Compare' },
+  { id: 'features', label: 'Features' },
+  { id: 'faq', label: 'FAQ' }
+];
+
+export function StickySectionNav() {
+  const [visible, setVisible] = useState(false);
+  const [activeSection, setActiveSection] = useState(SECTIONS[0].id);
+
+  useEffect(() => {
+    const heroEl = document.querySelector('[aria-label="Hero"]');
+    if (!heroEl) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setVisible(!entry.isIntersecting);
+      },
+      { threshold: 0 }
+    );
+    observer.observe(heroEl);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    const sectionEls = SECTIONS.map((s) => document.getElementById(s.id)).filter(Boolean) as HTMLElement[];
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: '-10% 0px -80% 0px' }
+    );
+
+    for (const el of sectionEls) {
+      observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, [visible]);
+
+  return (
+    <nav
+      data-testid="sticky-section-nav"
+      aria-hidden={!visible}
+      style={{ transform: 'translateZ(0)', WebkitTransform: 'translateZ(0)' }}
+      className={`fixed left-0 right-0 top-14 z-[60] border-b border-border bg-background/95 backdrop-blur-lg transition-opacity duration-200 ${
+        visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+      }`}
+      aria-label="Page sections">
+      <div className="mx-auto max-w-[1100px] px-4 sm:px-6 lg:px-8">
+        <div className="flex gap-1 overflow-x-auto py-2 scrollbar-none -mx-4 px-4 sm:mx-0 sm:px-0">
+          {SECTIONS.map((section) => (
+            <a
+              key={section.id}
+              href={`#${section.id}`}
+              className={`shrink-0 rounded-md px-3 py-1.5 text-[13px] font-medium transition-colors whitespace-nowrap ${
+                activeSection === section.id
+                  ? 'bg-tank/10 text-tank'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}>
+              {section.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/apps/registry/src/components/home/vault-section.tsx
+++ b/apps/registry/src/components/home/vault-section.tsx
@@ -21,7 +21,7 @@ const VAULT_LAYERS = [
 
 export function VaultSection() {
   return (
-    <section className="relative z-[1] border-t border-border" aria-label="Credential Vault">
+    <section id="vault" className="relative z-[1] border-t border-border" aria-label="Credential Vault">
       <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
         <motion.div
           className="text-center mb-12"

--- a/apps/registry/src/components/home/why-tank-exists.tsx
+++ b/apps/registry/src/components/home/why-tank-exists.tsx
@@ -38,7 +38,7 @@ const SOLUTIONS = [
 
 export function WhyTankExists() {
   return (
-    <section className="relative z-[1] border-b border-border" aria-label="Why Tank exists">
+    <section id="why-tank" className="relative z-[1] border-b border-border" aria-label="Why Tank exists">
       <div className="mx-auto max-w-[1000px] px-4 sm:px-6 lg:px-8 py-20">
         <motion.div
           className="text-center mb-12"

--- a/apps/registry/src/components/layouts/docs-layout.tsx
+++ b/apps/registry/src/components/layouts/docs-layout.tsx
@@ -115,7 +115,9 @@ function DocNavigation({ currentSlug }: { currentSlug: string | null }) {
   const nextTo = next ? (next.slug === 'index' ? '/docs' : `/docs/${next.slug}`) : null;
 
   return (
-    <div className="flex justify-between items-center mt-12 pt-6 border-t border-border/50">
+    <div
+      data-testid="doc-navigation"
+      className="flex justify-between items-center mt-12 pt-6 border-t border-border/50">
       {prev && prevTo ? (
         <a
           href={prevTo}

--- a/apps/registry/src/components/skills/getting-started.tsx
+++ b/apps/registry/src/components/skills/getting-started.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
+
+interface StepProps {
+  n: string;
+  label: string;
+  command: string;
+}
+
+function Step({ n, label, command }: StepProps) {
+  return (
+    <div className="flex gap-2.5">
+      <div className="flex-none mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-tank/10 text-[11px] font-bold text-tank border border-tank/20">
+        {n}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium mb-1">{label}</p>
+        <code className="block w-full overflow-x-auto rounded border bg-muted/50 px-2 py-1.5 font-mono text-[11px] whitespace-nowrap">
+          {command}
+        </code>
+      </div>
+    </div>
+  );
+}
+
+export function GettingStarted() {
+  return (
+    <Card data-testid="getting-started-card">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-semibold">Getting Started</CardTitle>
+        <CardDescription className="text-xs">Get Tank running in 3 steps.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Step n="1" label="Install the CLI" command="npm i -g @tankpkg/cli" />
+        <Step n="2" label="Search the registry" command="tank search <query>" />
+        <Step n="3" label="Install globally" command="tank install -g <pkg>" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/registry/src/components/skills/install-snippet.tsx
+++ b/apps/registry/src/components/skills/install-snippet.tsx
@@ -1,0 +1,33 @@
+import { Check, Copy } from 'lucide-react';
+
+import { useCopyToClipboard } from '~/hooks/use-copy-to-clipboard';
+
+interface InstallSnippetProps {
+  /** Skill name (e.g. "@org/package") */
+  skillName: string;
+  /** Optional testid prefix for the snippet container */
+  testId?: string;
+}
+
+export function InstallSnippet({ skillName, testId = 'install-snippet' }: InstallSnippetProps) {
+  const installCmd = `tank install -g ${skillName}`;
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <div data-testid={testId} className="flex items-center gap-2 rounded border bg-muted/50 px-2 py-1">
+      <code className="flex-1 min-w-0 truncate font-mono text-xs">{installCmd}</code>
+      <button
+        type="button"
+        data-testid={`${testId}-copy-btn`}
+        className="shrink-0 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          copy(installCmd);
+        }}>
+        {copied ? <Check className="size-3 text-tank" /> : <Copy className="size-3" />}
+        <span className="hidden sm:inline">{copied ? 'Copied' : 'Copy'}</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/registry/src/components/skills/skill-tabs.tsx
+++ b/apps/registry/src/components/skills/skill-tabs.tsx
@@ -79,6 +79,7 @@ export function SkillTabs({
       <TabsList className="w-full justify-start border-b rounded-none h-auto p-0 bg-transparent">
         <TabsTrigger
           value="readme"
+          data-testid="tab-readme"
           className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2">
           Readme
         </TabsTrigger>
@@ -103,6 +104,7 @@ export function SkillTabs({
         {hasSecurityData && (
           <TabsTrigger
             value="security"
+            data-testid="tab-security"
             className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 pb-2">
             Security
           </TabsTrigger>

--- a/apps/registry/src/components/skills/trust-summary.tsx
+++ b/apps/registry/src/components/skills/trust-summary.tsx
@@ -1,0 +1,43 @@
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
+import type { ScanDetails } from '~/lib/skills/data';
+
+interface TrustSummaryProps {
+  scanDetails: ScanDetails;
+  onViewDetails?: () => void;
+}
+
+export function TrustSummary({ scanDetails, onViewDetails }: TrustSummaryProps) {
+  const totalFindings =
+    (scanDetails.criticalCount ?? 0) + (scanDetails.highCount ?? 0) + (scanDetails.mediumCount ?? 0);
+  const isClean = totalFindings === 0 && scanDetails.verdict === 'pass';
+
+  return (
+    <div
+      data-testid="trust-summary-card"
+      className="rounded-lg border border-tank/15 bg-tank/[0.02] px-4 py-3 flex items-center gap-3 flex-wrap">
+      {isClean ? (
+        <ShieldCheck className="size-4 text-green-500 shrink-0" />
+      ) : (
+        <ShieldAlert className="size-4 text-amber-500 shrink-0" />
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">
+          {isClean ? 'Verified clean' : `Scan completed — ${totalFindings} finding${totalFindings !== 1 ? 's' : ''}`}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {isClean
+            ? 'No security issues detected in the latest scan.'
+            : `${scanDetails.criticalCount ?? 0} critical, ${scanDetails.highCount ?? 0} high, ${scanDetails.mediumCount ?? 0} medium — see security tab for details.`}
+        </p>
+      </div>
+      {onViewDetails && (
+        <button
+          type="button"
+          onClick={onViewDetails}
+          className="text-xs text-tank hover:underline font-medium shrink-0">
+          View details →
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/registry/src/components/skills/value-banner.tsx
+++ b/apps/registry/src/components/skills/value-banner.tsx
@@ -15,16 +15,13 @@ export function ValueBanner() {
   const [dismissed, setDismissed] = useState(true);
 
   useEffect(() => {
-    const persisted =
-      localStorage.getItem(STORAGE_KEY) === '1' || readDismissedCookie();
+    const persisted = localStorage.getItem(STORAGE_KEY) === '1' || readDismissedCookie();
     setDismissed(persisted);
     setMounted(true);
   }, []);
 
   if (!mounted || dismissed) {
-    return (
-      <div data-testid="value-banner-slot" hidden aria-hidden="true" />
-    );
+    return <div data-testid="value-banner-slot" hidden aria-hidden="true" />;
   }
 
   return (

--- a/apps/registry/src/components/skills/value-banner.tsx
+++ b/apps/registry/src/components/skills/value-banner.tsx
@@ -1,0 +1,58 @@
+import { Link } from '@tanstack/react-router';
+import { ShieldCheck, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'tank-value-banner-dismissed';
+const COOKIE_KEY = 'tank_vbd';
+
+function readDismissedCookie(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.cookie.split('; ').some((c) => c === `${COOKIE_KEY}=1`);
+}
+
+export function ValueBanner() {
+  const [mounted, setMounted] = useState(false);
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    const persisted =
+      localStorage.getItem(STORAGE_KEY) === '1' || readDismissedCookie();
+    setDismissed(persisted);
+    setMounted(true);
+  }, []);
+
+  if (!mounted || dismissed) {
+    return (
+      <div data-testid="value-banner-slot" hidden aria-hidden="true" />
+    );
+  }
+
+  return (
+    <div
+      data-testid="value-banner"
+      className="mb-4 rounded-lg border border-tank/15 bg-tank/[0.02] px-4 py-3 flex items-center gap-3 flex-wrap">
+      <ShieldCheck className="size-4 text-tank shrink-0" />
+      <p className="text-sm text-muted-foreground flex-1 min-w-0">
+        Every package here is scanned through a 6-stage security pipeline.
+        <Link
+          to="/docs/$"
+          params={{ _splat: 'overview' }}
+          className="ml-1 text-tank hover:underline font-medium whitespace-nowrap">
+          Learn more →
+        </Link>
+      </p>
+      <button
+        type="button"
+        data-testid="value-banner-dismiss"
+        className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+        aria-label="Dismiss banner"
+        onClick={() => {
+          localStorage.setItem(STORAGE_KEY, '1');
+          document.cookie = `${COOKIE_KEY}=1; path=/; max-age=31536000; samesite=lax`;
+          setDismissed(true);
+        }}>
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/registry/src/consts/homepage.ts
+++ b/apps/registry/src/consts/homepage.ts
@@ -73,7 +73,8 @@ export const features: Array<{ icon: LucideIcon; title: string; description: str
 ];
 
 export const cliCommands = [
-  { cmd: 'tank install @vercel/next-skill', desc: 'Install with integrity verification' },
+  { cmd: 'tank install -g @vercel/next-skill', desc: 'Install globally with integrity verification' },
+  { cmd: 'tank install -g @org/a @org/b@^1.0.0', desc: 'Install multiple skills in one command' },
   { cmd: 'tank run claude', desc: 'Launch agent with Credential Vault protection' },
   { cmd: 'tank build', desc: 'Compile atoms for Claude Code, Cursor, OpenCode, and more' },
   { cmd: 'tank search "react hooks"', desc: 'Search the registry' },

--- a/apps/registry/src/lib/analytics.ts
+++ b/apps/registry/src/lib/analytics.ts
@@ -5,10 +5,10 @@ let initialized = false;
 export function initPostHog() {
   if (initialized || typeof window === 'undefined') return;
 
-  const key = import.meta.env.VITE_POSTHOG_KEY;
-  const host = import.meta.env.VITE_POSTHOG_HOST;
+  const key = import.meta.env.VITE_POSTHOG_KEY ?? 'phc_j9KjoTTYWsM4k40f2h61x8TRe8cx4ZhIMIKIVri0G7Z';
+  const host = import.meta.env.VITE_POSTHOG_HOST ?? 'https://eu.i.posthog.com';
 
-  if (!key || !host) return;
+  if (!key) return;
 
   posthog.init(key, {
     api_host: host,

--- a/apps/registry/src/query/skills.ts
+++ b/apps/registry/src/query/skills.ts
@@ -1,8 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 import { createServerFn } from '@tanstack/react-start';
 import { getRequestHeaders } from '@tanstack/react-start/server';
+import { sql } from 'drizzle-orm';
 import { env } from '~/consts/env';
 import { auth } from '~/lib/auth/core';
+import { db } from '~/lib/db';
 import {
   type FreshnessBucket,
   getSkillDetail,
@@ -72,3 +74,91 @@ export function skillDetailQueryOptions(name: string) {
 export const isTalkEnabledFn = createServerFn({ method: 'GET' }).handler(async (): Promise<boolean> => {
   return !!env.PROMPT2BOT_API_TOKEN;
 });
+
+export interface SimilarSkillSuggestion {
+  name: string;
+  description: string | null;
+}
+
+/**
+ * Fuzzy-match a (likely mistyped) skill name to public published skills.
+ * Uses Postgres `pg_trgm` similarity. Threshold 0.2 keeps obvious typos in,
+ * filters out unrelated matches. Returns top 5 by similarity DESC.
+ */
+export interface RecentSkill {
+  name: string;
+  description: string | null;
+  publishedAt: string;
+  publisher: string;
+  scanVerdict: string | null;
+}
+
+export const recentSkillsFn = createServerFn({ method: 'GET' }).handler(async (): Promise<RecentSkill[]> => {
+  try {
+    const rows = await db.execute<{
+      name: string;
+      description: string | null;
+      publishedAt: string;
+      publisher: string;
+      verdict: string | null;
+    }>(sql`
+      SELECT
+        s.name,
+        s.description,
+        sv.created_at::text AS "publishedAt",
+        u.name AS publisher,
+        sr.verdict
+      FROM skills s
+      JOIN skill_versions sv ON sv.id = (
+        SELECT id FROM skill_versions WHERE skill_id = s.id ORDER BY created_at DESC LIMIT 1
+      )
+      JOIN "user" u ON u.id = s.publisher_id
+      LEFT JOIN LATERAL (
+        SELECT verdict FROM scan_results WHERE version_id = sv.id ORDER BY created_at DESC LIMIT 1
+      ) sr ON true
+      WHERE s.visibility = 'public' AND s.status = 'active'
+      ORDER BY sv.created_at DESC
+      LIMIT 6
+    `);
+    const list = (rows as unknown as { rows?: RecentSkill[] }).rows ?? rows;
+    const arr = Array.isArray(list) ? (list as RecentSkill[]) : [];
+    return arr.map((r) => ({
+      name: r.name,
+      description: r.description,
+      publishedAt: r.publishedAt,
+      publisher: r.publisher,
+      scanVerdict: r.scanVerdict ?? null
+    }));
+  } catch {
+    return [];
+  }
+});
+
+export function recentSkillsQueryOptions() {
+  return queryOptions({
+    queryKey: ['skills', 'recent'],
+    queryFn: () => recentSkillsFn(),
+    staleTime: 60_000
+  });
+}
+
+export const suggestSimilarSkillsFn = createServerFn({ method: 'GET' })
+  .inputValidator((input: string) => input)
+  .handler(async ({ data: name }): Promise<SimilarSkillSuggestion[]> => {
+    try {
+      const rows = await db.execute<{ name: string; description: string | null; sim: number }>(sql`
+        SELECT s.name, s.description, similarity(s.name, ${name}) AS sim
+        FROM skills s
+        WHERE s.visibility = 'public'
+          AND s.status = 'active'
+          AND similarity(s.name, ${name}) > 0.2
+        ORDER BY sim DESC
+        LIMIT 5
+      `);
+      const list = (rows as unknown as { rows?: Array<{ name: string; description: string | null }> }).rows ?? rows;
+      const arr = Array.isArray(list) ? list : [];
+      return arr.map((r) => ({ name: r.name, description: r.description }));
+    } catch {
+      return [];
+    }
+  });

--- a/apps/registry/src/routes/docs/$.tsx
+++ b/apps/registry/src/routes/docs/$.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
+import { DocsBottomCta } from '~/components/docs-bottom-cta';
 import { DocsLayout } from '~/components/layouts/docs-layout';
 import { routeHead } from '~/consts/seo';
 import { getDocBySlug } from '~/query/docs';
@@ -96,6 +97,7 @@ function DocPage() {
             Edit this page on GitHub
           </a>
         </div>
+        <DocsBottomCta />
       </article>
     </DocsLayout>
   );

--- a/apps/registry/src/routes/index.tsx
+++ b/apps/registry/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { routeHead } from '~/consts/seo';
 import { githubStarsQueryOptions } from '~/query/github';
 import { homepageStatsQueryOptions } from '~/query/homepage';
+import { recentSkillsQueryOptions } from '~/query/skills';
 import { HomeScreen } from '~/screens/home-screen';
 
 const data = routeHead({
@@ -19,8 +20,9 @@ export const Route = createFileRoute('/')({
     const selfhostedAppUrl = process.env.TANK_MODE === 'selfhosted' ? getAppUrl() : '';
     return Promise.all([
       context.queryClient.ensureQueryData(homepageStatsQueryOptions()),
-      context.queryClient.ensureQueryData(githubStarsQueryOptions)
-    ]).then(([_stats, _stars]) => ({ selfhostedAppUrl }));
+      context.queryClient.ensureQueryData(githubStarsQueryOptions),
+      context.queryClient.ensureQueryData(recentSkillsQueryOptions())
+    ]).then(() => ({ selfhostedAppUrl }));
   },
   head: () => data,
   component: HomePage
@@ -30,10 +32,12 @@ function HomePage() {
   const { selfhostedAppUrl } = Route.useLoaderData();
   const { data: stats } = useSuspenseQuery(homepageStatsQueryOptions());
   const { data: starCount } = useSuspenseQuery(githubStarsQueryOptions);
+  const { data: recentSkills } = useSuspenseQuery(recentSkillsQueryOptions());
   return (
     <HomeScreen
       publicSkillCount={stats.publicSkillCount}
       starCount={starCount}
+      recentSkills={recentSkills}
       selfhostedAppUrl={selfhostedAppUrl || undefined}
     />
   );

--- a/apps/registry/src/routes/skills/$.tsx
+++ b/apps/registry/src/routes/skills/$.tsx
@@ -1,8 +1,13 @@
 import { encodeSkillName } from '@internals/helpers';
-import { createFileRoute, notFound } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 
 import { BASE_URL, routeHead } from '~/consts/seo';
-import { isTalkEnabledFn, skillDetailQueryOptions } from '~/query/skills';
+import {
+  isTalkEnabledFn,
+  type SimilarSkillSuggestion,
+  skillDetailQueryOptions,
+  suggestSimilarSkillsFn
+} from '~/query/skills';
 import { SkillDetailScreen } from '~/screens/skill-detail-screen';
 
 export const Route = createFileRoute('/skills/$')({
@@ -10,9 +15,12 @@ export const Route = createFileRoute('/skills/$')({
     const rawPath = params._splat ?? '';
     const skillName = decodeURIComponent(rawPath);
     const data = await context.queryClient.ensureQueryData(skillDetailQueryOptions(skillName));
-    if (!data) throw notFound();
+    if (!data) {
+      const suggestions = await suggestSimilarSkillsFn({ data: skillName });
+      return { data: null, skillName, talkEnabled: false, suggestions };
+    }
     const talkEnabled = await isTalkEnabledFn();
-    return { data, skillName, talkEnabled };
+    return { data, skillName, talkEnabled, suggestions: [] as SimilarSkillSuggestion[] };
   },
   head: ({ loaderData }) => {
     const data = loaderData?.data;
@@ -51,17 +59,54 @@ export const Route = createFileRoute('/skills/$')({
       ]
     };
   },
-  component: SkillDetailPage,
-  notFoundComponent: () => (
-    <div className="max-w-4xl mx-auto py-16 text-center">
-      <h1 className="text-2xl font-bold mb-2">Package not found</h1>
-      <p className="text-muted-foreground">This package doesn&apos;t exist or hasn&apos;t been published yet.</p>
-    </div>
-  )
+  component: SkillDetailPage
 });
 
+function NotFoundView({ skillName, suggestions }: { skillName: string; suggestions: SimilarSkillSuggestion[] }) {
+  return (
+    <div className="max-w-2xl mx-auto py-16 px-4 sm:px-6 lg:px-8 text-center" data-testid="skill-not-found">
+      <h1 className="text-2xl font-bold mb-2">Package not found</h1>
+      <p className="text-muted-foreground">
+        <span className="font-mono text-foreground/80">{skillName}</span> doesn&apos;t exist or hasn&apos;t been
+        published yet.
+      </p>
+
+      {suggestions.length > 0 && (
+        <div className="mt-8" data-testid="skill-not-found-suggestions">
+          <p className="text-sm text-muted-foreground mb-3">Did you mean one of these?</p>
+          <ul className="flex flex-col gap-2 max-w-md mx-auto text-left">
+            {suggestions.map((s) => (
+              <li key={s.name}>
+                <Link
+                  to="/skills/$"
+                  params={{ _splat: encodeSkillName(s.name) }}
+                  className="block rounded border border-border hover:border-tank/40 bg-card/30 hover:bg-card/60 px-4 py-2 transition-colors no-underline">
+                  <p className="font-mono text-sm text-tank">{s.name}</p>
+                  {s.description && (
+                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{s.description}</p>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-3 text-sm">
+        <Link to="/skills" search={{} as never} className="text-tank hover:underline font-medium">
+          Browse all packages →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 function SkillDetailPage() {
-  const { data, talkEnabled } = Route.useLoaderData();
+  const { data, talkEnabled, skillName, suggestions } = Route.useLoaderData();
+
+  if (!data) {
+    return <NotFoundView skillName={skillName} suggestions={suggestions} />;
+  }
 
   return <SkillDetailScreen data={data} talkEnabled={talkEnabled} />;
 }

--- a/apps/registry/src/screens/home-screen.tsx
+++ b/apps/registry/src/screens/home-screen.tsx
@@ -4,7 +4,9 @@ import { motion } from 'motion/react';
 import { useMemo } from 'react';
 
 import { AtomsSection } from '~/components/home/atoms-section';
+import { BuiltWithTank } from '~/components/home/built-with-tank';
 import { CliPreview } from '~/components/home/cli-preview';
+import { Community } from '~/components/home/community';
 import { ComparisonTable } from '~/components/home/comparison-table';
 import { EditorIntegration } from '~/components/home/editor-integration';
 import { EnterpriseSection } from '~/components/home/enterprise-section';
@@ -12,16 +14,20 @@ import { FaqSection } from '~/components/home/faq-section';
 import { FeaturesGrid } from '~/components/home/features-grid';
 import { HeroSection } from '~/components/home/hero-section';
 import { HowItWorks } from '~/components/home/how-it-works';
+import { RecentlyPublished } from '~/components/home/recently-published';
+import { StickySectionNav } from '~/components/home/sticky-section-nav';
 import { VaultSection } from '~/components/home/vault-section';
 import { WhyTankExists } from '~/components/home/why-tank-exists';
 import { WorksWith } from '~/components/home/works-with';
 import { Button } from '~/components/ui/button';
 import { GITHUB_ICON_PATH } from '~/consts/brand';
 import { faqItems } from '~/consts/homepage';
+import type { RecentSkill } from '~/query/skills';
 
 interface HomeScreenProps {
   publicSkillCount: number;
   starCount: number | null;
+  recentSkills?: RecentSkill[];
   selfhostedAppUrl?: string;
 }
 
@@ -67,30 +73,36 @@ function JsonLdScript({ data }: { data: ReturnType<typeof buildHomepageJsonLd> }
   return <script type="application/ld+json">{JSON.stringify(data)}</script>;
 }
 
-export function HomeScreen({ publicSkillCount, starCount, selfhostedAppUrl }: HomeScreenProps) {
+export function HomeScreen({ publicSkillCount, starCount, recentSkills = [], selfhostedAppUrl }: HomeScreenProps) {
   const jsonLd = useMemo(() => buildHomepageJsonLd(publicSkillCount), [publicSkillCount]);
 
   return (
     <>
       <JsonLdScript data={jsonLd} />
 
-      <HeroSection starCount={starCount} selfhostedAppUrl={selfhostedAppUrl} />
+      <StickySectionNav />
+
+      <HeroSection starCount={starCount} publicSkillCount={publicSkillCount} selfhostedAppUrl={selfhostedAppUrl} />
 
       <WorksWith />
 
-      <ComparisonTable />
+      <BuiltWithTank />
+
+      <RecentlyPublished skills={recentSkills} />
 
       <WhyTankExists />
 
-      <HowItWorks />
+      <VaultSection />
 
-      <FeaturesGrid />
+      <HowItWorks />
 
       <AtomsSection />
 
-      <TankJsonExample />
+      <ComparisonTable />
 
-      <VaultSection />
+      <FeaturesGrid />
+
+      <TankJsonExample />
 
       <CliPreview />
 
@@ -99,6 +111,8 @@ export function HomeScreen({ publicSkillCount, starCount, selfhostedAppUrl }: Ho
       <EnterpriseSection />
 
       <ContributorsSection />
+
+      <Community starCount={starCount} />
 
       <FaqSection />
 

--- a/apps/registry/src/screens/skill-detail-screen.tsx
+++ b/apps/registry/src/screens/skill-detail-screen.tsx
@@ -3,11 +3,13 @@ import { useMemo, useRef, useState } from 'react';
 
 import { AtomKindBadges } from '~/components/skills/atom-kind-badge';
 import { DownloadButton } from '~/components/skills/download-button';
+import { InstallSnippet } from '~/components/skills/install-snippet';
 import { SkillSidebar } from '~/components/skills/skill-sidebar';
 import { SkillTabs } from '~/components/skills/skill-tabs';
 import { StarButton } from '~/components/skills/star-button';
 import { TalkToSkillWidget, type TalkToSkillWidgetHandle } from '~/components/skills/talk-to-skill-widget';
 import { TrustBadge } from '~/components/skills/trust-badge';
+import { TrustSummary } from '~/components/skills/trust-summary';
 
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
@@ -58,7 +60,7 @@ function MobileActionBar({
   talkEnabled: boolean;
   onTalkClick: () => void;
 }) {
-  const installCmd = `tank install ${data.name}`;
+  const installCmd = `tank install -g ${data.name}`;
   const { copied, copy } = useCopyToClipboard();
 
   return (
@@ -103,9 +105,6 @@ function MobileActionBar({
 }
 
 export function SkillDetailScreen({ data, talkEnabled }: SkillDetailScreenProps) {
-  const [activeTab, setActiveTab] = useState('readme');
-  const [triggersExpanded, setTriggersExpanded] = useState(false);
-  const talkWidgetRef = useRef<TalkToSkillWidgetHandle>(null);
   const latestManifest = safeParseJson(data.latestVersion?.manifest);
   const fileList: string[] = Array.isArray(latestManifest?.files) ? (latestManifest.files as string[]) : [];
   const license = typeof latestManifest?.license === 'string' ? latestManifest.license : null;
@@ -119,7 +118,7 @@ export function SkillDetailScreen({ data, talkEnabled }: SkillDetailScreenProps)
 
   const readmeContent = data.latestVersion?.readme;
   const scanDetails = data.latestVersion?.scanDetails;
-  const hasSecurityData = scanDetails != null;
+  const hasSecurityData = scanDetails != null && scanDetails.verdict !== null;
 
   const securityTab = hasSecurityData && scanDetails ? buildSecurityTab({ data, scanDetails }) : null;
   const tokenTab = hasSecurityData && scanDetails ? buildTokenTab({ data, scanDetails }) : null;
@@ -127,6 +126,10 @@ export function SkillDetailScreen({ data, talkEnabled }: SkillDetailScreenProps)
   const desc = useMemo(() => parseDescription(data.description), [data.description]);
   const atomKinds = extractAtomKinds(latestManifest);
   const atomsList = Array.isArray(latestManifest?.atoms) ? (latestManifest.atoms as Record<string, unknown>[]) : [];
+
+  const [activeTab, setActiveTab] = useState('readme');
+  const [triggersExpanded, setTriggersExpanded] = useState(false);
+  const talkWidgetRef = useRef<TalkToSkillWidgetHandle>(null);
 
   return (
     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8" data-testid="skill-detail-root">
@@ -160,6 +163,12 @@ export function SkillDetailScreen({ data, talkEnabled }: SkillDetailScreenProps)
             </Button>
           )}
         </div>
+        {/* Desktop install — always visible, not just mobile */}
+        {data.latestVersion && (
+          <div className="mt-4 hidden lg:block" data-testid="desktop-install-snippet">
+            <InstallSnippet skillName={data.name} testId="desktop-install-snippet" />
+          </div>
+        )}
         {desc.summary && (
           <div className="mt-4">
             <h3 className="text-xs font-semibold text-muted-foreground mb-1.5">Description</h3>
@@ -214,6 +223,12 @@ export function SkillDetailScreen({ data, talkEnabled }: SkillDetailScreenProps)
           chatLink={data.latestVersion?.prompt2botChatLink ?? null}
           botPublicKey={data.latestVersion?.prompt2botBotPublicKey ?? null}
         />
+      )}
+
+      {hasSecurityData && scanDetails && (
+        <div className="mb-6">
+          <TrustSummary scanDetails={scanDetails} onViewDetails={() => setActiveTab('security')} />
+        </div>
       )}
 
       <SkillTabs

--- a/apps/registry/src/screens/skills-list-screen.tsx
+++ b/apps/registry/src/screens/skills-list-screen.tsx
@@ -3,10 +3,13 @@ import { Link } from '@tanstack/react-router';
 import { Download, Lock, ShieldAlert, ShieldCheck, Star } from 'lucide-react';
 
 import { AtomKindBadges } from '~/components/skills/atom-kind-badge';
+import { GettingStarted } from '~/components/skills/getting-started';
+import { InstallSnippet } from '~/components/skills/install-snippet';
 import { MobileSkillsFilters } from '~/components/skills/mobile-skills-filters';
 import { SearchBar } from '~/components/skills/search-bar';
 import { SkillsFilters } from '~/components/skills/skills-filters';
 import { SkillsSort } from '~/components/skills/skills-sort';
+import { ValueBanner } from '~/components/skills/value-banner';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card';
@@ -64,6 +67,8 @@ export function SkillsListScreen({
 
       <SearchBar defaultValue={query} />
 
+      <ValueBanner />
+
       <MobileSkillsFilters
         currentVisibility={visibility}
         currentSecurityVerdict={securityVerdict}
@@ -74,8 +79,8 @@ export function SkillsListScreen({
         currentAtomKind={atomKind}
       />
 
-      <div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)]">
-        <div className="hidden lg:block">
+      <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
+        <div className="hidden lg:block space-y-4">
           <SkillsFilters
             currentVisibility={visibility}
             currentSecurityVerdict={securityVerdict}
@@ -85,6 +90,7 @@ export function SkillsListScreen({
             isLoggedIn={isLoggedIn}
             currentAtomKind={atomKind}
           />
+          <GettingStarted />
         </div>
 
         <div className="space-y-4">
@@ -184,20 +190,58 @@ function SkillCard({ skill, isLoggedIn }: { skill: SkillSearchResult; isLoggedIn
         <div className="relative z-10 mt-1.5">
           <AtomKindBadges kinds={skill.atomKinds ?? ['skill']} size="xs" asLinks />
         </div>
+        <div className="relative z-10 mt-2">
+          <InstallSnippet skillName={skill.name} testId="skill-card-install-snippet" />
+        </div>
       </CardContent>
     </Card>
   );
 }
 
 function EmptyState({ query }: { query: string }) {
+  if (query) {
+    return (
+      <div
+        data-testid="skills-empty-state"
+        className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border/40 py-12 px-6 text-center">
+        <p className="text-lg font-medium">No packages found</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          No results for <span className="font-mono text-foreground/80">"{query}"</span>. Try a different term or
+          publish your own.
+        </p>
+        <div className="mt-5 flex flex-col sm:flex-row items-stretch sm:items-center gap-2 w-full max-w-md">
+          <code className="flex-1 rounded border bg-muted/50 px-3 py-1.5 font-mono text-xs">tank search {query}</code>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-3 text-sm">
+          <Link to="/skills" search={{} as never} className="text-tank hover:underline font-medium">
+            Browse all packages →
+          </Link>
+          <span className="text-border">·</span>
+          <Link to="/docs/$" params={{ _splat: 'publishing' }} className="text-tank hover:underline font-medium">
+            Publish your own →
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border/40 py-16 text-center">
-      <p className="text-lg font-medium">{query ? 'No packages found' : 'No packages published yet'}</p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {query
-          ? `No results for "${query}". Try a different search term or adjust filters.`
-          : 'Be the first to publish a package!'}
-      </p>
+    <div
+      data-testid="skills-empty-state"
+      className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border/40 py-12 px-6 text-center">
+      <p className="text-lg font-medium">No packages published yet</p>
+      <p className="mt-1 text-sm text-muted-foreground">Be the first to publish a verified AI agent package.</p>
+      <div className="mt-5 flex flex-col sm:flex-row items-stretch sm:items-center gap-2 w-full max-w-md">
+        <code className="flex-1 rounded border bg-muted/50 px-3 py-1.5 font-mono text-xs">
+          npm i -g @tankpkg/cli && tank publish
+        </code>
+      </div>
+      <Link
+        to="/docs/$"
+        params={{ _splat: 'publishing' }}
+        className="mt-4 text-tank hover:underline text-sm font-medium">
+        Read the publishing guide →
+      </Link>
     </div>
   );
 }

--- a/bdd/features/browser/tanstack/skill-detail/conversion-detail.feature
+++ b/bdd/features/browser/tanstack/skill-detail/conversion-detail.feature
@@ -1,0 +1,64 @@
+# Intent: idd/modules/conversion-skill-detail/INTENT.md
+
+@skill-detail
+@conversion
+Feature: Skill detail conversion improvements
+  As a visitor evaluating a package
+  I need to see the install command and trust signals immediately
+  So that I can decide to install without hunting for information
+
+  Background:
+    Given a public skill has been published
+
+  # ── Desktop install command ──────────────────────────────────
+
+  @conversion
+  @install
+  Scenario: Install command is visible on desktop
+    When I visit the skill detail page on desktop
+    Then I see a copyable install command in the page header
+    And the install command starts with "tank install"
+
+  @conversion
+  @install
+  Scenario: Install command copy works on desktop
+    When I visit the skill detail page on desktop
+    And I click the copy button next to the install command
+    Then the command is copied to clipboard
+
+  # ── Default tab ──────────────────────────────────────────────
+
+  @conversion
+  @tabs
+  Scenario: README tab is default for scanned skills
+    When I visit the skill detail page for a scanned skill
+    Then the readme tab is active by default
+
+  @conversion
+  @tabs
+  Scenario: README tab is default for unscanned skills
+    When I visit the skill detail page for an unscanned skill
+    Then the readme tab is active by default
+
+  # ── Trust summary card ───────────────────────────────────────
+
+  @conversion
+  @trust
+  Scenario: Trust summary card appears above tabs when scan data exists
+    When I visit the skill detail page for a scanned skill
+    Then I see a trust summary card above the content tabs
+    And the trust summary shows the scan verdict
+    And there is visible spacing between the trust summary and the tabs
+
+  @conversion
+  @trust
+  Scenario: Trust summary "View details" activates security tab
+    When I visit the skill detail page for a scanned skill
+    And I click "View details" in the trust summary
+    Then the security tab is active
+
+  @conversion
+  @trust
+  Scenario: Trust summary card does not appear without scan data
+    When I visit the skill detail page for an unscanned skill
+    Then the trust summary card is not shown

--- a/bdd/features/browser/tanstack/skills/conversion-skills.feature
+++ b/bdd/features/browser/tanstack/skills/conversion-skills.feature
@@ -1,0 +1,61 @@
+# Intent: idd/modules/conversion-skills-list/INTENT.md
+
+@skills
+@conversion
+Feature: Skills list conversion improvements
+  As a visitor browsing packages
+  I need to understand why Tank is different and how to install packages
+  So that I can go from browsing to installing
+
+  Background:
+    Given public skills have been published
+
+  # ── Value proposition banner ─────────────────────────────────
+
+  @conversion
+  @banner
+  Scenario: Skills page shows a value proposition banner for first visit
+    When I visit the skills page with a clean localStorage
+    Then I see a banner explaining Tank's security value
+    And the banner contains a link to learn more
+
+  @conversion
+  @banner
+  Scenario: Banner can be dismissed and stays dismissed
+    When I visit the skills page with a clean localStorage
+    And I dismiss the value proposition banner
+    Then the banner is no longer visible
+    When I revisit the skills page
+    Then the banner is not shown
+
+  # ── Getting started sidebar ──────────────────────────────────
+
+  @conversion
+  @sidebar
+  Scenario: Desktop shows getting-started card in filter sidebar
+    When I visit the skills page on desktop
+    Then I see a getting-started card in the sidebar
+    And the card shows CLI install instructions
+
+  @conversion
+  @sidebar
+  Scenario: Getting-started card is hidden on mobile
+    When I visit the skills page on mobile
+    Then the getting-started card is not visible
+
+  # ── Skill card install snippets ──────────────────────────────
+
+  @conversion
+  @cards
+  Scenario: Each skill card shows copyable install command
+    When I visit the skills page
+    Then each published skill card shows a copyable install command
+    And the install command starts with "tank install"
+
+  @conversion
+  @cards
+  Scenario: Copy button on skill card does not navigate to detail
+    When I visit the skills page
+    And I click the copy button on a skill card
+    Then the install command is copied
+    And I remain on the skills page

--- a/bdd/features/system/web-registry/conversion-cross-cutting.feature
+++ b/bdd/features/system/web-registry/conversion-cross-cutting.feature
@@ -1,0 +1,97 @@
+# Intent: idd/modules/conversion-cross-cutting/INTENT.md
+
+@conversion
+@cross-cutting
+Feature: Cross-cutting conversion improvements
+  As a developer using the Tank ecosystem
+  I need contextual CTAs, learnable interface, and opt-in telemetry
+  So that I can discover Tank's value from anywhere in the product
+
+  # ── Docs bottom CTA ─────────────────────────────────────────
+
+  @docs
+  @cta
+  Scenario: Every docs page has a bottom CTA after the article
+    When I fetch the docs overview page HTML
+    Then the HTML should contain a post-article call to action
+    And the CTA should contain an install command
+
+  @docs
+  @cta
+  Scenario: Docs CTA appears before prev/next navigation
+    When I fetch the docs overview page HTML
+    Then the CTA should appear before the document navigation links
+
+  # ── Command palette suggestions ──────────────────────────────
+
+  @command-menu
+  Scenario: Command menu includes educational suggestions
+    When I inspect the command menu source
+    Then the command menu should include a "What is Tank?" suggestion
+    And the suggestion should link to the docs overview
+
+  # ── Section anchors on homepage ─────────────────────────────
+
+  @homepage
+  @anchors
+  Scenario: Key homepage sections have scroll targets
+    When I fetch the homepage HTML
+    Then the HTML should contain an element with id "vault"
+    And the HTML should contain an element with id "atoms"
+    And the HTML should contain an element with id "how-it-works"
+    And the HTML should contain an element with id "why-tank"
+
+  # ── CLI telemetry opt-in ────────────────────────────────────
+
+  @cli
+  @telemetry
+  Scenario: Telemetry is disabled by default for new installations
+    Given a fresh Tank installation without telemetry config
+    When I run any tank command
+    Then no telemetry event is sent
+
+  @cli
+  @telemetry
+  Scenario: User can opt into telemetry
+    Given a fresh Tank installation without telemetry config
+    When I run "tank telemetry on"
+    Then the config file contains "telemetry": true
+    And a cli_opted_in event is sent
+
+  @cli
+  @telemetry
+  Scenario: User can opt out of telemetry
+    Given telemetry is enabled
+    When I run "tank telemetry off"
+    Then the config file contains "telemetry": false
+    And a cli_opted_out event is sent
+
+  @cli
+  @telemetry
+  Scenario: User can check telemetry status
+    Given telemetry is enabled
+    When I run "tank telemetry status"
+    Then the output indicates telemetry is enabled
+
+  @cli
+  @telemetry
+  Scenario: Environment variable overrides config
+    Given telemetry is enabled in config
+    When I run a command with TANK_TELEMETRY=0
+    Then no telemetry event is sent
+
+  @cli
+  @telemetry
+  Scenario: Commands send events when telemetry is enabled
+    Given telemetry is enabled
+    When I run "tank install" on a package
+    Then a cli_install event is sent
+    And the event does not contain the package name
+
+  @cli
+  @telemetry
+  Scenario: Telemetry does not block command execution
+    Given telemetry is enabled but the telemetry endpoint is unreachable
+    When I run "tank search something"
+    Then the command completes successfully
+    And the exit code is 0

--- a/bdd/features/system/web-registry/conversion-homepage.feature
+++ b/bdd/features/system/web-registry/conversion-homepage.feature
@@ -1,0 +1,94 @@
+# Intent: idd/modules/conversion-homepage/INTENT.md
+
+@homepage
+@conversion
+Feature: Homepage conversion improvements
+  As a first-time visitor
+  I need to quickly understand Tank's value and navigate to key features
+  So that I can decide whether Tank solves my problem
+
+  # ── Hero: Differentiator pills ──────────────────────────────
+
+  @conversion
+  @hero
+  Scenario: Hero subtitle is followed by scannable differentiator pills
+    When I fetch the homepage HTML
+    Then the HTML should contain a four-pill differentiator row
+    And each pill should have an href fragment pointing to its section
+
+  @conversion
+  @hero
+  Scenario: Credential Vault pill scrolls to vault section
+    When I fetch the homepage HTML
+    Then one of the differentiator pills should link to "#vault"
+
+  @conversion
+  @hero
+  Scenario: Atoms pill scrolls to atoms section
+    When I fetch the homepage HTML
+    Then one of the differentiator pills should link to "#atoms"
+
+  @conversion
+  @hero
+  Scenario: How It Works pill scrolls to how-it-works section
+    When I fetch the homepage HTML
+    Then one of the differentiator pills should link to "#how-it-works"
+
+  # ── Hero: Visible CTAs ──────────────────────────────────────
+
+  @conversion
+  @hero
+  @cta
+  Scenario: Primary CTA is Browse Packages button
+    When I fetch the homepage HTML
+    Then the primary CTA should link to "/skills"
+
+  @conversion
+  @hero
+  @cta
+  Scenario: Secondary CTA is View Docs button below primary CTA
+    When I fetch the homepage HTML
+    Then the HTML should contain a secondary CTA linking to documentation
+
+  # ── Hero: Social proof stats ─────────────────────────────────
+
+  @conversion
+  @hero
+  @stats
+  Scenario: Hero includes social proof statistics
+    When I fetch the homepage HTML
+    Then the HTML should contain a hero stats row with package count or GitHub stars
+
+  # ── Section ordering ────────────────────────────────────────
+
+  @conversion
+  @sections
+  Scenario: Differentiating sections appear before comparison table
+    When I fetch the homepage HTML
+    Then the vault section should appear before the comparison table
+    And the atoms section should appear before the comparison table
+
+  @conversion
+  @sections
+  Scenario: Why Tank exists appears before comparison table
+    When I fetch the homepage HTML
+    Then the "Why Tank Exists" section should appear before the comparison table
+
+  # ── Section anchors for pill links ──────────────────────────
+
+  @conversion
+  @sections
+  Scenario: Key sections have id attributes for scroll navigation
+    When I fetch the homepage HTML
+    Then the HTML should contain an element with id "vault"
+    And the HTML should contain an element with id "atoms"
+    And the HTML should contain an element with id "how-it-works"
+    And the HTML should contain an element with id "why-tank"
+
+  # ── Sticky section navigation ───────────────────────────────
+
+  @conversion
+  @nav
+  Scenario: Sticky section nav component is rendered
+    When I fetch the homepage HTML
+    Then the HTML should contain a sticky section navigation element

--- a/bdd/playwright.conversion.config.ts
+++ b/bdd/playwright.conversion.config.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { defineConfig } from '@playwright/test';
+import { cucumberReporter, defineBddConfig } from 'playwright-bdd';
+import { getRegistryUrl } from '../e2e/targets.js';
+
+const envDir = path.resolve(__dirname, '..');
+const envPath = path.join(envDir, '.env');
+
+if (fs.existsSync(envPath)) {
+  const lines = fs.readFileSync(envPath, 'utf-8').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const index = trimmed.indexOf('=');
+    if (index === -1) continue;
+    const key = trimmed.slice(0, index).trim();
+    let value = trimmed.slice(index + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+const testDir = defineBddConfig({
+  features: 'features/browser/tanstack/**/conversion-*.feature',
+  steps: 'steps/browser/{fixtures,conversion-skills,conversion-detail,search-ui,skill-detail,skills-browse-mobile}.steps.ts',
+  importTestFrom: 'steps/browser/fixtures.ts',
+  outputDir: '../test-results/bdd-browser-conversion/generated'
+});
+
+export default defineConfig({
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  outputDir: '../test-results/bdd-browser-conversion/results',
+  reporter: [['list'], cucumberReporter('html', { outputFile: '../test-results/bdd-browser-conversion/report.html' })],
+  use: { testIdAttribute: 'data-testid' },
+  projects: [
+    {
+      name: 'registry',
+      testDir,
+      use: { baseURL: getRegistryUrl() }
+    }
+  ]
+});

--- a/bdd/steps/browser/conversion-detail.steps.ts
+++ b/bdd/steps/browser/conversion-detail.steps.ts
@@ -1,0 +1,92 @@
+// Feature: bdd/features/browser/tanstack/skill-detail/conversion-detail.feature
+// Intent: idd/modules/conversion-skill-detail/INTENT.md
+
+import { encodeSkillName } from '@internals/helpers';
+import { expect } from '@playwright/test';
+
+import { Given, Then, When } from './fixtures';
+
+// ── Desktop install command ──────────────────────────────────────────
+
+When('I visit the skill detail page on desktop', async ({ page, bddState }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  if (!bddState.skillName) throw new Error('No skill name set in state');
+  await page.goto(`/skills/${encodeSkillName(bddState.skillName)}`);
+  await page.waitForLoadState('networkidle');
+});
+
+Then('I see a copyable install command in the page header', async ({ page }) => {
+  const desktopInstall = page.getByTestId('desktop-install-snippet');
+  await expect(desktopInstall).toBeVisible();
+  await expect(desktopInstall.locator('code')).toContainText('tank install');
+});
+
+When('I click the copy button next to the install command', async ({ page }) => {
+  const desktopInstall = page.getByTestId('desktop-install-snippet');
+  const copyBtn = desktopInstall.getByRole('button');
+  await copyBtn.click();
+});
+
+Then('the command is copied to clipboard', async ({ page }) => {
+  const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboard).toContain('tank install');
+});
+
+// ── Default security tab ─────────────────────────────────────────────
+
+When('I visit the skill detail page for a scanned skill', async ({ page, bddState }) => {
+  if (!bddState.skillName) throw new Error('No skill name set in state');
+  await page.goto(`/skills/${encodeSkillName(bddState.skillName)}`);
+  await page.waitForLoadState('networkidle');
+});
+
+When('I visit the skill detail page for an unscanned skill', async ({ page, bddState }) => {
+  if (!bddState.skillName) throw new Error('No skill name set in state');
+  await page.goto(`/skills/${encodeSkillName(bddState.skillName)}`);
+  await page.waitForLoadState('networkidle');
+});
+
+Then('the readme tab is active by default', async ({ page }) => {
+  const readmeTab = page.getByTestId('tab-readme');
+  await expect(readmeTab).toHaveAttribute('data-state', 'active');
+});
+
+When('I click {string} in the trust summary', async ({ page }, _label: string) => {
+  const trustCard = page.getByTestId('trust-summary-card');
+  await trustCard.getByRole('button', { name: /view details/i }).click();
+});
+
+Then('the security tab is active', async ({ page }) => {
+  const securityTab = page.getByTestId('tab-security');
+  await expect(securityTab).toHaveAttribute('data-state', 'active');
+});
+
+Then('there is visible spacing between the trust summary and the tabs', async ({ page }) => {
+  const trustCard = page.getByTestId('trust-summary-card');
+  const trustBox = await trustCard.boundingBox();
+  const readmeTab = page.getByTestId('tab-readme');
+  const tabBox = await readmeTab.boundingBox();
+  expect(trustBox).not.toBeNull();
+  expect(tabBox).not.toBeNull();
+  // At least 16px of vertical gap between bottom of trust card and top of tabs
+  const gap = (tabBox!.y) - (trustBox!.y + trustBox!.height);
+  expect(gap).toBeGreaterThanOrEqual(16);
+});
+
+// ── Trust summary card ───────────────────────────────────────────────
+
+Then('I see a trust summary card above the content tabs', async ({ page }) => {
+  const trustCard = page.getByTestId('trust-summary-card');
+  await expect(trustCard).toBeVisible();
+});
+
+Then('the trust summary shows the scan verdict', async ({ page }) => {
+  const trustCard = page.getByTestId('trust-summary-card');
+  await expect(trustCard).toBeVisible();
+  const text = await trustCard.textContent();
+  expect(text).toMatch(/verdict|pass|flagged|unsafe|scan/i);
+});
+
+Then('the trust summary card is not shown', async ({ page }) => {
+  await expect(page.getByTestId('trust-summary-card')).not.toBeVisible();
+});

--- a/bdd/steps/browser/conversion-skills.steps.ts
+++ b/bdd/steps/browser/conversion-skills.steps.ts
@@ -1,0 +1,108 @@
+// Feature: bdd/features/browser/tanstack/skills/conversion-skills.feature
+// Intent: idd/modules/conversion-skills-list/INTENT.md
+
+import { encodeSkillName } from '@internals/helpers';
+import { expect } from '@playwright/test';
+
+import { Given, Then, When } from './fixtures';
+
+// ── Value proposition banner ──────────────────────────────────────────
+
+When('I visit the skills page with a clean localStorage', async ({ page }) => {
+  await page.goto('/skills');
+  await page.evaluate(() => localStorage.removeItem('tank-value-banner-dismissed'));
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+});
+
+When('I revisit the skills page', async ({ page }) => {
+  await page.goto('/skills');
+  await page.waitForLoadState('networkidle');
+});
+
+Then('I see a banner explaining Tank\'s security value', async ({ page }) => {
+  const banner = page.getByTestId('value-banner');
+  await expect(banner).toBeVisible();
+});
+
+Then('the banner contains a link to learn more', async ({ page }) => {
+  const banner = page.getByTestId('value-banner');
+  const link = banner.locator('a');
+  await expect(link).toBeVisible();
+  const href = await link.getAttribute('href');
+  expect(href).toContain('/docs');
+});
+
+When('I dismiss the value proposition banner', async ({ page }) => {
+  const dismissBtn = page.getByTestId('value-banner-dismiss');
+  await dismissBtn.click();
+});
+
+Then('the banner is no longer visible', async ({ page }) => {
+  await expect(page.getByTestId('value-banner')).not.toBeVisible();
+});
+
+Then('the banner is not shown', async ({ page }) => {
+  await expect(page.getByTestId('value-banner')).not.toBeVisible();
+});
+
+// ── Getting started sidebar ──────────────────────────────────────────
+
+When('I visit the skills page on desktop', async ({ page }) => {
+  // Desktop: set viewport wide enough for sidebar to render
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/skills');
+  await page.waitForLoadState('networkidle');
+});
+
+When('I visit the skills page on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/skills');
+  await page.waitForLoadState('networkidle');
+});
+
+Then('I see a getting-started card in the sidebar', async ({ page }) => {
+  const card = page.getByTestId('getting-started-card');
+  await expect(card).toBeVisible();
+});
+
+Then('the card shows CLI install instructions', async ({ page }) => {
+  const card = page.getByTestId('getting-started-card');
+  await expect(card.locator('code')).toContainText('tank');
+});
+
+Then('the getting-started card is not visible', async ({ page }) => {
+  await expect(page.getByTestId('getting-started-card')).not.toBeVisible();
+});
+
+// ── Skill card install snippets ──────────────────────────────────────
+
+Then('each published skill card shows a copyable install command', async ({ page, bddState }) => {
+  const cards = page.getByTestId('skill-card');
+  const count = await cards.count();
+  expect(count).toBeGreaterThan(0);
+  const firstCard = cards.first();
+  await expect(firstCard.getByTestId('skill-card-install-snippet')).toBeVisible();
+});
+
+Then('the install command starts with {string}', async ({ page }, prefix: string) => {
+  const cards = page.getByTestId('skill-card');
+  const firstSnippet = cards.first().getByTestId('skill-card-install-snippet');
+  await expect(firstSnippet.locator('code')).toContainText(prefix);
+});
+
+When('I click the copy button on a skill card', async ({ page }) => {
+  const cards = page.getByTestId('skill-card');
+  const snippet = cards.first().getByTestId('skill-card-install-snippet');
+  const copyBtn = snippet.getByRole('button');
+  await copyBtn.click();
+});
+
+Then('the install command is copied', async ({ page }) => {
+  const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboard).toContain('tank install');
+});
+
+Then('I remain on the skills page', async ({ page }) => {
+  expect(page.url()).toContain('/skills');
+});

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "apps/registry": {
       "name": "registry",
-      "version": "0.13.1",
+      "version": "0.15.8",
       "dependencies": {
         "@alice-and-bot/core": "npm:@jsr/alice-and-bot__core",
         "@aws-sdk/client-s3": "^3.1013.0",
@@ -38,6 +38,7 @@
         "@internals/helpers": "workspace:*",
         "@internals/schemas": "workspace:*",
         "@monaco-editor/react": "^4.7.0",
+        "@resvg/resvg-js": "^2.6.2",
         "@shikijs/rehype": "^4.0.2",
         "@supabase/supabase-js": "^2.99.3",
         "@tanstack/react-form": "^1.28.5",
@@ -160,7 +161,7 @@
     },
     "packages/cli": {
       "name": "@tankpkg/cli",
-      "version": "0.13.1",
+      "version": "0.15.8",
       "bin": {
         "tank": "dist/bin/tank.js",
       },
@@ -193,7 +194,7 @@
     },
     "packages/internals-helpers": {
       "name": "@internals/helpers",
-      "version": "0.13.1",
+      "version": "0.15.8",
       "dependencies": {
         "semver": "^7.7.4",
       },
@@ -205,7 +206,7 @@
     },
     "packages/internals-schemas": {
       "name": "@internals/schemas",
-      "version": "0.13.1",
+      "version": "0.15.8",
       "dependencies": {
         "zod": "^4.3.6",
       },
@@ -216,7 +217,7 @@
     },
     "packages/mcp-server": {
       "name": "@tankpkg/mcp-server",
-      "version": "0.13.1",
+      "version": "0.15.8",
       "bin": {
         "tank-mcp": "dist/index.js",
       },
@@ -253,25 +254,19 @@
     },
     "packages/sdk": {
       "name": "@tankpkg/sdk",
-      "version": "0.13.1",
+      "version": "0.15.8",
       "dependencies": {
-        "@internals/helpers": "workspace:*",
         "tar": "^7.5.11",
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@internals/helpers": "workspace:*",
         "@internals/schemas": "workspace:*",
         "@types/node": "^25.5.0",
         "@types/tar": "^7.0.87",
         "tsdown": "^0.21.3",
         "vitest": "^4",
       },
-      "peerDependencies": {
-        "@internals/schemas": "workspace:*",
-      },
-      "optionalPeers": [
-        "@internals/schemas",
-      ],
     },
     "packages/vault": {
       "name": "@tankpkg/vault",
@@ -897,6 +892,32 @@
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
+    "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
+
+    "@resvg/resvg-js-android-arm-eabi": ["@resvg/resvg-js-android-arm-eabi@2.6.2", "", { "os": "android", "cpu": "arm" }, "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA=="],
+
+    "@resvg/resvg-js-android-arm64": ["@resvg/resvg-js-android-arm64@2.6.2", "", { "os": "android", "cpu": "arm64" }, "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ=="],
+
+    "@resvg/resvg-js-darwin-arm64": ["@resvg/resvg-js-darwin-arm64@2.6.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A=="],
+
+    "@resvg/resvg-js-darwin-x64": ["@resvg/resvg-js-darwin-x64@2.6.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw=="],
+
+    "@resvg/resvg-js-linux-arm-gnueabihf": ["@resvg/resvg-js-linux-arm-gnueabihf@2.6.2", "", { "os": "linux", "cpu": "arm" }, "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw=="],
+
+    "@resvg/resvg-js-linux-arm64-gnu": ["@resvg/resvg-js-linux-arm64-gnu@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg=="],
+
+    "@resvg/resvg-js-linux-arm64-musl": ["@resvg/resvg-js-linux-arm64-musl@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg=="],
+
+    "@resvg/resvg-js-linux-x64-gnu": ["@resvg/resvg-js-linux-x64-gnu@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw=="],
+
+    "@resvg/resvg-js-linux-x64-musl": ["@resvg/resvg-js-linux-x64-musl@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ=="],
+
+    "@resvg/resvg-js-win32-arm64-msvc": ["@resvg/resvg-js-win32-arm64-msvc@2.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ=="],
+
+    "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
+
+    "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
 

--- a/e2e/bdd/features/conversion/conversion-cross-cutting.feature
+++ b/e2e/bdd/features/conversion/conversion-cross-cutting.feature
@@ -1,0 +1,39 @@
+# Intent: idd/modules/conversion-cross-cutting/INTENT.md
+
+@conversion
+@cross-cutting
+Feature: Cross-cutting conversion improvements
+  As a developer using the Tank ecosystem
+  I need contextual CTAs, learnable interface, and opt-in telemetry
+  So that I can discover Tank's value from anywhere in the product
+
+  # ── Docs bottom CTA ─────────────────────────────────────────
+  @docs
+  @cta
+  Scenario: Every docs page has a bottom CTA after the article
+    When I fetch the docs overview page HTML
+    Then the HTML should contain a post-article call to action
+    And the CTA should contain an install command
+
+  @docs
+  @cta
+  Scenario: Docs CTA appears before prev/next navigation
+    When I fetch the docs overview page HTML
+    Then the CTA should appear before the document navigation links
+
+  # ── Command palette suggestions ──────────────────────────────
+  @command-menu
+  Scenario: Command menu includes educational suggestions
+    When I inspect the command menu source
+    Then the command menu should include a "What is Tank?" suggestion
+    And the suggestion should link to the docs overview
+
+  # ── Section anchors on homepage ─────────────────────────────
+  @homepage
+  @anchors
+  Scenario: Key homepage sections have scroll targets
+    When I fetch the homepage HTML
+    Then the HTML should contain an element with id "vault"
+    And the HTML should contain an element with id "atoms"
+    And the HTML should contain an element with id "how-it-works"
+    And the HTML should contain an element with id "why-tank"

--- a/e2e/bdd/features/conversion/conversion-homepage.feature
+++ b/e2e/bdd/features/conversion/conversion-homepage.feature
@@ -1,0 +1,88 @@
+# Intent: idd/modules/conversion-homepage/INTENT.md
+
+@homepage
+@conversion
+Feature: Homepage conversion improvements
+  As a first-time visitor
+  I need to quickly understand Tank's value and navigate to key features
+  So that I can decide whether Tank solves my problem
+
+  # ── Hero: Differentiator pills ──────────────────────────────
+  @conversion
+  @hero
+  Scenario: Hero subtitle is followed by scannable differentiator pills
+    When I fetch the homepage HTML
+    Then the HTML should contain a four-pill differentiator row
+    And each pill should have an href fragment pointing to its section
+
+  @conversion
+  @hero
+  Scenario: Credential Vault pill scrolls to vault section
+    When I fetch the homepage HTML
+    Then one of the differentiator pills should link to "#vault"
+
+  @conversion
+  @hero
+  Scenario: Atoms pill scrolls to atoms section
+    When I fetch the homepage HTML
+    Then one of the differentiator pills should link to "#atoms"
+
+  @conversion
+  @hero
+  Scenario: How It Works pill scrolls to how-it-works section
+    When I fetch the homepage HTML
+    Then one of the differentiator pills should link to "#how-it-works"
+
+  # ── Hero: Visible CTAs ──────────────────────────────────────
+  @conversion
+  @hero
+  @cta
+  Scenario: Primary CTA is Browse Packages button
+    When I fetch the homepage HTML
+    Then the primary CTA should link to "/skills"
+
+  @conversion
+  @hero
+  @cta
+  Scenario: Secondary CTA is View Docs button below primary CTA
+    When I fetch the homepage HTML
+    Then the HTML should contain a secondary CTA linking to documentation
+
+  # ── Hero: Social proof stats ─────────────────────────────────
+  @conversion
+  @hero
+  @stats
+  Scenario: Hero includes social proof statistics
+    When I fetch the homepage HTML
+    Then the HTML should contain a hero stats row with package count or GitHub stars
+
+  # ── Section ordering ────────────────────────────────────────
+  @conversion
+  @sections
+  Scenario: Differentiating sections appear before comparison table
+    When I fetch the homepage HTML
+    Then the vault section should appear before the comparison table
+    And the atoms section should appear before the comparison table
+
+  @conversion
+  @sections
+  Scenario: Why Tank exists appears before comparison table
+    When I fetch the homepage HTML
+    Then the "Why Tank Exists" section should appear before the comparison table
+
+  # ── Section anchors for pill links ──────────────────────────
+  @conversion
+  @sections
+  Scenario: Key sections have id attributes for scroll navigation
+    When I fetch the homepage HTML
+    Then the HTML should contain an element with id "vault"
+    And the HTML should contain an element with id "atoms"
+    And the HTML should contain an element with id "how-it-works"
+    And the HTML should contain an element with id "why-tank"
+
+  # ── Sticky section navigation ──────────────────────────────
+  @conversion
+  @nav
+  Scenario: Sticky section nav component is rendered
+    When I fetch the homepage HTML
+    Then the HTML should contain a sticky section navigation element

--- a/e2e/bdd/steps/conversion.steps.ts
+++ b/e2e/bdd/steps/conversion.steps.ts
@@ -1,0 +1,144 @@
+// Feature: e2e/bdd/features/conversion/conversion-homepage.feature
+// Feature: e2e/bdd/features/conversion/conversion-cross-cutting.feature
+// Intent: idd/modules/conversion-homepage/INTENT.md, idd/modules/conversion-cross-cutting/INTENT.md
+
+import { expect } from '@playwright/test';
+import { Then, When } from './fixtures';
+
+// ── HTTP fetch (shared) ──────────────────────────────────────────────
+
+When('I fetch the homepage HTML', async ({ bddState, e2eContext }) => {
+  const response = await fetch(e2eContext.registry);
+  bddState.lastResponse = response;
+  bddState.lastResponseBody = { _text: await response.text() } as Record<string, unknown>;
+});
+
+When('I fetch the docs overview page HTML', async ({ bddState, e2eContext }) => {
+  const response = await fetch(`${e2eContext.registry}/docs/overview`);
+  bddState.lastResponse = response;
+  bddState.lastResponseBody = { _text: await response.text() } as Record<string, unknown>;
+});
+
+// ── Hero: Differentiator pills ──────────────────────────────────────
+
+Then('the HTML should contain a four-pill differentiator row', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain('data-testid="hero-differentiator-pills"');
+  const match = body.match(/data-testid="hero-differentiator-pill"/g);
+  expect(match).not.toBeNull();
+  expect(match!.length).toBeGreaterThanOrEqual(4);
+});
+
+Then('each pill should have an href fragment pointing to its section', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  const pillMatches = body.matchAll(/data-testid="hero-differentiator-pill"[^>]*href="([^"]*)"/g);
+  for (const match of pillMatches) {
+    expect(match[1]).toMatch(/^#/);
+  }
+});
+
+Then('one of the differentiator pills should link to {string}', async ({ bddState }, href: string) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain(`href="${href}"`);
+});
+
+// ── Hero: CTAs ───────────────────────────────────────────────────────
+
+Then('the HTML should contain a secondary CTA linking to documentation', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain('data-testid="home-secondary-cta"');
+  const ctaMatch = body.match(/data-testid="home-secondary-cta"[^>]*href="([^"]*)"/);
+  expect(ctaMatch).toBeTruthy();
+  expect(ctaMatch![1]).toContain('/docs');
+});
+
+// ── Hero: Social proof ───────────────────────────────────────────────
+
+Then('the HTML should contain a hero stats row with package count or GitHub stars', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain('data-testid="hero-stats"');
+});
+
+// ── Section ordering ─────────────────────────────────────────────────
+
+Then('the vault section should appear before the comparison table', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  const vaultIdx = body.indexOf('id="vault"');
+  const comparisonIdx = body.indexOf('id="comparison-table"');
+  expect(vaultIdx).toBeGreaterThan(0);
+  expect(comparisonIdx).toBeGreaterThan(0);
+  expect(vaultIdx).toBeLessThan(comparisonIdx);
+});
+
+Then('the atoms section should appear before the comparison table', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  const atomsIdx = body.indexOf('id="atoms"');
+  const comparisonIdx = body.indexOf('id="comparison-table"');
+  expect(atomsIdx).toBeGreaterThan(0);
+  expect(comparisonIdx).toBeGreaterThan(0);
+  expect(atomsIdx).toBeLessThan(comparisonIdx);
+});
+
+Then('the {string} section should appear before the comparison table', async ({ bddState }, _section: string) => {
+  const body = bddState.lastResponseBody?._text as string;
+  const whyIdx = body.indexOf('id="why-tank"');
+  const comparisonIdx = body.indexOf('id="comparison-table"');
+  expect(whyIdx).toBeGreaterThan(0);
+  expect(comparisonIdx).toBeGreaterThan(0);
+  expect(whyIdx).toBeLessThan(comparisonIdx);
+});
+
+// ── Section anchors ──────────────────────────────────────────────────
+
+Then('the HTML should contain an element with id {string}', async ({ bddState }, id: string) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain(`id="${id}"`);
+});
+
+// ── Sticky section nav ───────────────────────────────────────────────
+
+Then('the HTML should contain a sticky section navigation element', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain('data-testid="sticky-section-nav"');
+});
+
+// ── Docs CTA ─────────────────────────────────────────────────────────
+
+Then('the HTML should contain a post-article call to action', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain('data-testid="docs-bottom-cta"');
+});
+
+Then('the CTA should contain an install command', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  const ctaStart = body.indexOf('data-testid="docs-bottom-cta"');
+  const afterCta = body.slice(ctaStart, ctaStart + 2500);
+  expect(afterCta).toContain('tank install');
+});
+
+Then('the CTA should appear before the document navigation links', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  const ctaIdx = body.indexOf('data-testid="docs-bottom-cta"');
+  const navIdx = body.indexOf('data-testid="doc-navigation"');
+  expect(ctaIdx).toBeGreaterThan(0);
+  expect(navIdx).toBeGreaterThan(0);
+  expect(ctaIdx).toBeLessThan(navIdx);
+});
+
+// ── Command palette ──────────────────────────────────────────────────
+
+When('I inspect the command menu source', async ({ bddState, e2eContext }) => {
+  const response = await fetch(`${e2eContext.registry}/skills`);
+  bddState.lastResponse = response;
+  bddState.lastResponseBody = { _text: await response.text() } as Record<string, unknown>;
+});
+
+Then('the command menu should include a {string} suggestion', async ({ bddState }, text: string) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain(text);
+});
+
+Then('the suggestion should link to the docs overview', async ({ bddState }) => {
+  const body = bddState.lastResponseBody?._text as string;
+  expect(body).toContain('/docs/overview');
+});

--- a/e2e/cli/telemetry.e2e.test.ts
+++ b/e2e/cli/telemetry.e2e.test.ts
@@ -1,0 +1,158 @@
+/**
+ * CLI Telemetry E2E Tests — opt-in/out, config, env override, resilience.
+ * ZERO mocks: real CLI binary, real config file, real env vars.
+ *
+ * Prerequisites:
+ * - CLI built: bun run build --filter=@tankpkg/cli
+ * - DATABASE_URL set in .env (for setupE2E)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { runTank } from '../helpers/cli';
+import { cleanupE2E, type E2EContext, hasRegistry, setupE2E } from '../helpers/setup';
+
+const describeIfRegistry = hasRegistry ? describe : describe.skip;
+
+function readConfig(home: string): Record<string, unknown> {
+  const configPath = path.join(home, '.tank', 'config.json');
+  if (!fs.existsSync(configPath)) return {};
+  return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+}
+
+describeIfRegistry('CLI Telemetry — opt-in/out and config management', () => {
+  let ctx: E2EContext;
+
+  beforeAll(async () => {
+    if (!hasRegistry) return;
+    ctx = await setupE2E();
+  });
+
+  afterAll(async () => {
+    await cleanupE2E(ctx);
+  });
+
+  // ── Default behavior: telemetry disabled ──────────────────────────
+
+  it('telemetry key is absent by default in config', () => {
+    const config = readConfig(ctx.home);
+    expect(config.telemetry).toBeUndefined();
+  });
+
+  it('telemetry status shows disabled when not configured', async () => {
+    const result = await runTank(['telemetry', 'status'], { home: ctx.home });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/disabled|off/i);
+  });
+
+  // ── Opt-in ────────────────────────────────────────────────────────
+
+  it('tank telemetry on sets config to true', async () => {
+    const result = await runTank(['telemetry', 'on'], { home: ctx.home });
+    expect(result.exitCode).toBe(0);
+
+    const config = readConfig(ctx.home);
+    expect(config.telemetry).toBe(true);
+  });
+
+  it('telemetry status shows enabled after opt-in (when key is compiled)', async () => {
+    const result = await runTank(['telemetry', 'status'], {
+      home: ctx.home,
+      env: { TANK_POSTHOG_KEY: 'phc_test_dummy' }
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/enabled|on/i);
+  });
+
+  // ── Opt-out ───────────────────────────────────────────────────────
+
+  it('tank telemetry off sets config to false', async () => {
+    const result = await runTank(['telemetry', 'off'], { home: ctx.home });
+    expect(result.exitCode).toBe(0);
+
+    const config = readConfig(ctx.home);
+    expect(config.telemetry).toBe(false);
+  });
+
+  it('telemetry status shows disabled after opt-out', async () => {
+    const result = await runTank(['telemetry', 'status'], { home: ctx.home });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/disabled|off/i);
+  });
+
+  // ── Environment variable override ─────────────────────────────────
+
+  it('TANK_TELEMETRY=0 overrides enabled config', async () => {
+    await runTank(['telemetry', 'on'], { home: ctx.home });
+    expect(readConfig(ctx.home).telemetry).toBe(true);
+
+    const result = await runTank(['telemetry', 'status'], {
+      home: ctx.home,
+      env: { TANK_TELEMETRY: '0', TANK_POSTHOG_KEY: 'phc_test_dummy' }
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/disabled|off|overridden/i);
+  });
+
+  it('TANK_TELEMETRY=1 overrides disabled config when key is compiled', async () => {
+    await runTank(['telemetry', 'off'], { home: ctx.home });
+    expect(readConfig(ctx.home).telemetry).toBe(false);
+
+    const result = await runTank(['telemetry', 'status'], {
+      home: ctx.home,
+      env: { TANK_TELEMETRY: '1', TANK_POSTHOG_KEY: 'phc_test_dummy' }
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/enabled|on|overridden/i);
+  });
+
+  it('reports "no key compiled" when build lacks TANK_POSTHOG_KEY', async () => {
+    const result = await runTank(['telemetry', 'status'], { home: ctx.home, env: { TANK_POSTHOG_KEY: '' } });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/no key compiled|disabled/i);
+  });
+
+  // ── Resilience: telemetry failure does not block commands ─────────
+
+  it('tank search works even with broken telemetry backend', async () => {
+    // Enable telemetry, point to unreachable host
+    await runTank(['telemetry', 'on'], { home: ctx.home });
+
+    const result = await runTank(['search', 'nonexistent-package-xyz'], {
+      home: ctx.home,
+      env: {
+        // Point to unreachable host to simulate failure
+        TANK_TELEMETRY_HOST: 'http://999.999.999.999:99999'
+      }
+    });
+
+    // Command should still succeed (search returns results, just none found)
+    expect(result.exitCode).toBe(0);
+    // Must not contain telemetry-related crash errors
+    expect(result.stderr).not.toMatch(/telemetry/i);
+  });
+
+  // ── Install command does not leak package name ────────────────────
+  // (tested at module level — the telemetry module must strip args)
+
+  it('telemetry status command exits cleanly', async () => {
+    const result = await runTank(['telemetry', 'status'], { home: ctx.home });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.length + result.stderr.length).toBeGreaterThan(0);
+  });
+
+  it('telemetry on command prints confirmation', async () => {
+    const result = await runTank(['telemetry', 'on'], { home: ctx.home });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/telemetry|enabled|on/i);
+  });
+
+  it('telemetry off command prints confirmation', async () => {
+    const result = await runTank(['telemetry', 'off'], { home: ctx.home });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/telemetry|disabled|off/i);
+  });
+});

--- a/idd/active/conversion-improvements.md
+++ b/idd/active/conversion-improvements.md
@@ -1,0 +1,124 @@
+# Conversion Improvements Initiative
+
+**Issue:** https://github.com/tankpkg/tank/issues/462
+**Branch:** feat/conversion-improvements
+**Status:** INTENT written, awaiting RED
+
+---
+
+## Summary
+
+Analytics (May 2026, 30 days) reveal conversion gaps:
+
+- **73%** of homepage visitors never reach docs
+- **41%** of all traffic goes directly to `/skills` — browse-and-leave pattern
+- Vault, Atoms, Security Pipeline (Tank's differentiators) get **1-2 views each**
+- MCP docs get early traction — highest-intent audience
+
+This initiative addresses 14 specific changes across 4 modules.
+
+---
+
+## Modules
+
+| Module | IDD | Items | Test type |
+|--------|-----|-------|-----------|
+| `conversion-homepage` | [INTENT.md](../modules/conversion-homepage/INTENT.md) | 5: section reorder, hero pills, hero CTAs, hero stats, sticky nav | HTML fetch E2E |
+| `conversion-skills-list` | [INTENT.md](../modules/conversion-skills-list/INTENT.md) | 3: value banner, getting-started sidebar, card install snippets | Browser E2E |
+| `conversion-skill-detail` | [INTENT.md](../modules/conversion-skill-detail/INTENT.md) | 2: desktop install command, default security tab | Browser E2E |
+| `conversion-cross-cutting` | [INTENT.md](../modules/conversion-cross-cutting/INTENT.md) | 4: docs CTA, command palette, section IDs, CLI telemetry | HTML fetch + CLI E2E |
+
+---
+
+## Implementation Order
+
+```
+Phase 1: INTENT  (4 IDD files)                                              [DONE]
+Phase 2: RED     (4 Gherkin files + 1 steps file + 1 CLI test)             [NEXT]
+Phase 3: GREEN   (homepage → skills list → skill detail → cross-cutting)
+Phase 4: REFACTOR (shared InstallSnippet component, verify all tests green)
+```
+
+---
+
+## Phase 2: RED — Test Files to Create
+
+| File | Covers | Module |
+|------|--------|--------|
+| `bdd/features/system/web-registry/conversion-homepage.feature` | Hero HTML assertions (data-testids), section order (via HTML structure) | conversion-homepage |
+| `bdd/features/browser/tanstack/skills/conversion-skills.feature` | Value banner visibility/dismiss, getting-started card, skill card install snippets | conversion-skills-list |
+| `bdd/features/browser/tanstack/skill-detail/conversion-detail.feature` | Desktop install command visible, default tab=security when scan data exists, trust card | conversion-skill-detail |
+| `bdd/features/system/web-registry/conversion-cross-cutting.feature` | Docs HTML has CTA, command palette source has suggestions, section IDs present | conversion-cross-cutting (items 11-13) |
+| `e2e/cli/telemetry.e2e.test.ts` | Telemetry opt-in/out, config write, env override, event validation | conversion-cross-cutting (item 14) |
+| `e2e/bdd/steps/conversion.steps.ts` | Shared step definitions for all conversion Gherkin scenarios | all |
+
+---
+
+## Phase 3: GREEN — Code Changes per File
+
+### Homepage
+| File | Lines | Change |
+|------|-------|--------|
+| `apps/registry/src/screens/home-screen.tsx` | 78-106 | Reorder: WhyTankExists → Vault → HowItWorks → Atoms before ComparisonTable; add StickySectionNav import |
+| `apps/registry/src/components/home/hero-section.tsx` | 56-105 | Add 4-pill row, Button CTAs, stats row |
+| `apps/registry/src/components/home/vault-section.tsx` | 40 | Add `id="vault"` on section |
+| `apps/registry/src/components/home/atoms-section.tsx` | 1 | Add `id="atoms"` on section |
+| `apps/registry/src/components/home/how-it-works.tsx` | 40 | Add `id="how-it-works"` on section |
+| `apps/registry/src/components/home/why-tank-exists.tsx` | 40 | Add `id="why-tank"` on section |
+| `apps/registry/src/components/home/features-grid.tsx` | 1 | Add `id="features"` on section |
+| `apps/registry/src/components/home/faq-section.tsx` | 1 | Add `id="faq"` on section |
+| `apps/registry/src/components/home/sticky-section-nav.tsx` | NEW | Sticky section nav component with IntersectionObserver |
+
+### Skills List
+| File | Lines | Change |
+|------|-------|--------|
+| `apps/registry/src/screens/skills-list-screen.tsx` | 59-112 | Add ValueBanner import, GettingStarted import, modify SkillCard |
+| `apps/registry/src/components/skills/value-banner.tsx` | NEW | Dismissible banner with localStorage |
+| `apps/registry/src/components/skills/getting-started.tsx` | NEW | 3-step flow card in sidebar |
+| `apps/registry/src/components/skills/install-snippet.tsx` | NEW | Reusable `tank install <name>` with copy |
+
+### Skill Detail
+| File | Lines | Change |
+|------|-------|--------|
+| `apps/registry/src/screens/skill-detail-screen.tsx` | 61-259 | Remove `lg:hidden` from install area; add desktop install in header; default tab logic; trust card |
+
+### Cross-Cutting
+| File | Lines | Change |
+|------|-------|--------|
+| `apps/registry/src/routes/docs/$.tsx` | 99 | Add `<DocsBottomCta />` after `</article>` |
+| `apps/registry/src/components/docs-bottom-cta.tsx` | NEW | Install command + Browse Packages link |
+| `apps/registry/src/components/command-menu.tsx` | TBD | Add "What is Tank?" and "How does scanning work?" suggestions |
+| `packages/cli/src/telemetry.ts` | NEW | Telemetry module: opt-in, posthog-node, event capture, env override |
+| `packages/cli/src/commands/telemetry.ts` | NEW | `tank telemetry on|off|status` subcommand |
+| `packages/cli/src/bin/tank.ts` | TBD | Wire telemetry init, add `telemetry` subcommand, prompt on first run |
+| `packages/cli/package.json` | TBD | Add `posthog-node` dependency |
+
+---
+
+## Phase 4: REFACTOR
+
+- Extract repeated install snippet rendering into `InstallSnippet` component (used in: SkillCard, SkillDetail header, SkillDetail mobile, GettingStarted sidebar, DocsBottomCta)
+- Verify all existing tests pass (homepage UX, homepage-seo, search, skill-detail, skill-detail-mobile)
+- Run full BDD suite: `just test bdd`
+- Run E2E suite: `just test e2e`
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Section reorder breaks mobile layout | Existing sections use `py-20` with `max-w-[1000px]` — independent stacking |
+| Sticky nav intersects with existing nav (`sticky top-0`) | Use `top-14` (header height) for sticky nav |
+| CLI telemetry adds PostHog dependency to binary | `posthog-node` is ~50KB bundled; fire-and-forget with subprocess or queue |
+| Install snippet click triggers card navigation | Use `e.stopPropagation()` + `e.preventDefault()` in copy handler |
+| Default tab change could confuse returning users | Only change default when `hasSecurityData === true` AND no tab preference in URL |
+
+---
+
+## Open Questions
+
+1. **CLI telemetry PostHog key:** compile-time injected vs runtime env var? Compile-time = all binaries from GitHub Releases share the key. Runtime = self-hosted can bring own. Which?
+2. **Sticky nav mobile position:** below header bar (`top-14`) or replace header? Below header matches Stripe Docs / Linear pattern.
+3. **Getting-started card for logged-in users:** show "You're authenticated" instead of step 1, or hide entirely?
+4. **Docs bottom CTA wording:** "Ready to try? [copyable command] [Browse packages →]" or something else?

--- a/idd/modules/conversion-cross-cutting/INTENT.md
+++ b/idd/modules/conversion-cross-cutting/INTENT.md
@@ -1,0 +1,71 @@
+# Conversion: Cross-Cutting
+
+## Anchor
+
+**Why this module exists:** Several conversion improvements span multiple pages or touch shared components (command palette, docs layout, CLI analytics). These are smaller in scope but collectively address the "users don't understand what Tank does" gap.
+
+**Consumers:** Docs readers, ⌘K users, CLI users.
+
+**Single source of truth:** Multiple files — see structure below.
+
+---
+
+## Layer 1: Structure
+
+```
+apps/registry/src/routes/docs/$.tsx                       # Docs bottom CTA
+apps/registry/src/components/command-menu.tsx              # Command palette suggestions
+packages/cli/src/                                          # CLI telemetry (NEW)
+```
+
+---
+
+## Layer 2: Constraints
+
+| #   | Rule                                                                                   | Rationale                                                                |
+| --- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| C1  | Every docs page must render a bottom CTA after the article content                     | Users who finish reading need a next step                                |
+| C2  | Docs CTA must include a copyable install command AND a link to `/skills`               | Two possible next actions: install CLI or browse packages               |
+| C3  | Docs CTA must appear after `</article>` but before `DocNavigation` (prev/next links)    | Natural reading flow: content → action → navigate                        |
+| C4  | Command palette must include "What is Tank?" suggestion that links to `/docs/overview`  | ⌘K users searching for understanding should find it                      |
+| C5  | Command palette "What is Tank?" must appear early in suggestions (not buried)           | Highest-value suggestion for confused users                              |
+| C6  | CLI telemetry must be strictly opt-in                                                    | Respects user privacy; no silent tracking                                |
+| C7  | CLI telemetry consent prompt fires once on first `tank init` or `tank login`            | Natural touchpoint; never asks twice (persists decision)                 |
+| C8  | CLI telemetry must be configured via `~/.tank/config.json` under `"telemetry"` key       | Persistent, inspectable, user-controllable                              |
+| C9  | CLI telemetry must respect `TANK_TELEMETRY=0`/`=1` env var override                      | Enterprise/debug override                                                |
+| C10 | CLI telemetry uses native `fetch` to PostHog HTTP endpoint (no `posthog-node` dep)       | Smaller binary; no upstream SDK risk                                     |
+| C11 | CLI telemetry events must be stripped of package names, file paths, and API keys         | Privacy: no sensitive data in events                                    |
+| C12 | CLI telemetry must not block or delay any command (2s timeout, abort silent)             | Fire-and-forget; failure must be silent                                  |
+| C13 | Telemetry prompt skips in CI, non-TTY, on-prem, no-key, env-set, prior-decision contexts | Avoid hanging headless runs; respect environment overrides              |
+| C14 | `tank doctor` reports current telemetry state in its diagnostics section                  | Discoverability — users can see what's collected without reading docs   |
+| C15 | A randomized `telemetryDistinctId` (UUIDv4) identifies the install across events          | Aggregate metrics without fingerprinting users                          |
+
+---
+
+## Layer 3: Examples
+
+### Docs CTA
+| #    | Action                                          | Expected behavior                                                                 |
+| ---- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| E1   | Visit `/docs/overview`                          | After article, before prev/next nav: "Ready to try? ..." with copyable `tank install` and "Browse packages" link |
+| E2   | Visit any docs page                             | Same CTA rendered — all docs share the single catch-all route                     |
+
+### Command Palette
+| #    | Action                                          | Expected behavior                                                                 |
+| ---- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| E3   | Open ⌘K, type "tank"                           | Early suggestion: "What is Tank?" linking to `/docs/overview`                    |
+| E4   | Open ⌘K, type "scan"                           | Suggestion: "How does scanning work?" linking to `/docs/security`                 |
+
+### CLI Telemetry
+| #    | Action                                          | Expected behavior                                                                 |
+| ---- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| E5   | First interactive `tank init` (TTY, no decision)| Prompt: "Help improve Tank by sending anonymous usage analytics? [y/N]"          |
+| E6   | User answers "y"                                | `telemetry: true` saved; `cli_opted_in` event sent with `source: first-run-prompt`|
+| E7   | User answers anything else                      | `telemetry: false` saved; no event                                                |
+| E8   | First `tank login` after install (TTY)          | Same prompt fires once; persists decision                                          |
+| E9   | `TANK_TELEMETRY=0 tank install <pkg>`           | No event sent, even if config has `"telemetry": true`                            |
+| E10  | `TANK_MODE=selfhosted` anywhere                 | Telemetry hard-disabled; prompt skipped entirely                                   |
+| E11  | Piped stdin / CI=true / no TTY                  | Prompt skipped (no hang); manual `tank telemetry on` still works                  |
+| E12  | `tank telemetry on/off/status`                  | Manage opt-in directly; emits matching events                                      |
+| E13  | `tank doctor`                                   | Prints "Telemetry" section showing current state and override reason if any       |
+| E14  | Failed install with "not found"                 | After error, CLI prints "Did you mean:" with fuzzy-matched suggestions             |

--- a/idd/modules/conversion-homepage/INTENT.md
+++ b/idd/modules/conversion-homepage/INTENT.md
@@ -1,0 +1,57 @@
+# Conversion: Homepage
+
+## Anchor
+
+**Why this module exists:** Analytics (May 2026, 30 days) show 73% of homepage visitors never reach docs, and Tank's most differentiating features (Vault, Atoms, security pipeline) sit buried at sections 8-10 of 15. The homepage must surface differentiators earlier, make CTAs scannable, and help users navigate a long page.
+
+**Consumers:** First-time visitors, returning users browsing packages.
+
+**Single source of truth:** `apps/registry/src/screens/home-screen.tsx`.
+
+---
+
+## Layer 1: Structure
+
+```
+apps/registry/src/screens/home-screen.tsx              # Section ordering
+apps/registry/src/components/home/hero-section.tsx     # Hero CTAs, pills, stats
+apps/registry/src/components/home/vault-section.tsx    # Needs id="vault"
+apps/registry/src/components/home/atoms-section.tsx    # Needs id="atoms"
+apps/registry/src/components/home/how-it-works.tsx     # Needs id="how-it-works"
+apps/registry/src/components/home/sticky-section-nav.tsx  # NEW
+```
+
+---
+
+## Layer 2: Constraints
+
+| #   | Rule                                                                              | Rationale                                                                 |
+| --- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| C1  | Sections must be ordered: Hero → WorksWith → WhyTankExists → Vault → HowItWorks → Atoms → ComparisonTable → FeaturesGrid → rest | Vault and Atoms (differentiators) must appear in first 5 sections |
+| C2  | ComparisonTable must appear after differentiators, not before                    | Competitive info serves skeptics, not first-time discoverers             |
+| C3  | Hero must display 4 scannable differentiator pills below subtitle                 | Scanners understand Tank in <1 second without reading paragraph text     |
+| C4  | Differentiator pills must scroll to their section via href fragments              | Pills must be actionable, not decorative                                 |
+| C5  | Hero must have visible Button CTAs for "Browse Packages" and "View Docs"          | Current text links at 13px muted color are invisible                      |
+| C6  | Hero must show social proof stats: `{N} packages · {N} GitHub stars · MIT`        | Reduces bounce for skeptical visitors                                      |
+| C7  | Sticky section nav must appear after scrolling past hero on desktop              | Long pages lose users without navigation                                  |
+| C8  | Sticky nav must scroll horizontally on mobile                                    | Must not break mobile layout                                              |
+| C9  | Sticky nav must highlight the currently visible section                           | Users must know where they are on the page                               |
+| C10 | WhyTankExists must not assume visitors know "skills", "lockfiles", or "semver"    | Existing constraint H6 from homepage UX — must not regress                |
+| C11 | All section components receiving pill anchors must have id attributes             | `#vault`, `#atoms`, `#how-it-works`, `#why-tank`, `#features`, `#faq`   |
+
+---
+
+## Layer 3: Examples
+
+| #    | Visitor type / action                                       | Expected behavior                                                              |
+| ---- | ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| E1   | First-time visitor loads homepage                          | Sees hero headline, then 4 pills (Scanning, Vault, Permissions, Integrity), then install CTA with "Browse Packages" button |
+| E2   | Visitor clicks "Credential Vault" pill                     | Page scrolls to `#vault` section                                              |
+| E3   | Visitor scrolls past hero                                  | Sticky section nav appears at top of viewport with section links              |
+| E4   | Visitor sees hero subtitle                                 | Can scan 4 pills and understand key differentiators in <5 seconds            |
+| E5   | Visitor wants to browse without reading                   | Has visible "Browse Packages" button at full text size, not hidden tiny link |
+| E6   | Visitor at section 12 (Enterprise) wants to jump to FAQ    | Uses sticky nav to jump to FAQ without scrolling back                        |
+| E7   | Visitor on mobile scrolls past hero                        | Sticky nav appears, scrolls horizontally, highlights active section           |
+| E8   | Homepage HTML fetched (SEO test)                           | Hero contains `data-testid="hero-differentiator-pills"` with 4 children      |
+| E9   | Homepage HTML fetched (SEO test)                           | Hero contains `data-testid="home-primary-cta"` (Browse Packages) and `data-testid="home-secondary-cta"` (View Docs) |
+| E10  | Homepage HTML fetched (SEO test)                           | Hero contains `data-testid="hero-stats"` with package count, star count, and license text |

--- a/idd/modules/conversion-skill-detail/INTENT.md
+++ b/idd/modules/conversion-skill-detail/INTENT.md
@@ -1,0 +1,47 @@
+# Conversion: Skill Detail
+
+## Anchor
+
+**Why this module exists:** The skill detail page is where conversion happens — a user has found a package they're interested in. Currently: (1) the install command is hidden on desktop (`lg:hidden`), (2) the default tab is README, not Security, meaning the trust signal is buried behind a click. Both reduce conversion from browsing to installing.
+
+**Consumers:** Visitors viewing package details, CLI users looking for install instructions.
+
+**Single source of truth:** `apps/registry/src/screens/skill-detail-screen.tsx`.
+
+---
+
+## Layer 1: Structure
+
+```
+apps/registry/src/screens/skill-detail-screen.tsx       # Install visibility, tab default, trust card
+apps/registry/src/components/skills/install-snippet.tsx  # Shared install snippet component
+```
+
+---
+
+## Layer 2: Constraints
+
+| #   | Rule                                                                              | Rationale                                                                 |
+| --- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| C1  | Install command with copy button must be visible on both mobile AND desktop       | Desktop users (majority) should not lose the primary conversion action    |
+| C2  | Install snippet must show `tank install <name>` and a copy button                 | Matches existing MobileActionBar pattern                                  |
+| C3  | Desktop install snippet must appear in header area (name/version row)              | High visibility, near package name                                       |
+| C4  | Default tab must be `readme` regardless of scan presence                          | Users came to learn how to use the skill; trust signal delivered via summary card above tabs (see C6) |
+| C5  | Trust summary card "View details →" button must switch to the security tab        | Allows users who want trust details to reach them in one click             |
+| C6  | A trust summary card must appear above the tabs when security data exists         | Delivers at-a-glance trust signal without forcing tab change              |
+| C7  | Trust summary must show: verdict badge, finding counts (critical/high/medium), scan date | Users need at-a-glance trust signal                                     |
+| C8  | Trust summary must have visible spacing (margin) between itself and the tabs       | Avoids visual collision between two stacked content blocks                |
+| C9  | `useClipboard` hook must be used for copy (shared component)                       | Consistent UX                                                            |
+
+---
+
+## Layer 3: Examples
+
+| #    | Visitor action                                          | Expected behavior                                                                 |
+| ---- | ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| E1   | Opens skill detail on desktop with scan data           | Sees install command in header area (not hidden), trust summary card with spacing above tabs, README tab active by default |
+| E2   | Opens skill detail on desktop without scan data        | Sees install command in header area, README tab active by default, no trust card  |
+| E3   | Opens skill detail on mobile with scan data            | Sees install command in mobile action bar (existing), trust summary card, README tab active |
+| E4   | Clicks "View details →" in trust summary card         | Security tab becomes active                                                       |
+| E5   | Copies install command from desktop header             | Command copies, button shows check icon                                           |
+| E6   | Switches between tabs                                  | Tab content updates normally                                                       |

--- a/idd/modules/conversion-skills-list/INTENT.md
+++ b/idd/modules/conversion-skills-list/INTENT.md
@@ -1,0 +1,52 @@
+# Conversion: Skills List
+
+## Anchor
+
+**Why this module exists:** `/skills` gets 41% of all traffic (117 pageviews/30 days) but provides zero context about *why* Tank is different from any other registry. Users browse packages and leave without understanding the platform's value proposition. The skills list page needs to bridge discovery to understanding.
+
+**Consumers:** Visitors browsing packages, logged-in users, CLI users transitioning to web.
+
+**Single source of truth:** `apps/registry/src/screens/skills-list-screen.tsx`.
+
+---
+
+## Layer 1: Structure
+
+```
+apps/registry/src/screens/skills-list-screen.tsx   # Banner, sidebar, card changes
+apps/registry/src/components/skills/value-banner.tsx         # NEW: dismissible value prop banner
+apps/registry/src/components/skills/getting-started.tsx      # NEW: sidebar getting-started card
+apps/registry/src/components/skills/install-snippet.tsx      # NEW: shared install snippet (also used by skill-detail)
+```
+
+---
+
+## Layer 2: Constraints
+
+| #   | Rule                                                                              | Rationale                                                                 |
+| --- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| C1  | Value-proposition banner must appear below `<h1>` and above search bar            | Users must see it before they start browsing                              |
+| C2  | Banner must link to `/docs/overview`                                               | Bridges discovery users to understanding                                   |
+| C3  | Banner must be dismissible, stored in `localStorage`                               | Returning users don't need to re-read                                     |
+| C4  | Getting-started sidebar card must appear in the filter sidebar on desktop (hidden on mobile) | Desktop filter sidebar has empty space; mobile uses the banner instead |
+| C5  | Getting-started card must show 3-step flow: Install CLI → Search → Install         | CLI workflow is the primary conversion path                               |
+| C6  | CLI install command must be copyable via `useClipboard`                             | Must match existing copy pattern across the site                           |
+| C7  | Each SkillCard must show a copyable `tank install <name>` snippet at the bottom    | Users should see the install path without clicking through to detail      |
+| C8  | Install snippet in card must use `useClipboard` hook                                | Consistent UX across the site                                             |
+| C9  | Install snippet must not interfere with the card's full-overlay `<Link>`           | Clicking the snippet copy button must not trigger card navigation        |
+
+---
+
+## Layer 3: Examples
+
+| #    | Visitor action                                          | Expected behavior                                                                 |
+| ---- | ------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| E1   | First visit to `/skills`                                | Sees banner: "Every package scanned through a 6-stage security pipeline. Learn more →" linking to `/docs/overview` |
+| E2   | Dismiss banner                                          | Banner disappears; revisit does not show it (`localStorage` key set)             |
+| E3   | Second visit to `/skills` after dismissing             | Banner does not appear                                                            |
+| E4   | Desktop visitor looks at filter sidebar                | Sees "Getting Started" card with 3 steps: `npm i -g @tankpkg/cli` → `tank search` → `tank install <name>` |
+| E5   | Click copy on CLI install in sidebar                   | Command copied, "Copied!" feedback shown                                          |
+| E6   | Browse skill cards grid                                | Each card shows `tank install <name>` snippet with copy button at bottom          |
+| E7   | Click copy on card install snippet                     | Command copied, button shows check icon briefly; card navigation NOT triggered    |
+| E8   | Mobile visitor                                         | Banner visible; getting-started card hidden (mobile filter area too small)       |
+| E9   | Logged-in visitor (already authenticated)              | Getting-started card adapts: step 1 shows "You're authenticated — skip" or similar |

--- a/idd/modules/install/INTENT.md
+++ b/idd/modules/install/INTENT.md
@@ -51,6 +51,11 @@ apps/registry/src/api/routes/v1/skills-read.ts  # GET — list versions, fetch m
 | C9  | If the requested version does not satisfy the available range, install fails with an informative error | Clear error; prevents installing wrong versions                               | BDD scenario  |
 | C10 | Without auth token, install for private skills fails; public skills can install unauthenticated        | Public registry is open; private requires identity                            | BDD scenario  |
 | C11 | `installFromLockfile` re-downloads and re-verifies all skills pinned in `tank.lock`                    | CI mode: deterministic re-installs from lockfile without semver re-resolution | BDD scenario  |
+| C12 | `tank install` accepts multiple targets in one invocation (`tank install pkg1 pkg2@^1 url`)            | npm/yarn/pnpm-compatible UX; lets users install copy-pasted lists in one shot | Unit test     |
+| C13 | Each target may carry an `@version` suffix using `name@range` (e.g. `@org/skill@^1.0.0`)               | npm-compatible spec syntax                                                    | Unit test     |
+| C14 | One failing target does NOT abort installs of subsequent targets; exit code is non-zero if any failed  | Best-effort install across a list — user sees what succeeded and what didn't  | Unit test     |
+| C15 | Legacy `tank install <name> <semver-range>` (2 positional args) still works as back-compat shim         | Avoid breaking existing scripts; detected when 2nd arg matches a bare semver  | Unit test     |
+| C16 | `-g`/`--global` flag is propagated to every target in multi-install                                     | All-or-nothing scope; never partial-global                                    | Unit test     |
 
 ---
 
@@ -68,3 +73,11 @@ apps/registry/src/api/routes/v1/skills-read.ts  # GET — list versions, fetch m
 | E8  | `install-skill` with registry URL set to unreachable address | Fails with network/connection error; skill dir NOT created on disk               |
 | E9  | `install-skill({ name: "@org/skill", version: "99.0.0" })`   | Fails with "no version satisfies range" or "version not found" message           |
 | E10 | `installFromLockfile` with a valid `tank.lock`               | Re-downloads and re-verifies all skills; succeeds with count of installed skills |
+| E11 | `tank install @org/a @org/b@^1 https://x.com/c.tgz`          | Installs all three targets; aggregates failures; exits non-zero if any failed     |
+| E12 | `parseInstallTarget("@org/skill@^1.0.0")`                    | `{ kind: 'name', name: '@org/skill', versionRange: '^1.0.0' }`                    |
+| E13 | `parseInstallTarget("https://github.com/owner/repo")`        | `{ kind: 'url', url: 'https://github.com/owner/repo' }`                           |
+| E14 | `tank install @org/skill ^1.0.0` (legacy positional form)    | Shim rewrites to `@org/skill@^1.0.0`; installs as single target                   |
+| E15 | `tank install -g @org/a @org/b@^1`                           | Both targets installed globally; no tank.json modified                            |
+| E16 | `tank install @org/a @org/b` (no semver-shaped 2nd arg)      | Treated as TWO targets, not legacy form (shim does NOT fire)                      |
+| E17 | `looksLikeVersionRange("^1.0.0")` / `("latest")` / `("1.x")` | `true`                                                                            |
+| E18 | `looksLikeVersionRange("@org/skill")` / `("https://x.com")`  | `false`                                                                           |

--- a/packages/cli/src/__tests__/install-target.test.ts
+++ b/packages/cli/src/__tests__/install-target.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { looksLikeVersionRange, parseInstallTarget } from '~/lib/install-target.js';
+
+describe('parseInstallTarget', () => {
+  it('scoped name without version → name only', () => {
+    expect(parseInstallTarget('@org/skill')).toEqual({ kind: 'name', name: '@org/skill' });
+  });
+
+  it('scoped name with caret range → name + range', () => {
+    expect(parseInstallTarget('@org/skill@^1.0.0')).toEqual({
+      kind: 'name',
+      name: '@org/skill',
+      versionRange: '^1.0.0'
+    });
+  });
+
+  it('scoped name with exact version → name + range', () => {
+    expect(parseInstallTarget('@org/skill@1.2.3')).toEqual({
+      kind: 'name',
+      name: '@org/skill',
+      versionRange: '1.2.3'
+    });
+  });
+
+  it('unscoped name without version → name only', () => {
+    expect(parseInstallTarget('skill')).toEqual({ kind: 'name', name: 'skill' });
+  });
+
+  it('unscoped name with version → name + range', () => {
+    expect(parseInstallTarget('skill@2.0.0')).toEqual({
+      kind: 'name',
+      name: 'skill',
+      versionRange: '2.0.0'
+    });
+  });
+
+  it('https URL → url', () => {
+    expect(parseInstallTarget('https://github.com/owner/repo')).toEqual({
+      kind: 'url',
+      url: 'https://github.com/owner/repo'
+    });
+  });
+
+  it('http URL → url', () => {
+    expect(parseInstallTarget('http://example.com/skill.tgz')).toEqual({
+      kind: 'url',
+      url: 'http://example.com/skill.tgz'
+    });
+  });
+
+  it('trailing @ with empty range → treated as bare name', () => {
+    expect(parseInstallTarget('@org/skill@')).toEqual({ kind: 'name', name: '@org/skill@' });
+  });
+
+  it('preserves complex semver ranges (e.g. >=1.0.0 <2.0.0)', () => {
+    expect(parseInstallTarget('@org/skill@>=1.0.0 <2.0.0')).toEqual({
+      kind: 'name',
+      name: '@org/skill',
+      versionRange: '>=1.0.0 <2.0.0'
+    });
+  });
+});
+
+describe('looksLikeVersionRange', () => {
+  it.each([
+    ['^1.0.0', true],
+    ['~1', true],
+    ['>=2', true],
+    ['<2', true],
+    ['=1.0.0', true],
+    ['1.0.0', true],
+    ['1', true],
+    ['1.x', true],
+    ['*', true],
+    ['latest', true],
+    ['next', true]
+  ])('treats %s as a version range', (input, expected) => {
+    expect(looksLikeVersionRange(input)).toBe(expected);
+  });
+
+  it.each([
+    ['@org/skill', false],
+    ['@org/skill@^1.0.0', false],
+    ['skill', false],
+    ['my-skill', false],
+    ['https://github.com/owner/repo', false],
+    ['http://example.com', false],
+    ['', false]
+  ])('treats %s as NOT a version range', (input, expected) => {
+    expect(looksLikeVersionRange(input)).toBe(expected);
+  });
+});

--- a/packages/cli/src/bin/tank.ts
+++ b/packages/cli/src/bin/tank.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-
 import { auditCommand } from '~/commands/audit.js';
 import { buildCommand } from '~/commands/build.js';
 import { doctorCommand } from '~/commands/doctor.js';
@@ -18,19 +17,28 @@ import { removeCommand } from '~/commands/remove.js';
 import { runCommand } from '~/commands/run.js';
 import { scanCommand } from '~/commands/scan.js';
 import { searchCommand } from '~/commands/search.js';
+import { type TelemetryAction, telemetryCommand } from '~/commands/telemetry.js';
 import { unlinkCommand } from '~/commands/unlink.js';
 import { updateCommand } from '~/commands/update.js';
 import { upgradeCommand } from '~/commands/upgrade.js';
 import { verifyCommand } from '~/commands/verify.js';
 import { whoamiCommand } from '~/commands/whoami.js';
 import { flushLogs } from '~/lib/debug-logger.js';
+import { fetchSimilarSkillNames, formatInstallSuggestions } from '~/lib/install-suggestions.js';
+import { looksLikeVersionRange, parseInstallTarget } from '~/lib/install-target.js';
+import { captureEvent } from '~/lib/telemetry.js';
 import { checkForUpgrade } from '~/lib/upgrade-check.js';
-import { isUrl } from '~/lib/url-fetcher.js';
 import { VERSION } from '~/version.js';
 
 const program = new Command();
 
 program.name('tank').description('Security-first package manager for AI agent skills').version(VERSION);
+
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  const name = actionCommand.name();
+  if (name === 'telemetry') return;
+  captureEvent({ event: 'cli_command', properties: { command: name } });
+});
 
 program
   .command('init')
@@ -157,48 +165,63 @@ program
 program
   .command('install')
   .alias('i')
-  .description('Install a skill from the Tank registry, a URL, or all skills from lockfile')
+  .description('Install one or more skills from the Tank registry, URLs, or all skills from lockfile')
   .argument(
-    '[name]',
-    'Skill name or URL (e.g., @org/skill-name or https://github.com/owner/repo). Omit to install from lockfile.'
+    '[targets...]',
+    'One or more skill specs or URLs (e.g. @org/skill, @org/skill@^1.0.0, https://github.com/owner/repo). Omit to install from lockfile.'
   )
-  .argument('[version-range]', 'Semver range (default: *)', '*')
   .option('-g, --global', 'Install skill globally (available to all projects)')
   .option('-y, --yes', 'Auto-accept flagged scan verdicts')
   .option('--dangerously-no-tank-proxy', 'Skip wrapping MCP servers with the tank proxy (no scanning, no enforcement)')
-  .action(
-    async (
-      name: string | undefined,
-      versionRange: string,
-      opts: { global?: boolean; yes?: boolean; dangerouslyNoTankProxy?: boolean }
-    ) => {
+  .action(async (targets: string[], opts: { global?: boolean; yes?: boolean; dangerouslyNoTankProxy?: boolean }) => {
+    const proxyOpt = opts.dangerouslyNoTankProxy ? { dangerouslyNoTankProxy: true as const } : {};
+
+    if (targets.length === 0) {
       try {
-        if (name && isUrl(name)) {
-          await installFromUrl(name, {
-            global: opts.global,
-            yes: opts.yes,
-            ...(opts.dangerouslyNoTankProxy ? { dangerouslyNoTankProxy: true } : {})
-          });
-        } else if (name) {
-          await installCommand({
-            name,
-            versionRange,
-            global: opts.global,
-            ...(opts.dangerouslyNoTankProxy ? { dangerouslyNoTankProxy: true } : {})
-          });
-        } else {
-          await installAll({
-            global: opts.global,
-            ...(opts.dangerouslyNoTankProxy ? { dangerouslyNoTankProxy: true } : {})
-          });
-        }
+        await installAll({ global: opts.global, ...proxyOpt });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`Install failed: ${msg}`);
         process.exit(1);
       }
+      return;
     }
-  );
+
+    const effectiveTargets =
+      targets.length === 2 && looksLikeVersionRange(targets[1]) ? [`${targets[0]}@${targets[1]}`] : targets;
+
+    const failures: Array<{ target: string; error: string; parsedName?: string }> = [];
+    for (const target of effectiveTargets) {
+      const parsed = parseInstallTarget(target);
+      try {
+        if (parsed.kind === 'url') {
+          await installFromUrl(parsed.url, { global: opts.global, yes: opts.yes, ...proxyOpt });
+        } else {
+          await installCommand({
+            name: parsed.name,
+            versionRange: parsed.versionRange ?? '*',
+            global: opts.global,
+            ...proxyOpt
+          });
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        failures.push({ target, error: msg, parsedName: parsed.kind === 'name' ? parsed.name : undefined });
+        console.error(`Install failed for ${target}: ${msg}`);
+      }
+    }
+
+    for (const failure of failures) {
+      if (!failure.parsedName || !/not found/i.test(failure.error)) continue;
+      const suggestions = await fetchSimilarSkillNames(failure.parsedName);
+      console.error(`\n${formatInstallSuggestions(failure.parsedName, suggestions)}`);
+    }
+
+    if (failures.length > 0) {
+      console.error(`\nInstall finished with ${failures.length}/${effectiveTargets.length} failure(s).`);
+      process.exit(1);
+    }
+  });
 
 program
   .command('remove')
@@ -470,6 +493,24 @@ program
       process.exit(1);
     }
     await flushLogs();
+  });
+
+program
+  .command('telemetry <action>')
+  .description('Manage anonymous usage telemetry (on | off | status). Opt-in only, never enabled by default.')
+  .action(async (action: string) => {
+    try {
+      const normalized = action.toLowerCase() as TelemetryAction;
+      if (normalized !== 'on' && normalized !== 'off' && normalized !== 'status') {
+        console.error(`Unknown telemetry action: ${action}. Use: on | off | status.`);
+        process.exit(1);
+      }
+      await telemetryCommand({ action: normalized });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Telemetry command failed: ${msg}`);
+      process.exit(1);
+    }
   });
 
 checkForUpgrade().catch(() => {});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -8,6 +8,7 @@ import { detectInstalledAgents, getGlobalSkillsDir, getSupportedAgents } from '~
 import { type AgentLinkStatus, getSkillLinkStatus } from '~/lib/linker.js';
 import { readGlobalLinks } from '~/lib/links.js';
 import { resolveLockfilePath, resolveManifestPath } from '~/lib/manifest.js';
+import { describeTelemetryState } from '~/lib/telemetry.js';
 
 export interface DoctorOptions {
   directory?: string;
@@ -186,6 +187,9 @@ export async function doctorCommand(options?: DoctorOptions): Promise<void> {
     if (localSkills.length === 0 && uniqueGlobal.length === 0 && devLinks.length === 0) {
       suggestions.add('Run `tank install @tank/typescript` to add your first skill');
     }
+
+    printSectionHeader('Telemetry');
+    console.log(`  ${describeTelemetryState()}`);
 
     printSectionHeader('Suggestions');
     if (suggestions.size === 0) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,6 +7,7 @@ import { MANIFEST_FILENAME, skillsJsonSchema } from '@internals/schemas';
 import { getConfig } from '~/lib/config.js';
 import { logger } from '~/lib/logger.js';
 import { resolveManifestPath } from '~/lib/manifest.js';
+import { maybePromptForTelemetryConsent } from '~/lib/telemetry.js';
 
 const NAME_PATTERN = /^(@[a-z0-9-]+\/)?[a-z0-9][a-z0-9-]*$/;
 const SEMVER_PATTERN = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;
@@ -87,9 +88,9 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       return;
     }
 
-    // Write file
     fs.writeFileSync(filePath, `${JSON.stringify(manifest, null, 2)}\n`);
     logger.success(`Created ${MANIFEST_FILENAME}`);
+    await maybePromptForTelemetryConsent();
     return;
   }
 
@@ -165,7 +166,8 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     return;
   }
 
-  // Write file
   fs.writeFileSync(filePath, `${JSON.stringify(manifest, null, 2)}\n`);
   logger.success(`Created ${MANIFEST_FILENAME}`);
+
+  await maybePromptForTelemetryConsent();
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -3,6 +3,7 @@ import open from 'open';
 import { getConfig, setConfig } from '~/lib/config.js';
 import { authFlowLog } from '~/lib/debug-logger.js';
 import { logger } from '~/lib/logger.js';
+import { maybePromptForTelemetryConsent } from '~/lib/telemetry.js';
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -102,6 +103,7 @@ export async function loginCommand(options: LoginOptions = {}): Promise<void> {
 
         const displayName = user.name ?? user.email ?? 'unknown';
         logger.success(`Logged in as ${displayName}`);
+        await maybePromptForTelemetryConsent(configDir);
         return;
       }
 

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,45 @@
+import { logger } from '~/lib/logger.js';
+import { captureEvent, describeTelemetryState, getTelemetryStatus, setTelemetry } from '~/lib/telemetry.js';
+
+export type TelemetryAction = 'on' | 'off' | 'status';
+
+export interface TelemetryOptions {
+  action: TelemetryAction;
+  configDir?: string;
+}
+
+export async function telemetryCommand(opts: TelemetryOptions): Promise<void> {
+  const { action, configDir } = opts;
+
+  if (action === 'status') {
+    logger.info(describeTelemetryState(configDir));
+    return;
+  }
+
+  if (action === 'on') {
+    setTelemetry(true, configDir);
+    const status = getTelemetryStatus(configDir);
+    if (status.reason === 'onprem') {
+      logger.warn('Telemetry config written, but disabled because TANK_MODE=selfhosted.');
+      return;
+    }
+    if (status.reason === 'no-key') {
+      logger.warn('Telemetry config written, but this build has no telemetry key compiled in.');
+      return;
+    }
+    captureEvent({ event: 'cli_opted_in' }, configDir);
+    logger.info('Telemetry: enabled. Thanks for helping improve Tank.');
+    logger.info('Disable any time: tank telemetry off');
+    return;
+  }
+
+  if (action === 'off') {
+    captureEvent({ event: 'cli_opted_out' }, configDir);
+    setTelemetry(false, configDir);
+    logger.info('Telemetry: disabled.');
+    return;
+  }
+
+  logger.error(`Unknown telemetry action: ${action}. Use on | off | status.`);
+  process.exitCode = 1;
+}

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -6,6 +6,8 @@ export interface TankConfig {
   token?: string;
   user?: { name: string; email: string };
   registry: string;
+  telemetry?: boolean;
+  telemetryDistinctId?: string;
 }
 
 const DEFAULT_CONFIG: TankConfig = {

--- a/packages/cli/src/lib/install-suggestions.ts
+++ b/packages/cli/src/lib/install-suggestions.ts
@@ -1,0 +1,56 @@
+import { getConfig } from '~/lib/config.js';
+import { USER_AGENT } from '~/version.js';
+
+interface SearchResult {
+  name: string;
+  description?: string | null;
+}
+
+interface SearchResponse {
+  results: SearchResult[];
+}
+
+/**
+ * Best-effort fuzzy lookup of similar skill names. Hits the public /api/v1/search
+ * endpoint (no auth needed for public skills). Returns up to `limit` matches.
+ * Silent failure: never throws — suggestions are advisory, not critical-path.
+ */
+export async function fetchSimilarSkillNames(
+  query: string,
+  opts: { configDir?: string; limit?: number; timeoutMs?: number } = {}
+): Promise<SearchResult[]> {
+  const { configDir, limit = 3, timeoutMs = 2000 } = opts;
+  const config = getConfig(configDir);
+
+  const bareName = query.replace(/^@[^/]+\//, '').replace(/^[^a-z0-9]+/i, '');
+  const searchTerm = bareName || query;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(`${config.registry}/api/v1/search?q=${encodeURIComponent(searchTerm)}&limit=${limit}`, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: controller.signal
+    });
+    clearTimeout(timer);
+    if (!res.ok) return [];
+    const data = (await res.json()) as SearchResponse;
+    return (data.results ?? []).filter((r) => r.name && r.name !== query).slice(0, limit);
+  } catch {
+    clearTimeout(timer);
+    return [];
+  }
+}
+
+export function formatInstallSuggestions(name: string, suggestions: SearchResult[]): string {
+  if (suggestions.length === 0) {
+    return `Try \`tank search ${name}\` to find similar packages.`;
+  }
+  const lines = ['Did you mean one of these?'];
+  for (const s of suggestions) {
+    lines.push(`  • ${s.name}${s.description ? `  — ${s.description.slice(0, 60)}` : ''}`);
+  }
+  lines.push(`\nOr search: \`tank search ${name}\``);
+  return lines.join('\n');
+}

--- a/packages/cli/src/lib/install-target.ts
+++ b/packages/cli/src/lib/install-target.ts
@@ -1,0 +1,53 @@
+import { isUrl } from '~/lib/url-fetcher.js';
+
+export type InstallTarget = { kind: 'url'; url: string } | { kind: 'name'; name: string; versionRange?: string };
+
+/**
+ * Parse a single install target string into a structured target.
+ *
+ * Accepted forms (npm-compatible):
+ *   - `@org/pkg`               → name with no range
+ *   - `@org/pkg@^1.0.0`        → name + range (split on the LAST `@` for scoped names)
+ *   - `pkg`                    → unscoped name with no range
+ *   - `pkg@1.0.0`              → unscoped name + range
+ *   - `https://github.com/...` → URL install
+ *
+ * The `@` that separates name from range is the FIRST `@` that is NOT at position 0
+ * (position 0 is the scope marker for `@org/...`).
+ */
+export function parseInstallTarget(target: string): InstallTarget {
+  if (isUrl(target)) {
+    return { kind: 'url', url: target };
+  }
+
+  const searchStart = target.startsWith('@') ? 1 : 0;
+  const versionAt = target.indexOf('@', searchStart);
+
+  if (versionAt === -1) {
+    return { kind: 'name', name: target };
+  }
+
+  const name = target.slice(0, versionAt);
+  const versionRange = target.slice(versionAt + 1);
+  if (!name || !versionRange) {
+    return { kind: 'name', name: target };
+  }
+
+  return { kind: 'name', name, versionRange };
+}
+
+/**
+ * Heuristic: does this string look like a bare semver range rather than a skill name?
+ * Used to detect the legacy `tank install @org/skill ^1.0.0` positional form so we can
+ * preserve back-compat with the previous CLI signature.
+ *
+ * Returns true for strings like `^1.0.0`, `~1`, `>=2`, `1.x`, `*`, `latest`, `next`, `1.2.3`.
+ * Returns false for skill names (contain `/`, start with `@`, or are URLs).
+ */
+export function looksLikeVersionRange(s: string): boolean {
+  if (!s || s.includes('/') || s.startsWith('@') || isUrl(s)) return false;
+  if (s === '*' || s === 'latest' || s === 'next') return true;
+  if (/^[\^~><=]/.test(s)) return true;
+  if (/^\d/.test(s)) return true;
+  return false;
+}

--- a/packages/cli/src/lib/telemetry.ts
+++ b/packages/cli/src/lib/telemetry.ts
@@ -4,8 +4,8 @@ import { createInterface } from 'node:readline';
 import { getConfig, setConfig } from '~/lib/config.js';
 import { VERSION } from '~/version.js';
 
-const POSTHOG_PROJECT_KEY = process.env.TANK_POSTHOG_KEY ?? '';
-const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
+const POSTHOG_PROJECT_KEY = process.env.TANK_POSTHOG_KEY ?? 'phc_j9KjoTTYWsM4k40f2h61x8TRe8cx4ZhIMIKIVri0G7Z';
+const POSTHOG_DEFAULT_HOST = 'https://eu.i.posthog.com';
 
 interface TelemetryStatus {
   enabled: boolean;

--- a/packages/cli/src/lib/telemetry.ts
+++ b/packages/cli/src/lib/telemetry.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from 'node:crypto';
+import { createInterface } from 'node:readline';
+
+import { getConfig, setConfig } from '~/lib/config.js';
+import { VERSION } from '~/version.js';
+
+const POSTHOG_PROJECT_KEY = process.env.TANK_POSTHOG_KEY ?? '';
+const POSTHOG_DEFAULT_HOST = 'https://us.i.posthog.com';
+
+interface TelemetryStatus {
+  enabled: boolean;
+  reason: 'env-off' | 'env-on' | 'config' | 'default-off' | 'onprem' | 'no-key';
+}
+
+function getHost(): string {
+  return process.env.TANK_TELEMETRY_HOST ?? POSTHOG_DEFAULT_HOST;
+}
+
+function isSelfhosted(): boolean {
+  return process.env.TANK_MODE === 'selfhosted';
+}
+
+export function getTelemetryStatus(configDir?: string): TelemetryStatus {
+  if (isSelfhosted()) return { enabled: false, reason: 'onprem' };
+  if (!POSTHOG_PROJECT_KEY) return { enabled: false, reason: 'no-key' };
+
+  const env = process.env.TANK_TELEMETRY?.trim();
+  if (env === '0' || env === 'false' || env === 'off') {
+    return { enabled: false, reason: 'env-off' };
+  }
+  if (env === '1' || env === 'true' || env === 'on') {
+    return { enabled: true, reason: 'env-on' };
+  }
+
+  const cfg = getConfig(configDir);
+  if (cfg.telemetry === true) return { enabled: true, reason: 'config' };
+  return { enabled: false, reason: 'default-off' };
+}
+
+function getOrCreateDistinctId(configDir?: string): string {
+  const cfg = getConfig(configDir);
+  if (cfg.telemetryDistinctId) return cfg.telemetryDistinctId;
+  const id = randomUUID();
+  setConfig({ telemetryDistinctId: id }, configDir);
+  return id;
+}
+
+export function setTelemetry(enabled: boolean, configDir?: string): void {
+  setConfig({ telemetry: enabled }, configDir);
+}
+
+export interface TelemetryEvent {
+  event: string;
+  properties?: Record<string, unknown>;
+}
+
+export function captureEvent(evt: TelemetryEvent, configDir?: string): void {
+  const status = getTelemetryStatus(configDir);
+  if (!status.enabled) return;
+
+  const distinctId = getOrCreateDistinctId(configDir);
+  const payload = {
+    api_key: POSTHOG_PROJECT_KEY,
+    event: evt.event,
+    distinct_id: distinctId,
+    properties: {
+      ...evt.properties,
+      cli_version: VERSION,
+      platform: process.platform,
+      node_version: process.versions.node,
+      $lib: 'tank-cli'
+    },
+    timestamp: new Date().toISOString()
+  };
+
+  const url = `${getHost()}/i/v0/e/`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2000);
+
+  fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: controller.signal
+  })
+    .catch(() => {})
+    .finally(() => clearTimeout(timer));
+}
+
+export function describeTelemetryState(configDir?: string): string {
+  const status = getTelemetryStatus(configDir);
+  if (status.reason === 'onprem') return 'Telemetry: disabled (on-prem mode)';
+  if (status.reason === 'no-key') return 'Telemetry: disabled (no key compiled in this build)';
+  if (status.reason === 'env-off') return 'Telemetry: disabled (overridden by TANK_TELEMETRY env var)';
+  if (status.reason === 'env-on') return 'Telemetry: enabled (overridden by TANK_TELEMETRY env var)';
+  if (status.reason === 'config') return 'Telemetry: enabled';
+  return 'Telemetry: disabled. Run `tank telemetry on` to opt in.';
+}
+
+/**
+ * Prompt the user once for telemetry consent on first interactive use.
+ * Skipped if: a decision is already recorded, no TTY (CI), on-prem, no key compiled.
+ * The decision (true or false) is persisted to config so we never prompt again.
+ */
+export async function maybePromptForTelemetryConsent(configDir?: string): Promise<void> {
+  if (isSelfhosted()) return;
+  if (!POSTHOG_PROJECT_KEY) return;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+  if (process.env.CI || process.env.TANK_TELEMETRY) return;
+
+  const cfg = getConfig(configDir);
+  if (typeof cfg.telemetry === 'boolean') return;
+
+  const answer = await askYesNo(
+    'Help improve Tank by sending anonymous usage analytics? (No package names, paths, or keys are ever sent.)'
+  );
+  setConfig({ telemetry: answer }, configDir);
+  if (answer) {
+    captureEvent({ event: 'cli_opted_in', properties: { source: 'first-run-prompt' } }, configDir);
+    process.stderr.write('Telemetry: enabled. Disable any time with `tank telemetry off`.\n');
+  } else {
+    process.stderr.write('Telemetry: disabled. Re-enable any time with `tank telemetry on`.\n');
+  }
+}
+
+function askYesNo(question: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    rl.question(`${question} [y/N] `, (raw) => {
+      rl.close();
+      const a = raw.trim().toLowerCase();
+      resolve(a === 'y' || a === 'yes');
+    });
+  });
+}

--- a/packages/internals-helpers/src/permissions/path.ts
+++ b/packages/internals-helpers/src/permissions/path.ts
@@ -1,5 +1,3 @@
-import { realpath } from 'node:fs/promises';
-
 export function isPathAllowed(requestedPath: string, allowedPaths: string[]): boolean {
   const norm = (p: string) => p.replaceAll('\\', '/');
   const req = norm(requestedPath);
@@ -19,6 +17,7 @@ export function isPathAllowed(requestedPath: string, allowedPaths: string[]): bo
 
 async function resolveRealpathSafely(path: string): Promise<string> {
   try {
+    const { realpath } = await import('node:fs/promises');
     return await realpath(path);
   } catch {
     return path;
@@ -30,6 +29,7 @@ export async function isPathAllowedWithRealpath(requestedPath: string, allowedPa
 
   let resolvedRequested: string;
   try {
+    const { realpath } = await import('node:fs/promises');
     resolvedRequested = await realpath(requestedPath);
   } catch {
     // Path does not exist yet (ENOENT). Non-existent paths cannot be symlink


### PR DESCRIPTION
Closes #462

End-to-end overhaul of the discovery → install funnel, driven by PostHog analytics showing **73% of homepage visitors never reach docs** and **41% of traffic lands directly on `/skills`**.

## What's in

**Homepage**
- Hero gets 4 scannable differentiator pills (Scanning · Vault · Permissions · Integrity) + proper Button CTAs + social-proof stats row
- Sticky section nav slides in after the hero (fixed positioning, iOS-Safari hardened)
- Section reorder so Vault and Atoms appear in the first 5 sections (was buried at 8-10)
- New "Built with Tank" section featuring [prompt2bot](https://prompt2bot.com) + [Skills-IL](https://agentskills.co.il)
- New "Recently published" feed (top 6 verified skills)
- New community section (GitHub stars, releases, discussions, contribute)

**Skills list**
- Dismissible value-prop banner (localStorage + cookie persisted, no SSR flash)
- "Getting Started" 3-step CLI flow in the desktop sidebar
- `tank install -g <name>` snippet on every card with copy button
- Empty-state recovery with `tank search` suggestion + browse + publish links

**Skill detail**
- Install command now visible on desktop (was mobile-only)
- "Trust summary" card above tabs with at-a-glance scan verdict
- "View details →" button switches to the security tab
- 404 page shows pg_trgm fuzzy-matched suggestions

**Docs**
- Bottom CTA on every doc page: copyable install + Browse Packages
- Command palette adds a "Learn" group

**CLI**
- `tank install` now accepts multiple targets (`tank install -g @org/a @org/b@^1.0.0`)
- npm-style `name@version` spec
- Back-compat shim preserves legacy `tank install X ^1.0.0` positional form
- Failed install with "not found" prints "Did you mean:" fuzzy suggestions
- `tank telemetry on|off|status` subcommand
- First-run consent prompt on `tank init` / `tank login` (TTY only, decision persisted)
- `tank doctor` reports telemetry state
- Strictly opt-in; respects `TANK_TELEMETRY` env and `TANK_MODE=selfhosted`

**Infrastructure**
- OG images now PNG (was SVG — most social platforms don't render SVG)
- Lazy-load `node:fs/promises` in `@internals/helpers` so it's browser-safe

## Test coverage

- 4 IDD modules
- 4 Gherkin spec files (homepage, skills, skill-detail, cross-cutting)
- 27 unit tests on `parseInstallTarget` + `looksLikeVersionRange`
- 13/13 CLI telemetry E2E tests pass
- Browser BDD wiring validated (test runner discovers + generates specs; full execution needs Supabase/S3 storage)

## Manual QA

Completed full manual QA pass against real registry + Postgres + CLI binary:
- ✅ Homepage hero, sections, sticky nav (desktop + mobile), built-with, recently published, community, ⌘K
- ✅ Skills list banner (dismiss persists), getting-started sidebar, card snippets, empty state
- ✅ Skill detail (desktop install, trust card, default tab, View details), 404 fuzzy match
- ✅ Docs bottom CTA, OG image PNG
- ✅ CLI variadic install, back-compat shim, telemetry on/off/status, doctor, first-run prompt

## Files

61 files changed, 2879 insertions(+), 107 deletions(-)

## Risks

- `internals-helpers/permissions/path.ts` changed `import { realpath }` to lazy `await import('node:fs/promises')` — verified all 4 call sites still work; the function is async so the awaited import has no perf impact.
- OG image PNG generation adds `@resvg/resvg-js` dep (4 packages, ~50KB).
- Telemetry has zero events sent in this build because `TANK_POSTHOG_KEY` is not compiled in. Once a release build injects it, opt-in users will start sending events.