### PR TITLE
docs(scanner): add safe package URL examples

### DIFF
--- a/apps/registry/src/lib/scan/__tests__/url-expander.test.ts
+++ b/apps/registry/src/lib/scan/__tests__/url-expander.test.ts
@@ -213,6 +213,10 @@ describe('detectURLType', () => {
     expect(detectURLType('https://example.com/package.tar.gz')).toBe('tarball');
   });
 
+  it('detects scoped npm registry metadata URLs as tarballs', () => {
+    expect(detectURLType('https://registry.npmjs.org/@xquik%2ftweetclaw')).toBe('tarball');
+  });
+
   it('detects clawhub.ai skill URLs', () => {
     expect(detectURLType('https://clawhub.ai/pskoett/self-improving-agent')).toBe('clawhub');
     expect(detectURLType('https://www.clawhub.ai/pskoett/self-improving-agent')).toBe('clawhub');

--- a/docs/reference/packages/scanner-reference.md
+++ b/docs/reference/packages/scanner-reference.md
@@ -25,6 +25,20 @@ Endpoint map:
 - `POST /api/analyze/permissions → permission extraction path`
 - `POST /api/analyze/rescan → rescan an existing package`
 
+## Safe URL Examples
+
+Scanner requests should use fetchable source or registry URLs instead of
+browser-only package pages. Common accepted shapes:
+
+- scoped npm registry metadata:
+  `https://registry.npmjs.org/@xquik%2ftweetclaw`
+- GitHub skill or plugin folders:
+  `https://github.com/Xquik-dev/tweetclaw/tree/master/skills/tweetclaw`
+- ClawHub package pages:
+  `https://clawhub.ai/plugins/@xquik/tweetclaw`
+
+Use percent-encoding for the slash in scoped npm package names.
+
 ## Stages
 
 Stage map:

--- a/docs/scanner-reference.md
+++ b/docs/scanner-reference.md
@@ -25,6 +25,20 @@ Endpoint map:
 - `POST /api/analyze/permissions → permission extraction path`
 - `POST /api/analyze/rescan → rescan an existing package`
 
+## Safe URL Examples
+
+Scanner requests should use fetchable source or registry URLs instead of
+browser-only package pages. Common accepted shapes:
+
+- scoped npm registry metadata:
+  `https://registry.npmjs.org/@xquik%2ftweetclaw`
+- GitHub skill or plugin folders:
+  `https://github.com/Xquik-dev/tweetclaw/tree/master/skills/tweetclaw`
+- ClawHub package pages:
+  `https://clawhub.ai/plugins/@xquik/tweetclaw`
+
+Use percent-encoding for the slash in scoped npm package names.
+
 ## Stages
 
 Stage map:


### PR DESCRIPTION
## What does this PR do?

Adds scanner-reference examples for fetchable package sources that Tank already accepts: scoped npm registry metadata, GitHub skill folders, and ClawHub package pages. It also adds a regression test that keeps scoped npm registry metadata URLs classified as tarball inputs.

## Related Issues

None.

## How to Test

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --filter registry test src/lib/scan/__tests__/url-expander.test.ts`
- `bunx biome check apps/registry/src/lib/scan/__tests__/url-expander.test.ts docs/scanner-reference.md docs/reference/packages/scanner-reference.md`
- `bunx prettier --check docs/scanner-reference.md docs/reference/packages/scanner-reference.md`
- `npx --yes markdown-link-check docs/scanner-reference.md docs/reference/packages/scanner-reference.md --quiet`

## Checklist

- [x] Tests pass
- [x] Docs updated
- [x] Focused formatting and link checks passed
