### PR TITLE
fix(registry): download tarball instead of JSON metadata

### DIFF
--- a/apps/registry/src/components/skills/download-button.tsx
+++ b/apps/registry/src/components/skills/download-button.tsx
@@ -1,4 +1,5 @@
 import { Download } from 'lucide-react';
+import { useState } from 'react';
 
 import { Button } from '~/components/ui/button';
 
@@ -7,15 +8,75 @@ interface DownloadButtonProps {
   version: string;
 }
 
+interface VersionDetailResponse {
+  downloadUrl: string;
+}
+
+function deriveFileName(skillName: string, version: string, urlValue: string): string {
+  try {
+    const url = new URL(urlValue);
+    const last = url.pathname.split('/').filter(Boolean).pop();
+    if (last && /\.(tgz|tar\.gz|tar)$/i.test(last)) return last;
+  } catch {
+    // ignore — fall through to constructed name
+  }
+  const safeName = skillName.replace(/^@/, '').replace(/\//g, '-');
+  return `${safeName}-${version}.tgz`;
+}
+
 export function DownloadButton({ skillName, version }: DownloadButtonProps) {
-  const downloadUrl = `/api/v1/skills/${encodeURIComponent(skillName)}/${encodeURIComponent(version)}`;
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (isLoading) return;
+    setError(null);
+    setIsLoading(true);
+    try {
+      const metadataUrl = `/api/v1/skills/${encodeURIComponent(skillName)}/${encodeURIComponent(version)}`;
+      const res = await fetch(metadataUrl, { headers: { Accept: 'application/json' } });
+      if (!res.ok) throw new Error(`Failed to resolve download URL (${res.status})`);
+      const data = (await res.json()) as VersionDetailResponse;
+      if (!data.downloadUrl) throw new Error('Registry did not return a download URL');
+
+      const tarballRes = await fetch(data.downloadUrl);
+      if (!tarballRes.ok) throw new Error(`Tarball fetch failed (${tarballRes.status})`);
+      const blob = await tarballRes.blob();
+      const fileName = deriveFileName(skillName, version, data.downloadUrl);
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = objectUrl;
+      anchor.download = fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Download failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
-    <Button variant="outline" size="sm" className="gap-1.5" asChild>
-      <a href={downloadUrl} target="_blank" rel="noopener noreferrer">
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        onClick={handleClick}
+        disabled={isLoading}
+        aria-busy={isLoading}
+      >
         <Download className="size-3.5" />
-        <span className="text-xs">Download</span>
-      </a>
-    </Button>
+        <span className="text-xs">{isLoading ? 'Downloading…' : 'Download'}</span>
+      </Button>
+      {error ? (
+        <p role="alert" className="text-xs font-medium text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

Clicking **Download** on a skill detail page (e.g. https://www.tankpkg.dev/skills/@tank/frontend-craft) downloaded a JSON file instead of the package tarball.

The button linked directly to `/api/v1/skills/{name}/{version}`, but that endpoint returns JSON metadata (consumed by CLI, MCP server, and the web UI for audit info). The browser correctly saved the JSON response.

## Fix

Client-side only — the API stays unchanged because CLI/MCP depend on its current shape.

The button now:
1. Fetches the metadata JSON.
2. Reads `downloadUrl` (signed storage URL).
3. Fetches the tarball as a blob.
4. Triggers a real download via a synthetic `<a download>` with a sensible filename (e.g. `tank-frontend-craft-1.2.3.tgz`).
5. Shows "Downloading…" state and inline error reporting on failure.

## Verification

- Typecheck clean for the changed file.
- Both call sites (`skill-detail-screen.tsx`, `skill-sidebar.tsx`) unchanged — same props.