### PR TITLE
fix(cli): promote upgrade binary install fix

### DIFF
--- a/apps/registry/src/api/routes/cli.ts
+++ b/apps/registry/src/api/routes/cli.ts
@@ -12,7 +12,7 @@ const PLATFORMS: Record<string, string> = {
   'linux-arm64': 'tank-linux-arm64',
   'darwin-x64': 'tank-darwin-x64',
   'darwin-arm64': 'tank-darwin-arm64',
-  'win-x64': 'tank-win-x64.exe'
+  'win-x64': 'tank-windows-x64.exe'
 };
 
 /**

--- a/packages/cli/src/__tests__/upgrade.test.ts
+++ b/packages/cli/src/__tests__/upgrade.test.ts
@@ -220,6 +220,49 @@ describe('upgradeCommand', () => {
     }
   });
 
+  it('does not copy over the running POSIX binary', async () => {
+    if (process.platform === 'win32') return;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-upgrade-etxtbsy-'));
+    const copySpy = vi.spyOn(fs, 'copyFileSync').mockImplementation(() => {
+      const error = new Error('ETXTBSY: text file is busy') as NodeJS.ErrnoException;
+      error.code = 'ETXTBSY';
+      throw error;
+    });
+
+    try {
+      const fakeBinPath = path.join(tmpDir, 'tank');
+      fs.writeFileSync(fakeBinPath, 'old-binary');
+      process.argv[1] = fakeBinPath;
+
+      const mockFetch = vi.fn();
+      globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+      const fakeBinary = new Uint8Array([0xca, 0xfe, 0xba, 0xbe]);
+      const actualHash = crypto.createHash('sha256').update(fakeBinary).digest('hex');
+      const platform = process.platform === 'darwin' ? 'darwin' : 'linux';
+      const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+      const binaryName = `tank-${platform}-${arch}`;
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ tag_name: 'v99.0.0' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      );
+      mockFetch.mockResolvedValueOnce(new Response(fakeBinary, { status: 200 }));
+      mockFetch.mockResolvedValueOnce(new Response(`${actualHash}  ${binaryName}\n`, { status: 200 }));
+
+      await upgradeCommand();
+
+      expect(copySpy).not.toHaveBeenCalled();
+      expect(Buffer.from(fakeBinary).equals(fs.readFileSync(fakeBinPath))).toBe(true);
+    } finally {
+      copySpy.mockRestore();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('force flag bypasses version check', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-upgrade-force-'));
     try {

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -30,6 +30,16 @@ function resolveCurrentBinary(): string {
   }
 }
 
+function replaceBinary(tmpBin: string, currentBinaryPath: string): void {
+  if (process.platform !== 'win32') {
+    fs.renameSync(tmpBin, currentBinaryPath);
+    fs.chmodSync(currentBinaryPath, 0o755);
+    return;
+  }
+
+  fs.copyFileSync(tmpBin, currentBinaryPath);
+}
+
 export async function upgradeCommand(opts?: UpgradeOptions): Promise<void> {
   const currentBinaryPath = resolveCurrentBinary();
   if (
@@ -134,10 +144,7 @@ export async function upgradeCommand(opts?: UpgradeOptions): Promise<void> {
       fs.chmodSync(tmpBin, 0o755);
     }
 
-    fs.copyFileSync(tmpBin, currentBinaryPath);
-    if (process.platform !== 'win32') {
-      fs.chmodSync(currentBinaryPath, 0o755);
-    }
+    replaceBinary(tmpBin, currentBinaryPath);
 
     console.log(chalk.green(`✓ Upgraded tank ${VERSION} → ${targetVersion}`));
     console.log(chalk.gray(`Release notes: https://github.com/tankpkg/tank/releases/tag/v${targetVersion}`));


### PR DESCRIPTION
## Summary
- promote #480 to stable so production registry binary routes use the corrected asset filename
- includes CLI self-upgrade install fix for future CLI releases

## Verification
- bun test src/__tests__/upgrade.test.ts
- bunx biome check packages/cli/src/commands/upgrade.ts packages/cli/src/__tests__/upgrade.test.ts apps/registry/src/api/routes/cli.ts
- NITRO_PRESET=vercel bun turbo build --filter=registry...