### PR TITLE
fix(registry): recycle stale postgres connections

### DIFF
--- a/apps/registry/src/lib/db/index.ts
+++ b/apps/registry/src/lib/db/index.ts
@@ -3,6 +3,14 @@ import postgres from 'postgres';
 
 import * as schema from './schema';
 
+const POSTGRES_OPTIONS = {
+  max: 1,
+  prepare: false,
+  connect_timeout: 5,
+  idle_timeout: 20,
+  max_lifetime: 60 * 30
+} as const;
+
 let _sql: ReturnType<typeof postgres> | null = null;
 let _db: ReturnType<typeof drizzle<typeof schema>> | null = null;
 
@@ -13,12 +21,13 @@ function ensureInitialized() {
   // DATABASE_URL must use the Supabase pooler in transaction mode (port 6543).
   // `prepare: false` is required — PgBouncer transaction mode does not support
   // prepared statements (postgres-js uses them by default).
-  _sql = postgres(url, { max: 1, prepare: false });
+  _sql = postgres(url, POSTGRES_OPTIONS);
   _db = drizzle(_sql, { schema });
 }
 
 export function reinitializeDb(url: string) {
   process.env.DATABASE_URL = url;
+  void _sql?.end({ timeout: 1 }).catch(() => undefined);
   _sql = null;
   _db = null;
 }

--- a/apps/registry/src/services/kv/postgres.ts
+++ b/apps/registry/src/services/kv/postgres.ts
@@ -3,7 +3,13 @@ import postgres from 'postgres';
 import type { KVStore } from './store';
 
 export function createPostgresStore(connectionString: string): KVStore {
-  const sql = postgres(connectionString, { max: 1 });
+  const sql = postgres(connectionString, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 5,
+    idle_timeout: 20,
+    max_lifetime: 60 * 30
+  });
   let initialized = false;
 
   async function ensureTable() {


### PR DESCRIPTION
## Summary
- recycle Postgres sockets before Vercel can reuse stale idle connections
- add connect timeout / idle timeout / max lifetime to registry DB client
- apply the same serverless-safe options to the Postgres KV store

## Verification
- NITRO_PRESET=vercel bun turbo build --filter=registry...