### PR TITLE
fix(deploy): remove drizzle-kit push from Vercel build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "buildCommand": "cd apps/registry && (bunx drizzle-kit push --force || echo 'drizzle-kit push failed (likely schema prompt in CI), skipping') && cd ../.. && NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
+  "buildCommand": "NITRO_PRESET=vercel bun turbo build --filter=registry... && cp -r apps/registry/.vercel/output .vercel/output",
   "installCommand": "bun install",
   "devCommand": "bun --filter registry run dev"
 }


### PR DESCRIPTION
Stops Vercel builds from hanging on 'Pulling schema from database...' when the DB connection times out. Drizzle pushes belong in db-migrate.yml (already exists), not every Vercel deploy.