### PR TITLE
perf(registry): defer auth check to client on /skills

### DIFF
--- a/apps/registry/src/routes/skills/index.tsx
+++ b/apps/registry/src/routes/skills/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { routeHead } from '~/consts/seo';
-import { getSession } from '~/lib/auth/session';
+import { useSession } from '~/lib/auth/client';
 import { skillsSearchSchema } from '~/lib/skills/schemas';
 import { skillsListQueryOptions } from '~/query/skills';
 import { SkillsListScreen } from '~/screens/skills-list-screen';
@@ -17,17 +17,18 @@ export const Route = createFileRoute('/skills/')({
   validateSearch: zodValidator(skillsSearchSchema),
   loaderDeps: ({ search }) => search,
   loader: async ({ context, deps }) => {
-    const session = await getSession();
     const data = await context.queryClient.ensureQueryData(skillsListQueryOptions({ ...deps, limit: 20 }));
-    return { data, isLoggedIn: !!session?.user };
+    return { data };
   },
   head: () => headData,
   component: SkillsPage
 });
 
 function SkillsPage() {
-  const { data, isLoggedIn } = Route.useLoaderData();
+  const { data } = Route.useLoaderData();
   const search = Route.useSearch();
+  const { data: session } = useSession();
+  const isLoggedIn = !!session?.user;
 
   return (
     <SkillsListScreen


### PR DESCRIPTION
Follow-up to #468. The /skills loader was calling getSession() which blocks CDN-Cache-Control via better-auth's 'private' cache directive. Switching to client-side useSession() since isLoggedIn is only used for UI affordances. Now /skills should HIT the CDN cache the same way / and /docs/overview already do.