### PR TITLE
fix(registry): purge Cloudflare cache on skill mutations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,13 @@ SUPABASE_SERVICE_ROLE_KEY=<your-supabase-service-role-key>
 # ── KV Store (Redis — required for Vercel, optional for Docker/local) ──
 # REDIS_URL=redis://localhost:6379
 
+# ── Edge Cache (Cloudflare) ──
+# Required in cloud production to purge stale skill detail pages on publish.
+# Create token at https://dash.cloudflare.com/profile/api-tokens with
+# permission: Zone → Cache Purge → Purge. Without both vars, purges no-op.
+# CLOUDFLARE_API_TOKEN=
+# CLOUDFLARE_ZONE_ID=
+
 # ── Public (browser-side, baked at build time) ──
 # VITE_PUBLIC_APP_URL=http://localhost:5555
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 End-to-end overhaul of the discovery → install funnel, driven by analytics showing 73% of homepage visitors never reach docs and 41% of traffic lands directly on `/skills`.
 
 **Homepage**
+
 - Hero now shows 4 scannable differentiator pills (Scanning · Vault · Permissions · Integrity) linking to their respective sections
 - Hero CTAs upgraded from tiny muted links to proper `<Button>` elements (Browse Packages, View Docs)
 - Hero stats row: package count · GitHub stars · MIT license (auto-hides on empty registries)
@@ -24,22 +25,26 @@ End-to-end overhaul of the discovery → install funnel, driven by analytics sho
 - "Stay in the loop" community section linking to GitHub stars, releases, discussions, contributing
 
 **Skills list**
+
 - Dismissible value-proposition banner explaining the 6-stage security pipeline (localStorage persisted)
 - "Getting Started" CLI flow card in the desktop filter sidebar
 - Every skill card now shows a copyable `tank install -g <name>` snippet
 - Empty-state recovery: "No results for 'foo'" now includes copyable `tank search foo`, browse-all link, and publish guide link
 
 **Skill detail**
+
 - Install command (`tank install -g <name>`) now visible on desktop (was mobile-only)
 - "Trust summary" card above the tabs shows scan verdict at a glance
 - "View details →" button on the trust card jumps to the security tab
 - 404 page shows fuzzy-matched suggestions (`pg_trgm` similarity > 0.2) when a skill name doesn't exist
 
 **Docs**
+
 - Bottom CTA on every doc page: copyable install command + "Browse Packages" button
 - Command palette adds a "Learn" group with "What is Tank?" / "How does scanning work?" / "How does the Vault work?"
 
 **CLI**
+
 - `tank install` now accepts multiple targets in one invocation (`tank install -g @org/a @org/b@^1.0.0 https://x.com/c.tgz`)
 - npm-style `name@version` spec syntax
 - Back-compat shim preserves legacy `tank install @org/skill ^1.0.0` positional form
@@ -51,6 +56,7 @@ End-to-end overhaul of the discovery → install funnel, driven by analytics sho
 - All telemetry strictly opt-in; respects `TANK_TELEMETRY` env var and `TANK_MODE=selfhosted`
 
 **Infrastructure**
+
 - OG images now serve as PNG (was SVG — many social platforms don't render SVG previews)
 - Lazy-loaded `node:fs/promises` import in `@internals/helpers` so the package can be safely imported in browser bundles
 

--- a/apps/registry/public/docs/api.md
+++ b/apps/registry/public/docs/api.md
@@ -36,11 +36,11 @@ All Tank API keys begin with `tank_`. Tokens without this prefix are rejected wi
 
 **Scopes**
 
-| Scope | Grants |
-|---|---|
-| `skills:read` | Read skill metadata, versions, files, stars |
-| `skills:publish` | Publish new skills and new versions |
-| `skills:admin` | Administrative actions (moderation, user management) |
+| Scope            | Grants                                               |
+| ---------------- | ---------------------------------------------------- |
+| `skills:read`    | Read skill metadata, versions, files, stars          |
+| `skills:publish` | Publish new skills and new versions                  |
+| `skills:admin`   | Administrative actions (moderation, user management) |
 
 <Callout type="info">
   Tokens inherit the minimum scope needed. A token with only `skills:read` cannot publish; you will receive a `403` if you try.
@@ -52,11 +52,11 @@ All Tank API keys begin with `tank_`. Tokens without this prefix are rejected wi
 
 Rate limits are applied per IP for anonymous requests and per token for authenticated requests.
 
-| Tier | Requests / hour |
-|---|---|
-| Anonymous | 100 |
-| Authenticated | 1,000 |
-| Pro | 10,000 |
+| Tier          | Requests / hour |
+| ------------- | --------------- |
+| Anonymous     | 100             |
+| Authenticated | 1,000           |
+| Pro           | 10,000          |
 
 When you exceed your limit, the API returns `429 Too Many Requests`. The response includes a `Retry-After` header indicating how many seconds to wait before retrying.
 
@@ -75,14 +75,14 @@ All errors follow a consistent envelope. The `error` field contains a machine-re
 
 **Common HTTP status codes**
 
-| Status | Error Code | When it occurs |
-|---|---|---|
-| `401` | `UNAUTHORIZED` | Token missing, malformed, or revoked |
-| `403` | `FORBIDDEN` | Token valid but lacks the required scope |
-| `404` | `NOT_FOUND` | Skill, version, or resource does not exist |
-| `409` | `VERSION_EXISTS` | You attempted to publish an already-existing version |
-| `422` | `VALIDATION_ERROR` | Request body failed Zod schema validation |
-| `429` | `RATE_LIMITED` | Hourly request limit exceeded |
+| Status | Error Code         | When it occurs                                       |
+| ------ | ------------------ | ---------------------------------------------------- |
+| `401`  | `UNAUTHORIZED`     | Token missing, malformed, or revoked                 |
+| `403`  | `FORBIDDEN`        | Token valid but lacks the required scope             |
+| `404`  | `NOT_FOUND`        | Skill, version, or resource does not exist           |
+| `409`  | `VERSION_EXISTS`   | You attempted to publish an already-existing version |
+| `422`  | `VALIDATION_ERROR` | Request body failed Zod schema validation            |
+| `429`  | `RATE_LIMITED`     | Hourly request limit exceeded                        |
 
 **Validation error shape**
 
@@ -113,11 +113,11 @@ Full-text search across all public skills. Uses a hybrid strategy: `ILIKE` for e
 
 **Query parameters**
 
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `q` | string | — | Search query. Matched against skill name, description, and author. |
-| `page` | number | `1` | Page number. Minimum `1`. |
-| `limit` | number | `20` | Results per page. Range `1`–`50`. |
+| Parameter | Type   | Default | Description                                                        |
+| --------- | ------ | ------- | ------------------------------------------------------------------ |
+| `q`       | string | —       | Search query. Matched against skill name, description, and author. |
+| `page`    | number | `1`     | Page number. Minimum `1`.                                          |
+| `limit`   | number | `20`    | Results per page. Range `1`–`50`.                                  |
 
 **Response**
 
@@ -178,16 +178,16 @@ Initiates skill publication. The response includes a pre-signed `uploadUrl`; you
 }
 ```
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `manifest.name` | string | Yes | Scoped or unscoped skill name. Scoped names (`@org/name`) require org membership. |
-| `manifest.version` | string | Yes | Semver string. Must not already exist for this skill. |
-| `manifest.description` | string | Yes | Short description shown in search results. |
-| `manifest.visibility` | `"public"` \| `"private"` | Yes | Public skills are visible to everyone. Private skills require auth. |
-| `manifest.permissions` | object | Yes | Declared permission budget. Validated against Zod schema. |
-| `manifest.repository` | string | No | Source repository URL for provenance display. |
-| `readme` | string | No | Markdown content for the skill's registry page. |
-| `files` | string[] | No | List of file paths included in the tarball. |
+| Field                  | Type                      | Required | Description                                                                       |
+| ---------------------- | ------------------------- | -------- | --------------------------------------------------------------------------------- |
+| `manifest.name`        | string                    | Yes      | Scoped or unscoped skill name. Scoped names (`@org/name`) require org membership. |
+| `manifest.version`     | string                    | Yes      | Semver string. Must not already exist for this skill.                             |
+| `manifest.description` | string                    | Yes      | Short description shown in search results.                                        |
+| `manifest.visibility`  | `"public"` \| `"private"` | Yes      | Public skills are visible to everyone. Private skills require auth.               |
+| `manifest.permissions` | object                    | Yes      | Declared permission budget. Validated against Zod schema.                         |
+| `manifest.repository`  | string                    | No       | Source repository URL for provenance display.                                     |
+| `readme`               | string                    | No       | Markdown content for the skill's registry page.                                   |
+| `files`                | string[]                  | No       | List of file paths included in the tarball.                                       |
 
 **Validation rules**
 
@@ -234,9 +234,9 @@ Returns top-level metadata for a skill plus its latest published version.
 
 **Path parameters**
 
-| Parameter | Description |
-|---|---|
-| `name` | Skill name, URL-encoded. Scoped names use `@org%2Fskill` or `@org/skill` (both accepted). |
+| Parameter | Description                                                                               |
+| --------- | ----------------------------------------------------------------------------------------- |
+| `name`    | Skill name, URL-encoded. Scoped names use `@org%2Fskill` or `@org/skill` (both accepted). |
 
 **Response `200 OK`**
 
@@ -307,9 +307,9 @@ Returns full metadata for a specific published version, including its permission
 
 **Path parameters**
 
-| Parameter | Description |
-|---|---|
-| `name` | Skill name. |
+| Parameter | Description                         |
+| --------- | ----------------------------------- |
+| `name`    | Skill name.                         |
 | `version` | Exact semver string (e.g. `2.3.1`). |
 
 **Response `200 OK`**
@@ -349,11 +349,11 @@ Returns the raw content of a specific file within a skill version's tarball. Use
 
 **Path parameters**
 
-| Parameter | Description |
-|---|---|
-| `name` | Skill name. |
-| `version` | Exact semver string. |
-| `path` | File path within the tarball (e.g. `SKILL.md`, `src/index.ts`). |
+| Parameter | Description                                                     |
+| --------- | --------------------------------------------------------------- |
+| `name`    | Skill name.                                                     |
+| `version` | Exact semver string.                                            |
+| `path`    | File path within the tarball (e.g. `SKILL.md`, `src/index.ts`). |
 
 **Response**
 
@@ -383,11 +383,11 @@ After uploading the tarball to the `uploadUrl` returned by `POST /api/v1/skills`
 }
 ```
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `skillId` | string | Yes | `skillId` from the publish initiation response. |
-| `versionId` | string | Yes | `versionId` from the publish initiation response. |
-| `integrity` | string | Yes | SHA-512 hash of the tarball in the format `sha512-<base64>`. |
+| Field       | Type   | Required | Description                                                  |
+| ----------- | ------ | -------- | ------------------------------------------------------------ |
+| `skillId`   | string | Yes      | `skillId` from the publish initiation response.              |
+| `versionId` | string | Yes      | `versionId` from the publish initiation response.            |
+| `integrity` | string | Yes      | SHA-512 hash of the tarball in the format `sha512-<base64>`. |
 
 **Response `200 OK`**
 
@@ -538,23 +538,23 @@ curl -X POST https://tankpkg.dev/api/v1/scan \
 
 **Verdict rules**
 
-| Verdict | Condition |
-|---|---|
-| `PASS` | Zero findings, or only informational notes. |
-| `PASS_WITH_NOTES` | Low-severity findings only. |
-| `FLAGGED` | 1–3 high-severity findings. |
-| `FAIL` | Any critical finding, or 4+ high-severity findings. |
+| Verdict           | Condition                                           |
+| ----------------- | --------------------------------------------------- |
+| `PASS`            | Zero findings, or only informational notes.         |
+| `PASS_WITH_NOTES` | Low-severity findings only.                         |
+| `FLAGGED`         | 1–3 high-severity findings.                         |
+| `FAIL`            | Any critical finding, or 4+ high-severity findings. |
 
 **Pipeline stages**
 
-| Stage | Name | What it checks |
-|---|---|---|
-| `stage0` | Ingest | Tarball structure, SHA-512 hashing, extraction safety (no symlinks, no path traversal, no absolute paths) |
-| `stage1` | Structure | Required files (`SKILL.md`, manifest), file count (under 100), total size (under 50 MB) |
-| `stage2` | Static | AST analysis — eval, exec, obfuscated code, suspicious imports |
-| `stage3` | Injection | Prompt injection patterns in Markdown and skill definition files |
-| `stage4` | Secrets | Hardcoded credentials, API keys, tokens using entropy analysis |
-| `stage5` | Supply chain | Dependency tree analysis, known-malicious package hashes |
+| Stage    | Name         | What it checks                                                                                            |
+| -------- | ------------ | --------------------------------------------------------------------------------------------------------- |
+| `stage0` | Ingest       | Tarball structure, SHA-512 hashing, extraction safety (no symlinks, no path traversal, no absolute paths) |
+| `stage1` | Structure    | Required files (`SKILL.md`, manifest), file count (under 100), total size (under 50 MB)                   |
+| `stage2` | Static       | AST analysis — eval, exec, obfuscated code, suspicious imports                                            |
+| `stage3` | Injection    | Prompt injection patterns in Markdown and skill definition files                                          |
+| `stage4` | Secrets      | Hardcoded credentials, API keys, tokens using entropy analysis                                            |
+| `stage5` | Supply chain | Dependency tree analysis, known-malicious package hashes                                                  |
 
 <Callout type="info">
   Each stage is independent. A failure in one stage does not prevent subsequent stages from running. All findings are aggregated into the final verdict.
@@ -606,9 +606,9 @@ This URL is opened in the user's browser (not called directly by the CLI). The u
 
 **Query parameters**
 
-| Parameter | Description |
-|---|---|
-| `token` | The `pollToken` from the start response. |
+| Parameter | Description                              |
+| --------- | ---------------------------------------- |
+| `token`   | The `pollToken` from the start response. |
 
 After the user approves, the browser is redirected back to the CLI callback and the poll token transitions to an authorized state. The CLI can now exchange it.
 
@@ -672,21 +672,21 @@ Returns an SVG badge displaying a skill's current audit score. Designed to embed
 
 **Path parameters**
 
-| Parameter | Description |
-|---|---|
-| `name` | Skill name, URL-encoded (e.g. `@vercel%2Fnext-skill`). |
+| Parameter | Description                                            |
+| --------- | ------------------------------------------------------ |
+| `name`    | Skill name, URL-encoded (e.g. `@vercel%2Fnext-skill`). |
 
 **Response**
 
 Returns `image/svg+xml` content. The badge color encodes the score tier:
 
-| Score | Color | Meaning |
-|---|---|---|
-| 9–10 | Green | Excellent |
-| 7–8 | Yellow-green | Good |
-| 5–6 | Yellow | Fair |
-| 3–4 | Orange | Poor |
-| 0–2 | Red | Failing |
+| Score | Color        | Meaning   |
+| ----- | ------------ | --------- |
+| 9–10  | Green        | Excellent |
+| 7–8   | Yellow-green | Good      |
+| 5–6   | Yellow       | Fair      |
+| 3–4   | Orange       | Poor      |
+| 0–2   | Red          | Failing   |
 
 **Usage in Markdown**
 

--- a/apps/registry/src/api/routes/admin/packages.ts
+++ b/apps/registry/src/api/routes/admin/packages.ts
@@ -1,6 +1,7 @@
 import { and, count, desc, eq, ilike, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 
+import { purgeSkillCache } from '~/lib/cache-purge';
 import { db } from '~/lib/db';
 import { user } from '~/lib/db/auth-schema';
 import { auditEvents, skills, skillVersions } from '~/lib/db/schema';
@@ -133,6 +134,8 @@ export const packagesRoutes = new Hono()
       metadata: { name, updates: body }
     });
 
+    purgeSkillCache(name).catch(() => {});
+
     return c.json({ success: true });
   })
 
@@ -157,6 +160,8 @@ export const packagesRoutes = new Hono()
       metadata: { name }
     });
 
+    purgeSkillCache(name).catch(() => {});
+
     return c.json({ success: true });
   })
 
@@ -173,6 +178,7 @@ export const packagesRoutes = new Hono()
 
     try {
       const result = await runRescan(skill.id, adminUser.id);
+      purgeSkillCache(name).catch(() => {});
       return c.json(result);
     } catch (err) {
       return c.json({ error: (err as Error).message }, 502);

--- a/apps/registry/src/api/routes/og.ts
+++ b/apps/registry/src/api/routes/og.ts
@@ -1,4 +1,4 @@
-import { Resvg, initWasm } from '@resvg/resvg-wasm';
+import { initWasm, Resvg } from '@resvg/resvg-wasm';
 import { Hono } from 'hono';
 import type { ReactNode } from 'react';
 import satori from 'satori';

--- a/apps/registry/src/api/routes/v1/skills-confirm.ts
+++ b/apps/registry/src/api/routes/v1/skills-confirm.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi';
 import { eq } from 'drizzle-orm';
 import { env } from '~/consts/env';
 import { verifyCliAuth } from '~/lib/auth/authz';
+import { purgeSkillCache } from '~/lib/cache-purge';
 import { db } from '~/lib/db';
 import { scanFindings, scanResults, skills, skillVersions } from '~/lib/db/schema';
 import { depAuditService } from '~/lib/dep-audit/service';
@@ -283,6 +284,10 @@ export const skillsConfirmRoutes = new OpenAPIHono().openapi(confirmRoute, async
   }
 
   depAuditService.runAudit(versionId, manifest).catch(() => {});
+
+  if (skill?.name) {
+    purgeSkillCache(skill.name).catch(() => {});
+  }
 
   return c.json(
     {

--- a/apps/registry/src/consts/env.ts
+++ b/apps/registry/src/consts/env.ts
@@ -64,6 +64,12 @@ export const zEnv = z.object({
   // ── KV Store (Redis) ──
   REDIS_URL: zOptStr,
 
+  // ── Edge Cache (Cloudflare) ──
+  // API token needs `Zone:Cache Purge` permission on the zone.
+  // Without both, purges are no-ops (acceptable in dev / self-hosted).
+  CLOUDFLARE_API_TOKEN: zOptStr,
+  CLOUDFLARE_ZONE_ID: zOptStr,
+
   // ── Admin ──
   FIRST_ADMIN_EMAIL: zOptStr,
   FIRST_ADMIN_PASSWORD: zOptStr

--- a/apps/registry/src/lib/__tests__/cache-purge.test.ts
+++ b/apps/registry/src/lib/__tests__/cache-purge.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('~/consts/env', () => ({
+  env: {
+    APP_URL: 'https://www.tankpkg.dev',
+    CLOUDFLARE_API_TOKEN: '',
+    CLOUDFLARE_ZONE_ID: ''
+  }
+}));
+
+import { env } from '~/consts/env';
+import { purgeSkillCache } from '../cache-purge';
+
+const mockedEnv = env as { APP_URL: string; CLOUDFLARE_API_TOKEN: string; CLOUDFLARE_ZONE_ID: string };
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function setCloudflareEnv(token: string, zone: string): void {
+  mockedEnv.CLOUDFLARE_API_TOKEN = token;
+  mockedEnv.CLOUDFLARE_ZONE_ID = zone;
+}
+
+describe('purgeSkillCache', () => {
+  beforeEach(() => {
+    mockedEnv.APP_URL = 'https://www.tankpkg.dev';
+    setCloudflareEnv('', '');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    vi.restoreAllMocks();
+  });
+
+  it('no-ops when CLOUDFLARE_API_TOKEN is unset', async () => {
+    setCloudflareEnv('', 'zone-123');
+    const fetchFn = vi.fn(async () => new Response('{}'));
+    globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+    await purgeSkillCache('@tank/google-search-ads');
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when CLOUDFLARE_ZONE_ID is unset', async () => {
+    setCloudflareEnv('token-abc', '');
+    const fetchFn = vi.fn(async () => new Response('{}'));
+    globalThis.fetch = fetchFn as unknown as typeof fetch;
+
+    await purgeSkillCache('@tank/google-search-ads');
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('calls Cloudflare API v4 purge_cache with the canonical skill URL', async () => {
+    setCloudflareEnv('token-abc', 'zone-123');
+    let capturedUrl = '';
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      capturedUrl = url.toString();
+      capturedInit = init;
+      return new Response(JSON.stringify({ success: true }));
+    }) as unknown as typeof fetch;
+
+    await purgeSkillCache('@tank/google-search-ads');
+
+    expect(capturedUrl).toBe('https://api.cloudflare.com/client/v4/zones/zone-123/purge_cache');
+    expect(capturedInit?.method).toBe('POST');
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer token-abc');
+    expect(headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(capturedInit?.body as string) as { files: string[] };
+    expect(body.files).toEqual(['https://www.tankpkg.dev/skills/@tank/google-search-ads']);
+  });
+
+  it('strips trailing slash from APP_URL when building URLs', async () => {
+    setCloudflareEnv('token-abc', 'zone-123');
+    mockedEnv.APP_URL = 'https://www.tankpkg.dev/';
+    let captured: string[] = [];
+    globalThis.fetch = vi.fn(async (_url, init?: RequestInit) => {
+      captured = (JSON.parse(init?.body as string) as { files: string[] }).files;
+      return new Response(JSON.stringify({ success: true }));
+    }) as unknown as typeof fetch;
+
+    await purgeSkillCache('foo');
+
+    expect(captured).toEqual(['https://www.tankpkg.dev/skills/foo']);
+  });
+
+  it('logs and swallows when Cloudflare returns a non-2xx status', async () => {
+    setCloudflareEnv('token-abc', 'zone-123');
+    globalThis.fetch = vi.fn(async () => new Response('{}', { status: 403 })) as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(purgeSkillCache('foo')).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('[cache-purge] cloudflare HTTP 403'));
+  });
+
+  it('logs and swallows when fetch itself rejects', async () => {
+    setCloudflareEnv('token-abc', 'zone-123');
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(purgeSkillCache('foo')).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[cache-purge] cloudflare request failed'),
+      expect.any(Error)
+    );
+  });
+
+  it('logs and swallows when Cloudflare body has success:false', async () => {
+    setCloudflareEnv('token-abc', 'zone-123');
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ success: false, errors: [{ code: 1, message: 'bad' }] }))
+    ) as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(purgeSkillCache('foo')).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('[cache-purge] cloudflare rejected'));
+  });
+});

--- a/apps/registry/src/lib/cache-purge.ts
+++ b/apps/registry/src/lib/cache-purge.ts
@@ -1,0 +1,44 @@
+import { encodeSkillName } from '@internals/helpers';
+import { env } from '~/consts/env';
+
+const CLOUDFLARE_PURGE_TIMEOUT_MS = 5000;
+
+interface CloudflarePurgeResponse {
+  success: boolean;
+  errors?: Array<{ code: number; message: string }>;
+}
+
+/**
+ * Best-effort edge cache invalidation for a skill's public detail page.
+ * Never throws. No-ops when Cloudflare env vars are unset.
+ */
+export async function purgeSkillCache(name: string): Promise<void> {
+  if (!env.CLOUDFLARE_API_TOKEN || !env.CLOUDFLARE_ZONE_ID) return;
+
+  const base = env.APP_URL.replace(/\/$/, '');
+  const url = `${base}/skills/${encodeSkillName(name)}`;
+
+  try {
+    const res = await fetch(`https://api.cloudflare.com/client/v4/zones/${env.CLOUDFLARE_ZONE_ID}/purge_cache`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ files: [url] }),
+      signal: AbortSignal.timeout(CLOUDFLARE_PURGE_TIMEOUT_MS)
+    });
+
+    if (!res.ok) {
+      console.error(`[cache-purge] cloudflare HTTP ${res.status} for ${url}`);
+      return;
+    }
+
+    const body = (await res.json()) as CloudflarePurgeResponse;
+    if (!body.success) {
+      console.error(`[cache-purge] cloudflare rejected: ${JSON.stringify(body.errors ?? [])}`);
+    }
+  } catch (err) {
+    console.error('[cache-purge] cloudflare request failed:', err);
+  }
+}

--- a/apps/registry/src/lib/edge-cache.ts
+++ b/apps/registry/src/lib/edge-cache.ts
@@ -12,7 +12,10 @@ import { setResponseHeader } from '@tanstack/react-start/server';
  */
 export function setEdgeCache(sMaxAge: number, staleWhileRevalidate: number = sMaxAge * 12): void {
   try {
-    setResponseHeader('CDN-Cache-Control', `public, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`);
+    setResponseHeader(
+      'CDN-Cache-Control',
+      `public, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`
+    );
     setResponseHeader('Cache-Control', 'public, max-age=0, must-revalidate');
   } catch {
     // Outside a request context (e.g. test-time) — no-op.

--- a/apps/registry/src/query/skills.ts
+++ b/apps/registry/src/query/skills.ts
@@ -54,7 +54,7 @@ export const getSkillDetailFn = createServerFn({ method: 'GET' })
   .inputValidator((input: string) => input)
   .handler(async ({ data: name }): Promise<SkillDetailResult | null> => {
     const viewerUserId = await getViewerUserId();
-    if (!viewerUserId) setEdgeCache(300);
+    if (!viewerUserId) setEdgeCache(60);
     return getSkillDetail(name, viewerUserId);
   });
 

--- a/bdd/features/browser/tanstack/skill-detail/conversion-detail.feature
+++ b/bdd/features/browser/tanstack/skill-detail/conversion-detail.feature
@@ -11,7 +11,6 @@ Feature: Skill detail conversion improvements
     Given a public skill has been published
 
   # ── Desktop install command ──────────────────────────────────
-
   @conversion
   @install
   Scenario: Install command is visible on desktop
@@ -27,7 +26,6 @@ Feature: Skill detail conversion improvements
     Then the command is copied to clipboard
 
   # ── Default tab ──────────────────────────────────────────────
-
   @conversion
   @tabs
   Scenario: README tab is default for scanned skills
@@ -41,7 +39,6 @@ Feature: Skill detail conversion improvements
     Then the readme tab is active by default
 
   # ── Trust summary card ───────────────────────────────────────
-
   @conversion
   @trust
   Scenario: Trust summary card appears above tabs when scan data exists

--- a/bdd/features/browser/tanstack/skills/conversion-skills.feature
+++ b/bdd/features/browser/tanstack/skills/conversion-skills.feature
@@ -11,7 +11,6 @@ Feature: Skills list conversion improvements
     Given public skills have been published
 
   # ── Value proposition banner ─────────────────────────────────
-
   @conversion
   @banner
   Scenario: Skills page shows a value proposition banner for first visit
@@ -29,7 +28,6 @@ Feature: Skills list conversion improvements
     Then the banner is not shown
 
   # ── Getting started sidebar ──────────────────────────────────
-
   @conversion
   @sidebar
   Scenario: Desktop shows getting-started card in filter sidebar
@@ -44,7 +42,6 @@ Feature: Skills list conversion improvements
     Then the getting-started card is not visible
 
   # ── Skill card install snippets ──────────────────────────────
-
   @conversion
   @cards
   Scenario: Each skill card shows copyable install command

--- a/bdd/features/system/web-registry/conversion-cross-cutting.feature
+++ b/bdd/features/system/web-registry/conversion-cross-cutting.feature
@@ -8,7 +8,6 @@ Feature: Cross-cutting conversion improvements
   So that I can discover Tank's value from anywhere in the product
 
   # ── Docs bottom CTA ─────────────────────────────────────────
-
   @docs
   @cta
   Scenario: Every docs page has a bottom CTA after the article
@@ -23,7 +22,6 @@ Feature: Cross-cutting conversion improvements
     Then the CTA should appear before the document navigation links
 
   # ── Command palette suggestions ──────────────────────────────
-
   @command-menu
   Scenario: Command menu includes educational suggestions
     When I inspect the command menu source
@@ -31,7 +29,6 @@ Feature: Cross-cutting conversion improvements
     And the suggestion should link to the docs overview
 
   # ── Section anchors on homepage ─────────────────────────────
-
   @homepage
   @anchors
   Scenario: Key homepage sections have scroll targets
@@ -42,7 +39,6 @@ Feature: Cross-cutting conversion improvements
     And the HTML should contain an element with id "why-tank"
 
   # ── CLI telemetry opt-in ────────────────────────────────────
-
   @cli
   @telemetry
   Scenario: Telemetry is disabled by default for new installations

--- a/bdd/features/system/web-registry/conversion-homepage.feature
+++ b/bdd/features/system/web-registry/conversion-homepage.feature
@@ -8,7 +8,6 @@ Feature: Homepage conversion improvements
   So that I can decide whether Tank solves my problem
 
   # ── Hero: Differentiator pills ──────────────────────────────
-
   @conversion
   @hero
   Scenario: Hero subtitle is followed by scannable differentiator pills
@@ -35,7 +34,6 @@ Feature: Homepage conversion improvements
     Then one of the differentiator pills should link to "#how-it-works"
 
   # ── Hero: Visible CTAs ──────────────────────────────────────
-
   @conversion
   @hero
   @cta
@@ -51,7 +49,6 @@ Feature: Homepage conversion improvements
     Then the HTML should contain a secondary CTA linking to documentation
 
   # ── Hero: Social proof stats ─────────────────────────────────
-
   @conversion
   @hero
   @stats
@@ -60,7 +57,6 @@ Feature: Homepage conversion improvements
     Then the HTML should contain a hero stats row with package count or GitHub stars
 
   # ── Section ordering ────────────────────────────────────────
-
   @conversion
   @sections
   Scenario: Differentiating sections appear before comparison table
@@ -75,7 +71,6 @@ Feature: Homepage conversion improvements
     Then the "Why Tank Exists" section should appear before the comparison table
 
   # ── Section anchors for pill links ──────────────────────────
-
   @conversion
   @sections
   Scenario: Key sections have id attributes for scroll navigation
@@ -86,7 +81,6 @@ Feature: Homepage conversion improvements
     And the HTML should contain an element with id "why-tank"
 
   # ── Sticky section navigation ───────────────────────────────
-
   @conversion
   @nav
   Scenario: Sticky section nav component is rendered

--- a/bdd/playwright.conversion.config.ts
+++ b/bdd/playwright.conversion.config.ts
@@ -25,7 +25,8 @@ if (fs.existsSync(envPath)) {
 
 const testDir = defineBddConfig({
   features: 'features/browser/tanstack/**/conversion-*.feature',
-  steps: 'steps/browser/{fixtures,conversion-skills,conversion-detail,search-ui,skill-detail,skills-browse-mobile}.steps.ts',
+  steps:
+    'steps/browser/{fixtures,conversion-skills,conversion-detail,search-ui,skill-detail,skills-browse-mobile}.steps.ts',
   importTestFrom: 'steps/browser/fixtures.ts',
   outputDir: '../test-results/bdd-browser-conversion/generated'
 });

--- a/bdd/steps/browser/conversion-detail.steps.ts
+++ b/bdd/steps/browser/conversion-detail.steps.ts
@@ -4,7 +4,7 @@
 import { encodeSkillName } from '@internals/helpers';
 import { expect } from '@playwright/test';
 
-import { Given, Then, When } from './fixtures';
+import { Then, When } from './fixtures';
 
 // ── Desktop install command ──────────────────────────────────────────
 
@@ -66,10 +66,9 @@ Then('there is visible spacing between the trust summary and the tabs', async ({
   const trustBox = await trustCard.boundingBox();
   const readmeTab = page.getByTestId('tab-readme');
   const tabBox = await readmeTab.boundingBox();
-  expect(trustBox).not.toBeNull();
-  expect(tabBox).not.toBeNull();
+  if (!trustBox || !tabBox) throw new Error('expected bounding boxes to exist');
   // At least 16px of vertical gap between bottom of trust card and top of tabs
-  const gap = (tabBox!.y) - (trustBox!.y + trustBox!.height);
+  const gap = tabBox.y - (trustBox.y + trustBox.height);
   expect(gap).toBeGreaterThanOrEqual(16);
 });
 

--- a/bdd/steps/browser/conversion-skills.steps.ts
+++ b/bdd/steps/browser/conversion-skills.steps.ts
@@ -1,10 +1,9 @@
 // Feature: bdd/features/browser/tanstack/skills/conversion-skills.feature
 // Intent: idd/modules/conversion-skills-list/INTENT.md
 
-import { encodeSkillName } from '@internals/helpers';
 import { expect } from '@playwright/test';
 
-import { Given, Then, When } from './fixtures';
+import { Then, When } from './fixtures';
 
 // ── Value proposition banner ──────────────────────────────────────────
 
@@ -20,7 +19,7 @@ When('I revisit the skills page', async ({ page }) => {
   await page.waitForLoadState('networkidle');
 });
 
-Then('I see a banner explaining Tank\'s security value', async ({ page }) => {
+Then("I see a banner explaining Tank's security value", async ({ page }) => {
   const banner = page.getByTestId('value-banner');
   await expect(banner).toBeVisible();
 });

--- a/idd/active/conversion-improvements.md
+++ b/idd/active/conversion-improvements.md
@@ -21,12 +21,12 @@ This initiative addresses 14 specific changes across 4 modules.
 
 ## Modules
 
-| Module | IDD | Items | Test type |
-|--------|-----|-------|-----------|
-| `conversion-homepage` | [INTENT.md](../modules/conversion-homepage/INTENT.md) | 5: section reorder, hero pills, hero CTAs, hero stats, sticky nav | HTML fetch E2E |
-| `conversion-skills-list` | [INTENT.md](../modules/conversion-skills-list/INTENT.md) | 3: value banner, getting-started sidebar, card install snippets | Browser E2E |
-| `conversion-skill-detail` | [INTENT.md](../modules/conversion-skill-detail/INTENT.md) | 2: desktop install command, default security tab | Browser E2E |
-| `conversion-cross-cutting` | [INTENT.md](../modules/conversion-cross-cutting/INTENT.md) | 4: docs CTA, command palette, section IDs, CLI telemetry | HTML fetch + CLI E2E |
+| Module                     | IDD                                                        | Items                                                             | Test type            |
+| -------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------- | -------------------- |
+| `conversion-homepage`      | [INTENT.md](../modules/conversion-homepage/INTENT.md)      | 5: section reorder, hero pills, hero CTAs, hero stats, sticky nav | HTML fetch E2E       |
+| `conversion-skills-list`   | [INTENT.md](../modules/conversion-skills-list/INTENT.md)   | 3: value banner, getting-started sidebar, card install snippets   | Browser E2E          |
+| `conversion-skill-detail`  | [INTENT.md](../modules/conversion-skill-detail/INTENT.md)  | 2: desktop install command, default security tab                  | Browser E2E          |
+| `conversion-cross-cutting` | [INTENT.md](../modules/conversion-cross-cutting/INTENT.md) | 4: docs CTA, command palette, section IDs, CLI telemetry          | HTML fetch + CLI E2E |
 
 ---
 
@@ -43,55 +43,59 @@ Phase 4: REFACTOR (shared InstallSnippet component, verify all tests green)
 
 ## Phase 2: RED — Test Files to Create
 
-| File | Covers | Module |
-|------|--------|--------|
-| `bdd/features/system/web-registry/conversion-homepage.feature` | Hero HTML assertions (data-testids), section order (via HTML structure) | conversion-homepage |
-| `bdd/features/browser/tanstack/skills/conversion-skills.feature` | Value banner visibility/dismiss, getting-started card, skill card install snippets | conversion-skills-list |
-| `bdd/features/browser/tanstack/skill-detail/conversion-detail.feature` | Desktop install command visible, default tab=security when scan data exists, trust card | conversion-skill-detail |
-| `bdd/features/system/web-registry/conversion-cross-cutting.feature` | Docs HTML has CTA, command palette source has suggestions, section IDs present | conversion-cross-cutting (items 11-13) |
-| `e2e/cli/telemetry.e2e.test.ts` | Telemetry opt-in/out, config write, env override, event validation | conversion-cross-cutting (item 14) |
-| `e2e/bdd/steps/conversion.steps.ts` | Shared step definitions for all conversion Gherkin scenarios | all |
+| File                                                                   | Covers                                                                                  | Module                                 |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------- |
+| `bdd/features/system/web-registry/conversion-homepage.feature`         | Hero HTML assertions (data-testids), section order (via HTML structure)                 | conversion-homepage                    |
+| `bdd/features/browser/tanstack/skills/conversion-skills.feature`       | Value banner visibility/dismiss, getting-started card, skill card install snippets      | conversion-skills-list                 |
+| `bdd/features/browser/tanstack/skill-detail/conversion-detail.feature` | Desktop install command visible, default tab=security when scan data exists, trust card | conversion-skill-detail                |
+| `bdd/features/system/web-registry/conversion-cross-cutting.feature`    | Docs HTML has CTA, command palette source has suggestions, section IDs present          | conversion-cross-cutting (items 11-13) |
+| `e2e/cli/telemetry.e2e.test.ts`                                        | Telemetry opt-in/out, config write, env override, event validation                      | conversion-cross-cutting (item 14)     |
+| `e2e/bdd/steps/conversion.steps.ts`                                    | Shared step definitions for all conversion Gherkin scenarios                            | all                                    |
 
 ---
 
 ## Phase 3: GREEN — Code Changes per File
 
 ### Homepage
-| File | Lines | Change |
-|------|-------|--------|
-| `apps/registry/src/screens/home-screen.tsx` | 78-106 | Reorder: WhyTankExists → Vault → HowItWorks → Atoms before ComparisonTable; add StickySectionNav import |
-| `apps/registry/src/components/home/hero-section.tsx` | 56-105 | Add 4-pill row, Button CTAs, stats row |
-| `apps/registry/src/components/home/vault-section.tsx` | 40 | Add `id="vault"` on section |
-| `apps/registry/src/components/home/atoms-section.tsx` | 1 | Add `id="atoms"` on section |
-| `apps/registry/src/components/home/how-it-works.tsx` | 40 | Add `id="how-it-works"` on section |
-| `apps/registry/src/components/home/why-tank-exists.tsx` | 40 | Add `id="why-tank"` on section |
-| `apps/registry/src/components/home/features-grid.tsx` | 1 | Add `id="features"` on section |
-| `apps/registry/src/components/home/faq-section.tsx` | 1 | Add `id="faq"` on section |
-| `apps/registry/src/components/home/sticky-section-nav.tsx` | NEW | Sticky section nav component with IntersectionObserver |
+
+| File                                                       | Lines  | Change                                                                                                  |
+| ---------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------- |
+| `apps/registry/src/screens/home-screen.tsx`                | 78-106 | Reorder: WhyTankExists → Vault → HowItWorks → Atoms before ComparisonTable; add StickySectionNav import |
+| `apps/registry/src/components/home/hero-section.tsx`       | 56-105 | Add 4-pill row, Button CTAs, stats row                                                                  |
+| `apps/registry/src/components/home/vault-section.tsx`      | 40     | Add `id="vault"` on section                                                                             |
+| `apps/registry/src/components/home/atoms-section.tsx`      | 1      | Add `id="atoms"` on section                                                                             |
+| `apps/registry/src/components/home/how-it-works.tsx`       | 40     | Add `id="how-it-works"` on section                                                                      |
+| `apps/registry/src/components/home/why-tank-exists.tsx`    | 40     | Add `id="why-tank"` on section                                                                          |
+| `apps/registry/src/components/home/features-grid.tsx`      | 1      | Add `id="features"` on section                                                                          |
+| `apps/registry/src/components/home/faq-section.tsx`        | 1      | Add `id="faq"` on section                                                                               |
+| `apps/registry/src/components/home/sticky-section-nav.tsx` | NEW    | Sticky section nav component with IntersectionObserver                                                  |
 
 ### Skills List
-| File | Lines | Change |
-|------|-------|--------|
-| `apps/registry/src/screens/skills-list-screen.tsx` | 59-112 | Add ValueBanner import, GettingStarted import, modify SkillCard |
-| `apps/registry/src/components/skills/value-banner.tsx` | NEW | Dismissible banner with localStorage |
-| `apps/registry/src/components/skills/getting-started.tsx` | NEW | 3-step flow card in sidebar |
-| `apps/registry/src/components/skills/install-snippet.tsx` | NEW | Reusable `tank install <name>` with copy |
+
+| File                                                      | Lines  | Change                                                          |
+| --------------------------------------------------------- | ------ | --------------------------------------------------------------- |
+| `apps/registry/src/screens/skills-list-screen.tsx`        | 59-112 | Add ValueBanner import, GettingStarted import, modify SkillCard |
+| `apps/registry/src/components/skills/value-banner.tsx`    | NEW    | Dismissible banner with localStorage                            |
+| `apps/registry/src/components/skills/getting-started.tsx` | NEW    | 3-step flow card in sidebar                                     |
+| `apps/registry/src/components/skills/install-snippet.tsx` | NEW    | Reusable `tank install <name>` with copy                        |
 
 ### Skill Detail
-| File | Lines | Change |
-|------|-------|--------|
+
+| File                                                | Lines  | Change                                                                                             |
+| --------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------- |
 | `apps/registry/src/screens/skill-detail-screen.tsx` | 61-259 | Remove `lg:hidden` from install area; add desktop install in header; default tab logic; trust card |
 
 ### Cross-Cutting
-| File | Lines | Change |
-|------|-------|--------|
-| `apps/registry/src/routes/docs/$.tsx` | 99 | Add `<DocsBottomCta />` after `</article>` |
-| `apps/registry/src/components/docs-bottom-cta.tsx` | NEW | Install command + Browse Packages link |
-| `apps/registry/src/components/command-menu.tsx` | TBD | Add "What is Tank?" and "How does scanning work?" suggestions |
-| `packages/cli/src/telemetry.ts` | NEW | Telemetry module: opt-in, posthog-node, event capture, env override |
-| `packages/cli/src/commands/telemetry.ts` | NEW | `tank telemetry on|off|status` subcommand |
-| `packages/cli/src/bin/tank.ts` | TBD | Wire telemetry init, add `telemetry` subcommand, prompt on first run |
-| `packages/cli/package.json` | TBD | Add `posthog-node` dependency |
+
+| File                                               | Lines | Change                                                               |
+| -------------------------------------------------- | ----- | -------------------------------------------------------------------- | --- | ------------------ |
+| `apps/registry/src/routes/docs/$.tsx`              | 99    | Add `<DocsBottomCta />` after `</article>`                           |
+| `apps/registry/src/components/docs-bottom-cta.tsx` | NEW   | Install command + Browse Packages link                               |
+| `apps/registry/src/components/command-menu.tsx`    | TBD   | Add "What is Tank?" and "How does scanning work?" suggestions        |
+| `packages/cli/src/telemetry.ts`                    | NEW   | Telemetry module: opt-in, posthog-node, event capture, env override  |
+| `packages/cli/src/commands/telemetry.ts`           | NEW   | `tank telemetry on                                                   | off | status` subcommand |
+| `packages/cli/src/bin/tank.ts`                     | TBD   | Wire telemetry init, add `telemetry` subcommand, prompt on first run |
+| `packages/cli/package.json`                        | TBD   | Add `posthog-node` dependency                                        |
 
 ---
 
@@ -106,13 +110,13 @@ Phase 4: REFACTOR (shared InstallSnippet component, verify all tests green)
 
 ## Risks
 
-| Risk | Mitigation |
-|------|-----------|
-| Section reorder breaks mobile layout | Existing sections use `py-20` with `max-w-[1000px]` — independent stacking |
-| Sticky nav intersects with existing nav (`sticky top-0`) | Use `top-14` (header height) for sticky nav |
-| CLI telemetry adds PostHog dependency to binary | `posthog-node` is ~50KB bundled; fire-and-forget with subprocess or queue |
-| Install snippet click triggers card navigation | Use `e.stopPropagation()` + `e.preventDefault()` in copy handler |
-| Default tab change could confuse returning users | Only change default when `hasSecurityData === true` AND no tab preference in URL |
+| Risk                                                     | Mitigation                                                                       |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Section reorder breaks mobile layout                     | Existing sections use `py-20` with `max-w-[1000px]` — independent stacking       |
+| Sticky nav intersects with existing nav (`sticky top-0`) | Use `top-14` (header height) for sticky nav                                      |
+| CLI telemetry adds PostHog dependency to binary          | `posthog-node` is ~50KB bundled; fire-and-forget with subprocess or queue        |
+| Install snippet click triggers card navigation           | Use `e.stopPropagation()` + `e.preventDefault()` in copy handler                 |
+| Default tab change could confuse returning users         | Only change default when `hasSecurityData === true` AND no tab preference in URL |
 
 ---
 

--- a/idd/modules/conversion-cross-cutting/INTENT.md
+++ b/idd/modules/conversion-cross-cutting/INTENT.md
@@ -22,50 +22,53 @@ packages/cli/src/                                          # CLI telemetry (NEW)
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                                   | Rationale                                                                |
-| --- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| C1  | Every docs page must render a bottom CTA after the article content                     | Users who finish reading need a next step                                |
-| C2  | Docs CTA must include a copyable install command AND a link to `/skills`               | Two possible next actions: install CLI or browse packages               |
-| C3  | Docs CTA must appear after `</article>` but before `DocNavigation` (prev/next links)    | Natural reading flow: content → action → navigate                        |
-| C4  | Command palette must include "What is Tank?" suggestion that links to `/docs/overview`  | ⌘K users searching for understanding should find it                      |
-| C5  | Command palette "What is Tank?" must appear early in suggestions (not buried)           | Highest-value suggestion for confused users                              |
-| C6  | CLI telemetry must be strictly opt-in                                                    | Respects user privacy; no silent tracking                                |
-| C7  | CLI telemetry consent prompt fires once on first `tank init` or `tank login`            | Natural touchpoint; never asks twice (persists decision)                 |
-| C8  | CLI telemetry must be configured via `~/.tank/config.json` under `"telemetry"` key       | Persistent, inspectable, user-controllable                              |
-| C9  | CLI telemetry must respect `TANK_TELEMETRY=0`/`=1` env var override                      | Enterprise/debug override                                                |
-| C10 | CLI telemetry uses native `fetch` to PostHog HTTP endpoint (no `posthog-node` dep)       | Smaller binary; no upstream SDK risk                                     |
-| C11 | CLI telemetry events must be stripped of package names, file paths, and API keys         | Privacy: no sensitive data in events                                    |
-| C12 | CLI telemetry must not block or delay any command (2s timeout, abort silent)             | Fire-and-forget; failure must be silent                                  |
-| C13 | Telemetry prompt skips in CI, non-TTY, on-prem, no-key, env-set, prior-decision contexts | Avoid hanging headless runs; respect environment overrides              |
-| C14 | `tank doctor` reports current telemetry state in its diagnostics section                  | Discoverability — users can see what's collected without reading docs   |
-| C15 | A randomized `telemetryDistinctId` (UUIDv4) identifies the install across events          | Aggregate metrics without fingerprinting users                          |
+| #   | Rule                                                                                     | Rationale                                                             |
+| --- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| C1  | Every docs page must render a bottom CTA after the article content                       | Users who finish reading need a next step                             |
+| C2  | Docs CTA must include a copyable install command AND a link to `/skills`                 | Two possible next actions: install CLI or browse packages             |
+| C3  | Docs CTA must appear after `</article>` but before `DocNavigation` (prev/next links)     | Natural reading flow: content → action → navigate                     |
+| C4  | Command palette must include "What is Tank?" suggestion that links to `/docs/overview`   | ⌘K users searching for understanding should find it                   |
+| C5  | Command palette "What is Tank?" must appear early in suggestions (not buried)            | Highest-value suggestion for confused users                           |
+| C6  | CLI telemetry must be strictly opt-in                                                    | Respects user privacy; no silent tracking                             |
+| C7  | CLI telemetry consent prompt fires once on first `tank init` or `tank login`             | Natural touchpoint; never asks twice (persists decision)              |
+| C8  | CLI telemetry must be configured via `~/.tank/config.json` under `"telemetry"` key       | Persistent, inspectable, user-controllable                            |
+| C9  | CLI telemetry must respect `TANK_TELEMETRY=0`/`=1` env var override                      | Enterprise/debug override                                             |
+| C10 | CLI telemetry uses native `fetch` to PostHog HTTP endpoint (no `posthog-node` dep)       | Smaller binary; no upstream SDK risk                                  |
+| C11 | CLI telemetry events must be stripped of package names, file paths, and API keys         | Privacy: no sensitive data in events                                  |
+| C12 | CLI telemetry must not block or delay any command (2s timeout, abort silent)             | Fire-and-forget; failure must be silent                               |
+| C13 | Telemetry prompt skips in CI, non-TTY, on-prem, no-key, env-set, prior-decision contexts | Avoid hanging headless runs; respect environment overrides            |
+| C14 | `tank doctor` reports current telemetry state in its diagnostics section                 | Discoverability — users can see what's collected without reading docs |
+| C15 | A randomized `telemetryDistinctId` (UUIDv4) identifies the install across events         | Aggregate metrics without fingerprinting users                        |
 
 ---
 
 ## Layer 3: Examples
 
 ### Docs CTA
-| #    | Action                                          | Expected behavior                                                                 |
-| ---- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| E1   | Visit `/docs/overview`                          | After article, before prev/next nav: "Ready to try? ..." with copyable `tank install` and "Browse packages" link |
-| E2   | Visit any docs page                             | Same CTA rendered — all docs share the single catch-all route                     |
+
+| #   | Action                 | Expected behavior                                                                                                |
+| --- | ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| E1  | Visit `/docs/overview` | After article, before prev/next nav: "Ready to try? ..." with copyable `tank install` and "Browse packages" link |
+| E2  | Visit any docs page    | Same CTA rendered — all docs share the single catch-all route                                                    |
 
 ### Command Palette
-| #    | Action                                          | Expected behavior                                                                 |
-| ---- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| E3   | Open ⌘K, type "tank"                           | Early suggestion: "What is Tank?" linking to `/docs/overview`                    |
-| E4   | Open ⌘K, type "scan"                           | Suggestion: "How does scanning work?" linking to `/docs/security`                 |
+
+| #   | Action               | Expected behavior                                                 |
+| --- | -------------------- | ----------------------------------------------------------------- |
+| E3  | Open ⌘K, type "tank" | Early suggestion: "What is Tank?" linking to `/docs/overview`     |
+| E4  | Open ⌘K, type "scan" | Suggestion: "How does scanning work?" linking to `/docs/security` |
 
 ### CLI Telemetry
-| #    | Action                                          | Expected behavior                                                                 |
-| ---- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| E5   | First interactive `tank init` (TTY, no decision)| Prompt: "Help improve Tank by sending anonymous usage analytics? [y/N]"          |
-| E6   | User answers "y"                                | `telemetry: true` saved; `cli_opted_in` event sent with `source: first-run-prompt`|
-| E7   | User answers anything else                      | `telemetry: false` saved; no event                                                |
-| E8   | First `tank login` after install (TTY)          | Same prompt fires once; persists decision                                          |
-| E9   | `TANK_TELEMETRY=0 tank install <pkg>`           | No event sent, even if config has `"telemetry": true`                            |
-| E10  | `TANK_MODE=selfhosted` anywhere                 | Telemetry hard-disabled; prompt skipped entirely                                   |
-| E11  | Piped stdin / CI=true / no TTY                  | Prompt skipped (no hang); manual `tank telemetry on` still works                  |
-| E12  | `tank telemetry on/off/status`                  | Manage opt-in directly; emits matching events                                      |
-| E13  | `tank doctor`                                   | Prints "Telemetry" section showing current state and override reason if any       |
-| E14  | Failed install with "not found"                 | After error, CLI prints "Did you mean:" with fuzzy-matched suggestions             |
+
+| #   | Action                                           | Expected behavior                                                                  |
+| --- | ------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| E5  | First interactive `tank init` (TTY, no decision) | Prompt: "Help improve Tank by sending anonymous usage analytics? [y/N]"            |
+| E6  | User answers "y"                                 | `telemetry: true` saved; `cli_opted_in` event sent with `source: first-run-prompt` |
+| E7  | User answers anything else                       | `telemetry: false` saved; no event                                                 |
+| E8  | First `tank login` after install (TTY)           | Same prompt fires once; persists decision                                          |
+| E9  | `TANK_TELEMETRY=0 tank install <pkg>`            | No event sent, even if config has `"telemetry": true`                              |
+| E10 | `TANK_MODE=selfhosted` anywhere                  | Telemetry hard-disabled; prompt skipped entirely                                   |
+| E11 | Piped stdin / CI=true / no TTY                   | Prompt skipped (no hang); manual `tank telemetry on` still works                   |
+| E12 | `tank telemetry on/off/status`                   | Manage opt-in directly; emits matching events                                      |
+| E13 | `tank doctor`                                    | Prints "Telemetry" section showing current state and override reason if any        |
+| E14 | Failed install with "not found"                  | After error, CLI prints "Did you mean:" with fuzzy-matched suggestions             |

--- a/idd/modules/conversion-homepage/INTENT.md
+++ b/idd/modules/conversion-homepage/INTENT.md
@@ -25,33 +25,33 @@ apps/registry/src/components/home/sticky-section-nav.tsx  # NEW
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                              | Rationale                                                                 |
-| --- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| C1  | Sections must be ordered: Hero → WorksWith → WhyTankExists → Vault → HowItWorks → Atoms → ComparisonTable → FeaturesGrid → rest | Vault and Atoms (differentiators) must appear in first 5 sections |
-| C2  | ComparisonTable must appear after differentiators, not before                    | Competitive info serves skeptics, not first-time discoverers             |
-| C3  | Hero must display 4 scannable differentiator pills below subtitle                 | Scanners understand Tank in <1 second without reading paragraph text     |
-| C4  | Differentiator pills must scroll to their section via href fragments              | Pills must be actionable, not decorative                                 |
-| C5  | Hero must have visible Button CTAs for "Browse Packages" and "View Docs"          | Current text links at 13px muted color are invisible                      |
-| C6  | Hero must show social proof stats: `{N} packages · {N} GitHub stars · MIT`        | Reduces bounce for skeptical visitors                                      |
-| C7  | Sticky section nav must appear after scrolling past hero on desktop              | Long pages lose users without navigation                                  |
-| C8  | Sticky nav must scroll horizontally on mobile                                    | Must not break mobile layout                                              |
-| C9  | Sticky nav must highlight the currently visible section                           | Users must know where they are on the page                               |
-| C10 | WhyTankExists must not assume visitors know "skills", "lockfiles", or "semver"    | Existing constraint H6 from homepage UX — must not regress                |
-| C11 | All section components receiving pill anchors must have id attributes             | `#vault`, `#atoms`, `#how-it-works`, `#why-tank`, `#features`, `#faq`   |
+| #   | Rule                                                                                                                            | Rationale                                                             |
+| --- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| C1  | Sections must be ordered: Hero → WorksWith → WhyTankExists → Vault → HowItWorks → Atoms → ComparisonTable → FeaturesGrid → rest | Vault and Atoms (differentiators) must appear in first 5 sections     |
+| C2  | ComparisonTable must appear after differentiators, not before                                                                   | Competitive info serves skeptics, not first-time discoverers          |
+| C3  | Hero must display 4 scannable differentiator pills below subtitle                                                               | Scanners understand Tank in <1 second without reading paragraph text  |
+| C4  | Differentiator pills must scroll to their section via href fragments                                                            | Pills must be actionable, not decorative                              |
+| C5  | Hero must have visible Button CTAs for "Browse Packages" and "View Docs"                                                        | Current text links at 13px muted color are invisible                  |
+| C6  | Hero must show social proof stats: `{N} packages · {N} GitHub stars · MIT`                                                      | Reduces bounce for skeptical visitors                                 |
+| C7  | Sticky section nav must appear after scrolling past hero on desktop                                                             | Long pages lose users without navigation                              |
+| C8  | Sticky nav must scroll horizontally on mobile                                                                                   | Must not break mobile layout                                          |
+| C9  | Sticky nav must highlight the currently visible section                                                                         | Users must know where they are on the page                            |
+| C10 | WhyTankExists must not assume visitors know "skills", "lockfiles", or "semver"                                                  | Existing constraint H6 from homepage UX — must not regress            |
+| C11 | All section components receiving pill anchors must have id attributes                                                           | `#vault`, `#atoms`, `#how-it-works`, `#why-tank`, `#features`, `#faq` |
 
 ---
 
 ## Layer 3: Examples
 
-| #    | Visitor type / action                                       | Expected behavior                                                              |
-| ---- | ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| E1   | First-time visitor loads homepage                          | Sees hero headline, then 4 pills (Scanning, Vault, Permissions, Integrity), then install CTA with "Browse Packages" button |
-| E2   | Visitor clicks "Credential Vault" pill                     | Page scrolls to `#vault` section                                              |
-| E3   | Visitor scrolls past hero                                  | Sticky section nav appears at top of viewport with section links              |
-| E4   | Visitor sees hero subtitle                                 | Can scan 4 pills and understand key differentiators in <5 seconds            |
-| E5   | Visitor wants to browse without reading                   | Has visible "Browse Packages" button at full text size, not hidden tiny link |
-| E6   | Visitor at section 12 (Enterprise) wants to jump to FAQ    | Uses sticky nav to jump to FAQ without scrolling back                        |
-| E7   | Visitor on mobile scrolls past hero                        | Sticky nav appears, scrolls horizontally, highlights active section           |
-| E8   | Homepage HTML fetched (SEO test)                           | Hero contains `data-testid="hero-differentiator-pills"` with 4 children      |
-| E9   | Homepage HTML fetched (SEO test)                           | Hero contains `data-testid="home-primary-cta"` (Browse Packages) and `data-testid="home-secondary-cta"` (View Docs) |
-| E10  | Homepage HTML fetched (SEO test)                           | Hero contains `data-testid="hero-stats"` with package count, star count, and license text |
+| #   | Visitor type / action                                   | Expected behavior                                                                                                          |
+| --- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| E1  | First-time visitor loads homepage                       | Sees hero headline, then 4 pills (Scanning, Vault, Permissions, Integrity), then install CTA with "Browse Packages" button |
+| E2  | Visitor clicks "Credential Vault" pill                  | Page scrolls to `#vault` section                                                                                           |
+| E3  | Visitor scrolls past hero                               | Sticky section nav appears at top of viewport with section links                                                           |
+| E4  | Visitor sees hero subtitle                              | Can scan 4 pills and understand key differentiators in <5 seconds                                                          |
+| E5  | Visitor wants to browse without reading                 | Has visible "Browse Packages" button at full text size, not hidden tiny link                                               |
+| E6  | Visitor at section 12 (Enterprise) wants to jump to FAQ | Uses sticky nav to jump to FAQ without scrolling back                                                                      |
+| E7  | Visitor on mobile scrolls past hero                     | Sticky nav appears, scrolls horizontally, highlights active section                                                        |
+| E8  | Homepage HTML fetched (SEO test)                        | Hero contains `data-testid="hero-differentiator-pills"` with 4 children                                                    |
+| E9  | Homepage HTML fetched (SEO test)                        | Hero contains `data-testid="home-primary-cta"` (Browse Packages) and `data-testid="home-secondary-cta"` (View Docs)        |
+| E10 | Homepage HTML fetched (SEO test)                        | Hero contains `data-testid="hero-stats"` with package count, star count, and license text                                  |

--- a/idd/modules/conversion-skill-detail/INTENT.md
+++ b/idd/modules/conversion-skill-detail/INTENT.md
@@ -21,27 +21,27 @@ apps/registry/src/components/skills/install-snippet.tsx  # Shared install snippe
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                              | Rationale                                                                 |
-| --- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| C1  | Install command with copy button must be visible on both mobile AND desktop       | Desktop users (majority) should not lose the primary conversion action    |
-| C2  | Install snippet must show `tank install <name>` and a copy button                 | Matches existing MobileActionBar pattern                                  |
-| C3  | Desktop install snippet must appear in header area (name/version row)              | High visibility, near package name                                       |
-| C4  | Default tab must be `readme` regardless of scan presence                          | Users came to learn how to use the skill; trust signal delivered via summary card above tabs (see C6) |
-| C5  | Trust summary card "View details →" button must switch to the security tab        | Allows users who want trust details to reach them in one click             |
-| C6  | A trust summary card must appear above the tabs when security data exists         | Delivers at-a-glance trust signal without forcing tab change              |
-| C7  | Trust summary must show: verdict badge, finding counts (critical/high/medium), scan date | Users need at-a-glance trust signal                                     |
-| C8  | Trust summary must have visible spacing (margin) between itself and the tabs       | Avoids visual collision between two stacked content blocks                |
-| C9  | `useClipboard` hook must be used for copy (shared component)                       | Consistent UX                                                            |
+| #   | Rule                                                                                     | Rationale                                                                                             |
+| --- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| C1  | Install command with copy button must be visible on both mobile AND desktop              | Desktop users (majority) should not lose the primary conversion action                                |
+| C2  | Install snippet must show `tank install <name>` and a copy button                        | Matches existing MobileActionBar pattern                                                              |
+| C3  | Desktop install snippet must appear in header area (name/version row)                    | High visibility, near package name                                                                    |
+| C4  | Default tab must be `readme` regardless of scan presence                                 | Users came to learn how to use the skill; trust signal delivered via summary card above tabs (see C6) |
+| C5  | Trust summary card "View details →" button must switch to the security tab               | Allows users who want trust details to reach them in one click                                        |
+| C6  | A trust summary card must appear above the tabs when security data exists                | Delivers at-a-glance trust signal without forcing tab change                                          |
+| C7  | Trust summary must show: verdict badge, finding counts (critical/high/medium), scan date | Users need at-a-glance trust signal                                                                   |
+| C8  | Trust summary must have visible spacing (margin) between itself and the tabs             | Avoids visual collision between two stacked content blocks                                            |
+| C9  | `useClipboard` hook must be used for copy (shared component)                             | Consistent UX                                                                                         |
 
 ---
 
 ## Layer 3: Examples
 
-| #    | Visitor action                                          | Expected behavior                                                                 |
-| ---- | ------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| E1   | Opens skill detail on desktop with scan data           | Sees install command in header area (not hidden), trust summary card with spacing above tabs, README tab active by default |
-| E2   | Opens skill detail on desktop without scan data        | Sees install command in header area, README tab active by default, no trust card  |
-| E3   | Opens skill detail on mobile with scan data            | Sees install command in mobile action bar (existing), trust summary card, README tab active |
-| E4   | Clicks "View details →" in trust summary card         | Security tab becomes active                                                       |
-| E5   | Copies install command from desktop header             | Command copies, button shows check icon                                           |
-| E6   | Switches between tabs                                  | Tab content updates normally                                                       |
+| #   | Visitor action                                  | Expected behavior                                                                                                          |
+| --- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| E1  | Opens skill detail on desktop with scan data    | Sees install command in header area (not hidden), trust summary card with spacing above tabs, README tab active by default |
+| E2  | Opens skill detail on desktop without scan data | Sees install command in header area, README tab active by default, no trust card                                           |
+| E3  | Opens skill detail on mobile with scan data     | Sees install command in mobile action bar (existing), trust summary card, README tab active                                |
+| E4  | Clicks "View details →" in trust summary card   | Security tab becomes active                                                                                                |
+| E5  | Copies install command from desktop header      | Command copies, button shows check icon                                                                                    |
+| E6  | Switches between tabs                           | Tab content updates normally                                                                                               |

--- a/idd/modules/conversion-skills-list/INTENT.md
+++ b/idd/modules/conversion-skills-list/INTENT.md
@@ -2,7 +2,7 @@
 
 ## Anchor
 
-**Why this module exists:** `/skills` gets 41% of all traffic (117 pageviews/30 days) but provides zero context about *why* Tank is different from any other registry. Users browse packages and leave without understanding the platform's value proposition. The skills list page needs to bridge discovery to understanding.
+**Why this module exists:** `/skills` gets 41% of all traffic (117 pageviews/30 days) but provides zero context about _why_ Tank is different from any other registry. Users browse packages and leave without understanding the platform's value proposition. The skills list page needs to bridge discovery to understanding.
 
 **Consumers:** Visitors browsing packages, logged-in users, CLI users transitioning to web.
 
@@ -23,30 +23,30 @@ apps/registry/src/components/skills/install-snippet.tsx      # NEW: shared insta
 
 ## Layer 2: Constraints
 
-| #   | Rule                                                                              | Rationale                                                                 |
-| --- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| C1  | Value-proposition banner must appear below `<h1>` and above search bar            | Users must see it before they start browsing                              |
-| C2  | Banner must link to `/docs/overview`                                               | Bridges discovery users to understanding                                   |
-| C3  | Banner must be dismissible, stored in `localStorage`                               | Returning users don't need to re-read                                     |
+| #   | Rule                                                                                         | Rationale                                                              |
+| --- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| C1  | Value-proposition banner must appear below `<h1>` and above search bar                       | Users must see it before they start browsing                           |
+| C2  | Banner must link to `/docs/overview`                                                         | Bridges discovery users to understanding                               |
+| C3  | Banner must be dismissible, stored in `localStorage`                                         | Returning users don't need to re-read                                  |
 | C4  | Getting-started sidebar card must appear in the filter sidebar on desktop (hidden on mobile) | Desktop filter sidebar has empty space; mobile uses the banner instead |
-| C5  | Getting-started card must show 3-step flow: Install CLI → Search → Install         | CLI workflow is the primary conversion path                               |
-| C6  | CLI install command must be copyable via `useClipboard`                             | Must match existing copy pattern across the site                           |
-| C7  | Each SkillCard must show a copyable `tank install <name>` snippet at the bottom    | Users should see the install path without clicking through to detail      |
-| C8  | Install snippet in card must use `useClipboard` hook                                | Consistent UX across the site                                             |
-| C9  | Install snippet must not interfere with the card's full-overlay `<Link>`           | Clicking the snippet copy button must not trigger card navigation        |
+| C5  | Getting-started card must show 3-step flow: Install CLI → Search → Install                   | CLI workflow is the primary conversion path                            |
+| C6  | CLI install command must be copyable via `useClipboard`                                      | Must match existing copy pattern across the site                       |
+| C7  | Each SkillCard must show a copyable `tank install <name>` snippet at the bottom              | Users should see the install path without clicking through to detail   |
+| C8  | Install snippet in card must use `useClipboard` hook                                         | Consistent UX across the site                                          |
+| C9  | Install snippet must not interfere with the card's full-overlay `<Link>`                     | Clicking the snippet copy button must not trigger card navigation      |
 
 ---
 
 ## Layer 3: Examples
 
-| #    | Visitor action                                          | Expected behavior                                                                 |
-| ---- | ------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| E1   | First visit to `/skills`                                | Sees banner: "Every package scanned through a 6-stage security pipeline. Learn more →" linking to `/docs/overview` |
-| E2   | Dismiss banner                                          | Banner disappears; revisit does not show it (`localStorage` key set)             |
-| E3   | Second visit to `/skills` after dismissing             | Banner does not appear                                                            |
-| E4   | Desktop visitor looks at filter sidebar                | Sees "Getting Started" card with 3 steps: `npm i -g @tankpkg/cli` → `tank search` → `tank install <name>` |
-| E5   | Click copy on CLI install in sidebar                   | Command copied, "Copied!" feedback shown                                          |
-| E6   | Browse skill cards grid                                | Each card shows `tank install <name>` snippet with copy button at bottom          |
-| E7   | Click copy on card install snippet                     | Command copied, button shows check icon briefly; card navigation NOT triggered    |
-| E8   | Mobile visitor                                         | Banner visible; getting-started card hidden (mobile filter area too small)       |
-| E9   | Logged-in visitor (already authenticated)              | Getting-started card adapts: step 1 shows "You're authenticated — skip" or similar |
+| #   | Visitor action                             | Expected behavior                                                                                                  |
+| --- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| E1  | First visit to `/skills`                   | Sees banner: "Every package scanned through a 6-stage security pipeline. Learn more →" linking to `/docs/overview` |
+| E2  | Dismiss banner                             | Banner disappears; revisit does not show it (`localStorage` key set)                                               |
+| E3  | Second visit to `/skills` after dismissing | Banner does not appear                                                                                             |
+| E4  | Desktop visitor looks at filter sidebar    | Sees "Getting Started" card with 3 steps: `npm i -g @tankpkg/cli` → `tank search` → `tank install <name>`          |
+| E5  | Click copy on CLI install in sidebar       | Command copied, "Copied!" feedback shown                                                                           |
+| E6  | Browse skill cards grid                    | Each card shows `tank install <name>` snippet with copy button at bottom                                           |
+| E7  | Click copy on card install snippet         | Command copied, button shows check icon briefly; card navigation NOT triggered                                     |
+| E8  | Mobile visitor                             | Banner visible; getting-started card hidden (mobile filter area too small)                                         |
+| E9  | Logged-in visitor (already authenticated)  | Getting-started card adapts: step 1 shows "You're authenticated — skip" or similar                                 |

--- a/idd/modules/install/INTENT.md
+++ b/idd/modules/install/INTENT.md
@@ -54,8 +54,8 @@ apps/registry/src/api/routes/v1/skills-read.ts  # GET — list versions, fetch m
 | C12 | `tank install` accepts multiple targets in one invocation (`tank install pkg1 pkg2@^1 url`)            | npm/yarn/pnpm-compatible UX; lets users install copy-pasted lists in one shot | Unit test     |
 | C13 | Each target may carry an `@version` suffix using `name@range` (e.g. `@org/skill@^1.0.0`)               | npm-compatible spec syntax                                                    | Unit test     |
 | C14 | One failing target does NOT abort installs of subsequent targets; exit code is non-zero if any failed  | Best-effort install across a list — user sees what succeeded and what didn't  | Unit test     |
-| C15 | Legacy `tank install <name> <semver-range>` (2 positional args) still works as back-compat shim         | Avoid breaking existing scripts; detected when 2nd arg matches a bare semver  | Unit test     |
-| C16 | `-g`/`--global` flag is propagated to every target in multi-install                                     | All-or-nothing scope; never partial-global                                    | Unit test     |
+| C15 | Legacy `tank install <name> <semver-range>` (2 positional args) still works as back-compat shim        | Avoid breaking existing scripts; detected when 2nd arg matches a bare semver  | Unit test     |
+| C16 | `-g`/`--global` flag is propagated to every target in multi-install                                    | All-or-nothing scope; never partial-global                                    | Unit test     |
 
 ---
 
@@ -73,11 +73,11 @@ apps/registry/src/api/routes/v1/skills-read.ts  # GET — list versions, fetch m
 | E8  | `install-skill` with registry URL set to unreachable address | Fails with network/connection error; skill dir NOT created on disk               |
 | E9  | `install-skill({ name: "@org/skill", version: "99.0.0" })`   | Fails with "no version satisfies range" or "version not found" message           |
 | E10 | `installFromLockfile` with a valid `tank.lock`               | Re-downloads and re-verifies all skills; succeeds with count of installed skills |
-| E11 | `tank install @org/a @org/b@^1 https://x.com/c.tgz`          | Installs all three targets; aggregates failures; exits non-zero if any failed     |
-| E12 | `parseInstallTarget("@org/skill@^1.0.0")`                    | `{ kind: 'name', name: '@org/skill', versionRange: '^1.0.0' }`                    |
-| E13 | `parseInstallTarget("https://github.com/owner/repo")`        | `{ kind: 'url', url: 'https://github.com/owner/repo' }`                           |
-| E14 | `tank install @org/skill ^1.0.0` (legacy positional form)    | Shim rewrites to `@org/skill@^1.0.0`; installs as single target                   |
-| E15 | `tank install -g @org/a @org/b@^1`                           | Both targets installed globally; no tank.json modified                            |
-| E16 | `tank install @org/a @org/b` (no semver-shaped 2nd arg)      | Treated as TWO targets, not legacy form (shim does NOT fire)                      |
-| E17 | `looksLikeVersionRange("^1.0.0")` / `("latest")` / `("1.x")` | `true`                                                                            |
-| E18 | `looksLikeVersionRange("@org/skill")` / `("https://x.com")`  | `false`                                                                           |
+| E11 | `tank install @org/a @org/b@^1 https://x.com/c.tgz`          | Installs all three targets; aggregates failures; exits non-zero if any failed    |
+| E12 | `parseInstallTarget("@org/skill@^1.0.0")`                    | `{ kind: 'name', name: '@org/skill', versionRange: '^1.0.0' }`                   |
+| E13 | `parseInstallTarget("https://github.com/owner/repo")`        | `{ kind: 'url', url: 'https://github.com/owner/repo' }`                          |
+| E14 | `tank install @org/skill ^1.0.0` (legacy positional form)    | Shim rewrites to `@org/skill@^1.0.0`; installs as single target                  |
+| E15 | `tank install -g @org/a @org/b@^1`                           | Both targets installed globally; no tank.json modified                           |
+| E16 | `tank install @org/a @org/b` (no semver-shaped 2nd arg)      | Treated as TWO targets, not legacy form (shim does NOT fire)                     |
+| E17 | `looksLikeVersionRange("^1.0.0")` / `("latest")` / `("1.x")` | `true`                                                                           |
+| E18 | `looksLikeVersionRange("@org/skill")` / `("https://x.com")`  | `false`                                                                          |


### PR DESCRIPTION
## Problem

Skill detail pages (e.g. https://www.tankpkg.dev/skills/@tank/google-search-ads) were pinned in Cloudflare's 24h edge cache after publish. Users running `tank install` got the new version immediately (the install path is untouched), but the marketing/discovery page kept showing the old version metadata until the 24h TTL elapsed.

## Fix

Best-effort `POST /client/v4/zones/{id}/purge_cache` on every mutation that affects the public detail page:

- `POST /api/v1/skills/confirm` (publish completion) — after `auditStatus` finalized
- `PATCH /api/admin/packages/:name` (status/visibility/featured changes)
- `DELETE /api/admin/packages/:name` (hard delete)
- `POST /api/admin/packages/:name/rescan` (verdict changes)

Also lowered Vercel `s-maxage` from 300 -> 60 on the skill detail server fn to shrink the SWR window from 1h to 12min as a defense-in-depth for the case where the Cloudflare purge fails.

## Safety

- Fire-and-forget at every call site (`purgeSkillCache(name).catch(() => {})`) — never blocks the response, never throws
- 5s timeout via `AbortSignal.timeout`
- **No-ops without env vars** — safe in dev and self-hosted instances. Cloud needs:
  - `CLOUDFLARE_API_TOKEN` (Zone:Cache Purge permission on the zone)
  - `CLOUDFLARE_ZONE_ID`
- All errors logged with `[cache-purge]` prefix (matches `[prompt2bot]` convention)

## Verification

- `bun run test` — 121/121 passing (7 new cache-purge tests with message-prefix assertions)
- `bunx biome check` — 0 errors on changed files
- Clean-code review pass: collapsed speculative generality, tightened test type-safety leaks, strengthened error assertions

## Operator action required after merge

Set in Vercel (production + preview):
```
CLOUDFLARE_API_TOKEN=<token with Zone:Cache Purge permission>
CLOUDFLARE_ZONE_ID=<zone id for tankpkg.dev>
```

Without these, the code path is inert and the bug persists.

## Out of scope (intentional)

- **Vercel CDN purge** — TanStack Start has no `revalidatePath` equivalent for `CDN-Cache-Control`-controlled responses. Lowered s-maxage to 60s as mitigation. Follow-up if 1-min lag is unacceptable.
- **Tag-based purge** — single-URL purge only. List/search pages self-heal via shorter TTLs.