### PR TITLE
fix(cli): link transitive skill deps to agents, not just roots

### DIFF
--- a/apps/registry/src/components/skills/download-button.tsx
+++ b/apps/registry/src/components/skills/download-button.tsx
@@ -67,8 +67,7 @@ export function DownloadButton({ skillName, version }: DownloadButtonProps) {
         className="gap-1.5"
         onClick={handleClick}
         disabled={isLoading}
-        aria-busy={isLoading}
-      >
+        aria-busy={isLoading}>
         <Download className="size-3.5" />
         <span className="text-xs">{isLoading ? 'Downloading…' : 'Download'}</span>
       </Button>

--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -1946,3 +1946,115 @@ describe('installCommand — transitive dependency resolution', () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 });
+
+describe('installCommand — transitive dependency linking', () => {
+  let tmpDir: string;
+  let configDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  let fakeTarball: Buffer;
+  let fakeTarballIntegrity: string;
+
+  const rootVersionsResponse = {
+    name: '@test-org/my-skill',
+    versions: [
+      {
+        version: '1.0.0',
+        integrity: 'sha512-root',
+        auditScore: 9.0,
+        auditStatus: 'published',
+        publishedAt: '2026-01-01T00:00:00Z'
+      }
+    ]
+  };
+
+  const depVersionsResponse = {
+    name: '@dep/helper',
+    versions: [
+      {
+        version: '1.0.0',
+        integrity: 'sha512-dep',
+        auditScore: 9.0,
+        auditStatus: 'published',
+        publishedAt: '2026-01-01T00:00:00Z'
+      }
+    ]
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-translink-test-'));
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tank-translink-config-'));
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({ registry: 'https://tankpkg.dev' }));
+    fs.writeFileSync(
+      path.join(tmpDir, 'tank.json'),
+      JSON.stringify({ name: 'my-project', version: '1.0.0', skills: {} }, null, 2)
+    );
+
+    fakeTarball = Buffer.from('fake-tarball-translink-test');
+    const hash = crypto.createHash('sha512').update(fakeTarball).digest('base64');
+    fakeTarballIntegrity = `sha512-${hash}`;
+
+    mockFetch.mockReset();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(configDir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.resetModules();
+    vi.doUnmock('~/lib/frontmatter.js');
+    vi.doUnmock('~/lib/linker.js');
+  });
+
+  function makeMeta(name: string, version: string, dependencies: Record<string, string> = {}) {
+    return {
+      name,
+      version,
+      description: `Test skill ${name}`,
+      integrity: fakeTarballIntegrity,
+      permissions: {},
+      auditScore: 9.0,
+      auditStatus: 'published',
+      downloadUrl: `https://storage.example.com/${name}-${version}.tgz`,
+      publishedAt: '2026-01-01T00:00:00Z',
+      dependencies
+    };
+  }
+
+  it('links transitive deps declared in registry metadata, not just the root', async () => {
+    vi.resetModules();
+    const prepareAgentSkillDir = vi.fn().mockReturnValue('/mock/agent-skills/skill');
+    const linkSkillToAgents = vi.fn().mockReturnValue({ linked: ['claude'], skipped: [], failed: [] });
+    vi.doMock('~/lib/frontmatter.js', () => ({ prepareAgentSkillDir }));
+    vi.doMock('~/lib/linker.js', () => ({ linkSkillToAgents }));
+
+    const { installCommand } = await import('~/commands/install.js');
+
+    // Modern resolver path: the dependency comes from registry metadata
+    // (not from the extracted tank.json legacy fallback).
+    mockFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify(rootVersionsResponse)))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeMeta('@test-org/my-skill', '1.0.0', { '@dep/helper': '^1.0.0' })))
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify(depVersionsResponse)))
+      .mockResolvedValueOnce(new Response(JSON.stringify(makeMeta('@dep/helper', '1.0.0'))))
+      .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)))
+      .mockResolvedValueOnce(new Response(new Uint8Array(fakeTarball)));
+
+    await installCommand({
+      name: '@test-org/my-skill',
+      directory: tmpDir,
+      configDir,
+      homedir: tmpDir
+    });
+
+    const linkedSkillNames = linkSkillToAgents.mock.calls.map((call) => call[0]?.skillName);
+    expect(linkedSkillNames).toContain('@test-org/my-skill');
+    expect(linkedSkillNames).toContain('@dep/helper');
+  });
+});

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -325,8 +325,8 @@ function wrapMcpServerForSkill(options: {
   }
 }
 
-async function linkInstalledRoots(options: {
-  rootSkillNames: string[];
+async function linkInstalledSkills(options: {
+  skillNames: string[];
   resolvedNodeByName: Map<string, ResolvedNode>;
   extractDirForSkill: (skillName: string) => string;
   directory: string;
@@ -336,7 +336,7 @@ async function linkInstalledRoots(options: {
   dangerouslyNoTankProxy?: boolean;
 }): Promise<void> {
   const {
-    rootSkillNames,
+    skillNames,
     resolvedNodeByName,
     extractDirForSkill,
     directory,
@@ -351,7 +351,7 @@ async function linkInstalledRoots(options: {
     : path.join(directory, '.tank', 'agent-skills');
   const linksDir = global ? path.join(resolvedHome, '.tank') : path.join(directory, '.tank');
 
-  for (const skillName of rootSkillNames) {
+  for (const skillName of skillNames) {
     try {
       const node = resolvedNodeByName.get(skillName);
       if (!node) {
@@ -388,7 +388,7 @@ async function linkInstalledRoots(options: {
         dangerouslyNoTankProxy
       });
     } catch {
-      if (rootSkillNames.length === 1) {
+      if (skillNames.length === 1) {
         logger.warn('Agent linking skipped (non-fatal)');
       } else {
         logger.warn(`Agent linking skipped for ${skillName} (non-fatal)`);
@@ -410,7 +410,7 @@ async function linkInstalledRoots(options: {
   };
   const platforms = new Set(detectedAgents.map((a) => agentToPlatform[a.id]).filter(Boolean));
 
-  for (const skillName of rootSkillNames) {
+  for (const skillName of skillNames) {
     const node = resolvedNodeByName.get(skillName);
     if (!node) continue;
     const skillDir = extractDirForSkill(skillName);
@@ -487,8 +487,8 @@ async function executeInstallPipeline(options: ExecuteInstallPipelineOptions): P
     homedir
   });
 
-  await linkInstalledRoots({
-    rootSkillNames,
+  await linkInstalledSkills({
+    skillNames: nodesToInstall.map((node) => node.name),
     resolvedNodeByName,
     extractDirForSkill,
     directory,


### PR DESCRIPTION
## Problem

`tank install` resolved, downloaded, extracted, and locked transitive skill dependencies correctly — but only **root** skills were symlinked into agent skill dirs. Transitive skill deps surfaced via registry metadata (e.g. `@tank/bulletproof` → `@tank/idd` + `@tank/bdd-e2e-testing`) were left unlinked: present on disk under `~/.tank/skills/`, but missing from `~/.tank/agent-skills/` and the agents' skill dirs, so agents couldn't load them.

## Fix

`executeInstallPipeline` now links every freshly-installed node (`nodesToInstall` = root + transitive) via `linkInstalledSkills`, instead of only the requested roots. `runLegacyFallback` is unchanged (correctly roots-only); lockfile/URL install paths unaffected.

## Verification (real registry, RED→GREEN)

Installed `@tank/bulletproof --global` against www.tankpkg.dev into an isolated HOME:

| location | before | after |
|---|---|---|
| `~/.tank/agent-skills/` | only `tank--bulletproof` | + `tank--idd` + `tank--bdd-e2e-testing` |
| `~/.claude/skills/` | only `tank--bulletproof` | all 3 symlinks (resolve to real SKILL.md) |

Plus `tsc --noEmit` clean, biome lint/format clean. Adds a regression test covering the modern resolver path (deps declared in registry metadata).

## Also

- One commit fixes a pre-existing biome formatting error in `download-button.tsx` that was failing `lint:readonly`/`format:readonly` and keeping CI red on every PR.

## Notes

- `lint:readonly` still reports ~150 **non-fatal** warnings (noNonNullAssertion/noConsole/noDocumentCookie) repo-wide — pre-existing, don't block CI. Can be cleaned up separately.
- The CLI vitest unit suite doesn't import locally due to a pre-existing zod v4 resolution issue (affects `main` too); verified via real-CLI E2E instead.
