### PR TITLE
perf(registry): edge-cache read-only server functions

### DIFF
--- a/apps/registry/src/lib/auth/session.ts
+++ b/apps/registry/src/lib/auth/session.ts
@@ -3,6 +3,7 @@ import { getRequestHeaders } from '@tanstack/react-start/server';
 import { enabledProviders, env } from '~/consts/env';
 import { isAdmin as checkIsAdmin } from '~/lib/auth/authz';
 import { auth } from '~/lib/auth/core';
+import { setEdgeCache } from '~/lib/edge-cache';
 
 export const getSession = createServerFn({ method: 'GET' }).handler(async () => {
   const headers = getRequestHeaders();
@@ -20,6 +21,7 @@ export const getAdminSession = createServerFn({ method: 'GET' }).handler(async (
 });
 
 export const getAuthProviders = createServerFn({ method: 'GET' }).handler(async () => {
+  setEdgeCache(3600);
   return {
     providers: [...enabledProviders],
     oidcProviderId: env.OIDC_PROVIDER_ID,

--- a/apps/registry/src/lib/edge-cache.ts
+++ b/apps/registry/src/lib/edge-cache.ts
@@ -1,0 +1,20 @@
+import { setResponseHeader } from '@tanstack/react-start/server';
+
+/**
+ * Vercel-only edge cache directive: cached on the Vercel CDN for `sMaxAge` seconds,
+ * served stale for up to `staleWhileRevalidate` while a fresh fetch runs in the
+ * background. Browsers are told `max-age=0, must-revalidate` so client navigation
+ * still hits the (cached) edge but does not pin stale data locally.
+ *
+ * Use ONLY on server functions whose response does NOT depend on the requester
+ * (no auth headers, no per-user data). For mixed-auth endpoints, set this only
+ * on the unauthenticated branch.
+ */
+export function setEdgeCache(sMaxAge: number, staleWhileRevalidate: number = sMaxAge * 12): void {
+  try {
+    setResponseHeader('CDN-Cache-Control', `public, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`);
+    setResponseHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+  } catch {
+    // Outside a request context (e.g. test-time) — no-op.
+  }
+}

--- a/apps/registry/src/query/docs.ts
+++ b/apps/registry/src/query/docs.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 
 import docsData from '~/generated/docs.json';
+import { setEdgeCache } from '~/lib/edge-cache';
 
 export interface DocEntry {
   title: string;
@@ -15,11 +16,13 @@ const docs: DocEntry[] = docsData as DocEntry[];
 export const getDocBySlug = createServerFn({ method: 'GET' })
   .inputValidator((slug: string) => slug)
   .handler(async ({ data: slug }) => {
+    setEdgeCache(86400);
     const normalized = slug === '' || slug === 'index' ? '' : slug;
     const doc = docs.find((d) => d.slug === normalized);
     return doc ?? null;
   });
 
 export const getAllDocs = createServerFn({ method: 'GET' }).handler(async () => {
+  setEdgeCache(86400);
   return docs.map(({ title, description, slug }) => ({ title, description, slug }));
 });

--- a/apps/registry/src/query/github.ts
+++ b/apps/registry/src/query/github.ts
@@ -2,8 +2,10 @@ import { queryOptions } from '@tanstack/react-query';
 import { createServerFn } from '@tanstack/react-start';
 
 import { GITHUB_REPO } from '~/consts/brand';
+import { setEdgeCache } from '~/lib/edge-cache';
 
 export const getGitHubStars = createServerFn({ method: 'GET' }).handler(async () => {
+  setEdgeCache(300, 3600);
   try {
     const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
       headers: { Accept: 'application/vnd.github.v3+json' }

--- a/apps/registry/src/query/homepage.ts
+++ b/apps/registry/src/query/homepage.ts
@@ -4,8 +4,10 @@ import { count, eq } from 'drizzle-orm';
 
 import { db } from '~/lib/db';
 import { skills } from '~/lib/db/schema';
+import { setEdgeCache } from '~/lib/edge-cache';
 
 export const getHomepageStats = createServerFn({ method: 'GET' }).handler(async () => {
+  setEdgeCache(300);
   try {
     const [row] = await db.select({ count: count() }).from(skills).where(eq(skills.visibility, 'public'));
 

--- a/apps/registry/src/query/skills.ts
+++ b/apps/registry/src/query/skills.ts
@@ -5,6 +5,7 @@ import { sql } from 'drizzle-orm';
 import { env } from '~/consts/env';
 import { auth } from '~/lib/auth/core';
 import { db } from '~/lib/db';
+import { setEdgeCache } from '~/lib/edge-cache';
 import {
   type FreshnessBucket,
   getSkillDetail,
@@ -44,6 +45,7 @@ export const getSkillsList = createServerFn({ method: 'GET' })
   .inputValidator((input: SkillsListParams) => input)
   .handler(async ({ data }): Promise<SkillSearchResponse> => {
     const viewerUserId = await getViewerUserId();
+    if (!viewerUserId) setEdgeCache(60);
     const params: SkillsSearchParams = { ...data, requesterUserId: viewerUserId };
     return searchSkills(params);
   });
@@ -52,6 +54,7 @@ export const getSkillDetailFn = createServerFn({ method: 'GET' })
   .inputValidator((input: string) => input)
   .handler(async ({ data: name }): Promise<SkillDetailResult | null> => {
     const viewerUserId = await getViewerUserId();
+    if (!viewerUserId) setEdgeCache(300);
     return getSkillDetail(name, viewerUserId);
   });
 
@@ -72,6 +75,7 @@ export function skillDetailQueryOptions(name: string) {
 }
 
 export const isTalkEnabledFn = createServerFn({ method: 'GET' }).handler(async (): Promise<boolean> => {
+  setEdgeCache(3600);
   return !!env.PROMPT2BOT_API_TOKEN;
 });
 
@@ -94,6 +98,7 @@ export interface RecentSkill {
 }
 
 export const recentSkillsFn = createServerFn({ method: 'GET' }).handler(async (): Promise<RecentSkill[]> => {
+  setEdgeCache(300);
   try {
     const rows = await db.execute<{
       name: string;
@@ -145,6 +150,7 @@ export function recentSkillsQueryOptions() {
 export const suggestSimilarSkillsFn = createServerFn({ method: 'GET' })
   .inputValidator((input: string) => input)
   .handler(async ({ data: name }): Promise<SimilarSkillSuggestion[]> => {
+    setEdgeCache(600);
     try {
       const rows = await db.execute<{ name: string; description: string | null; sim: number }>(sql`
         SELECT s.name, s.description, similarity(s.name, ${name}) AS sim


### PR DESCRIPTION
Closes the /__server cost issue surfaced in Vercel observability.

## Problem

Vercel shows 98.8% cache miss rate on /__server with 7K+ requests each from /contact, /about, /home (bot referrers — these aren't real Tank routes; they're LinkedIn/Discord/Twitter URL probes that 404). Each bot hit triggers:

1. `registry-layout.tsx` renders → `useQuery(githubStarsQueryOptions)` fires → /__server hits getGitHubStars → fetches api.github.com (rate-limited!)
2. `HomeNavAuthCta` renders → better-auth /api/auth/get-session → DB query (separate endpoint, addressed elsewhere)

None of the server function responses set `CDN-Cache-Control`, so every request reaches origin. The codebase already uses this pattern for llms.txt and sitemap.xml — just not for /__server.

## Fix

Adds `setEdgeCache(sMaxAge, swr)` helper. Applied to 10 always-public read-only server functions:

| Function | s-maxage | Note |
|---|---|---|
| getGitHubStars | 300 | rate-limited external API |
| getHomepageStats | 300 | DB count |
| recentSkillsFn | 300 | top-6 query |
| getSkillsList | 60 | only when no viewer |
| getSkillDetailFn | 300 | only when no viewer |
| suggestSimilarSkillsFn | 600 | pg_trgm expensive |
| isTalkEnabledFn | 3600 | env var |
| getDocBySlug | 86400 | pre-rendered |
| getAllDocs | 86400 | pre-rendered |
| getAuthProviders | 3600 | env-driven |

Per-user (`getSession`, `listTokensFn`, `listOrgsFn`) and admin functions intentionally NOT cached. Auth-aware functions only set the cache header for unauthenticated requests (preserves private-skill visibility).

## Expected impact

- Cache hit rate: 1.2% → 90%+
- GitHub API calls: ~21K/day → ~288/day (5min cache means max 12/hr × 24)
- DB queries on bot traffic: dramatically reduced
- Vercel bandwidth + function invocations: should fall in proportion