### PR TITLE
chore(docs): regenerate CLI docs to satisfy drift check

### DIFF
--- a/apps/registry/public/docs/cli.md
+++ b/apps/registry/public/docs/cli.md
@@ -1,9 +1,9 @@
 ---
 title: CLI Reference
-description: Complete reference for all 22 Tank CLI commands — install, publish, search, audit, and manage AI agent skills with security-first design.
+description: Complete reference for all 23 Tank CLI commands — install, publish, search, audit, and manage AI agent skills with security-first design.
 ---
 
-The Tank CLI provides 22 commands for publishing, installing, and managing AI agent skills with security-first design.
+The Tank CLI provides 23 commands for publishing, installing, and managing AI agent skills with security-first design.
 
 ## Installation
 
@@ -106,7 +106,7 @@ tank publish
 
 ## tank install
 
-Install one or more skills from the Tank registry, URLs, or all skills from lockfile.
+Install one or more skills from the Tank registry, URLs, or all skills from lockfile
 
 **Aliases:** `i`
 
@@ -114,82 +114,19 @@ Install one or more skills from the Tank registry, URLs, or all skills from lock
 tank install [targets...]
 ```
 
-### Examples
-
-```bash
-# Install a single skill
-tank install @org/skill
-
-# Install with a version range (npm-style spec)
-tank install @org/skill@^1.0.0
-
-# Install multiple skills in one command
-tank install -g @org/a @org/b@^1.0.0 https://github.com/owner/repo
-
-# Install all skills from tank.lock
-tank install
-```
-
-If one target fails, others still attempt to install. The exit code is non-zero
-if any failed. When a name isn't found, the CLI prints "Did you mean:" with
-fuzzy-matched suggestions.
-
 ### Arguments
 
 | Name | Description | Required |
 |------|-------------|----------|
-| `targets` | One or more skill specs (`@org/skill`, `@org/skill@^1.0.0`) or URLs. Omit to install from lockfile. | No |
+| `targets...` | One or more skill specs or URLs (e.g. @org/skill, @org/skill@^1.0.0, https://github.com/owner/repo). Omit to install from lockfile. | No |
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
-| `-g, --global` | Install skill(s) globally (available to all projects) |
+| `-g, --global` | Install skill globally (available to all projects) |
 | `-y, --yes` | Auto-accept flagged scan verdicts |
 | `--dangerously-no-tank-proxy` | Skip wrapping MCP servers with the tank proxy (no scanning, no enforcement) |
-
-### Back-compat: legacy positional form
-
-The previous syntax `tank install @org/skill ^1.0.0` (positional version range)
-is still supported via a back-compat shim. The shim detects this form and
-rewrites it as `@org/skill@^1.0.0` internally.
-
-
-## tank telemetry
-
-Manage anonymous, opt-in usage telemetry.
-
-Telemetry is **disabled by default** and **never silently enabled**. The CLI
-asks once on first `tank init` or `tank login` (interactive only — never in
-CI). Decisions are persisted to `~/.tank/config.json` and never re-prompted.
-
-```bash
-tank telemetry <action>
-```
-
-### Examples
-
-```bash
-tank telemetry on       # opt in
-tank telemetry off      # opt out
-tank telemetry status   # show current state and reason
-```
-
-### Behavior
-
-- **Strictly opt-in.** No telemetry is sent until you run `tank telemetry on`
-  or accept the first-run prompt.
-- **No sensitive data.** Events contain command names, CLI version, OS
-  platform, and a random per-install UUID. Package names, file paths, repo
-  URLs, and API keys are never sent.
-- **Fire-and-forget.** Telemetry never blocks a command. Network failures are
-  swallowed silently with a 2-second timeout.
-- **Disabled on-prem.** `TANK_MODE=selfhosted` hard-disables telemetry.
-- **Env override.** `TANK_TELEMETRY=0` forces off; `TANK_TELEMETRY=1` forces
-  on — even if config says otherwise.
-
-To see what gets sent in production, run `tank doctor` — the diagnostics
-report includes the current telemetry state and reason.
 
 
 ## tank remove
@@ -429,6 +366,15 @@ tank upgrade [version]
 | `--force` | Reinstall even if already on the target version |
 
 
+## tank telemetry <action>
+
+Manage anonymous usage telemetry (on | off | status). Opt-in only, never enabled by default.
+
+```bash
+tank telemetry <action>
+```
+
+
 ## Quick Reference
 
 | Command | Alias(es) | Description |
@@ -439,7 +385,7 @@ tank upgrade [version]
 | `tank whoami` | — | Show the currently logged-in user |
 | `tank logout` | — | Remove authentication token from config |
 | `tank publish` | `pub` | Pack and publish a skill to the Tank registry |
-| `tank install` | `i` | Install a skill from the Tank registry, a URL, or all skills from lockfile |
+| `tank install` | `i` | Install one or more skills from the Tank registry, URLs, or all skills from lockfile |
 | `tank remove` | `rm`, `r`, `uninstall` | Remove an installed skill |
 | `tank update` | `up` | Update skills to latest versions within their ranges |
 | `tank verify` | — | Verify installed skills match the lockfile |
@@ -455,6 +401,7 @@ tank upgrade [version]
 | `tank doctor` | — | Diagnose agent integration health |
 | `tank migrate` | — | Migrate skills.json → tank.json and skills.lock → tank.lock |
 | `tank upgrade` | — | Update tank to the latest version |
+| `tank telemetry <action>` | — | Manage anonymous usage telemetry (on | off | status). Opt-in only, never enabled by default. |
 
 ---
 


### PR DESCRIPTION
Re-runs `scripts/gen-cli-docs.mjs` after #463 added `tank install` variadic targets and `tank telemetry`. Auto-generated reference now reflects the actual command signatures. Richer prose lives in CHANGELOG.md and `--help` output.