### PR TITLE
chore: update Homebrew formula for v0.16.5

### DIFF
--- a/Formula/tank.rb
+++ b/Formula/tank.rb
@@ -1,19 +1,19 @@
 class Tank < Formula
   desc "Security-first package manager for AI agent skills"
   homepage "https://tankpkg.dev"
-  version "0.16.4"
+  version "0.16.5"
   if OS.mac? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-arm64.tar.gz"
-    sha256 "d91eac24f13164484bf999e1b635510aa53451c04db93c76655e84d4bd7a8a8d"
+    sha256 "9952762545e56470722f0968c0eb60b0e032e9f11d018105ff78b6334d1d6175"
   elsif OS.mac?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-darwin-x64.tar.gz"
-    sha256 "3c9301c2855e5ae7d579ab43304cb808f5dedc53e7bd9019162ae8c9fd2128cc"
+    sha256 "a1a6a519a0a662cef32f3228e6645092903ac6e944caad3efea8f97712cca892"
   elsif OS.linux? && Hardware::CPU.arm?
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-arm64.tar.gz"
-    sha256 "001b73b061f7b50d6de6622784b1d179f8f3443f833c18c8d0539909ba38171c"
+    sha256 "336420033b77d390a9b6a79583e313e48be18dce6325f82336caaa61cfdb26e0"
   else
     url "https://github.com/tankpkg/tank/releases/download/v#{version}/tank-linux-x64.tar.gz"
-    sha256 "ad5933efbdadb2938faec6d60dd658fe2759fbace36b1a6b528613cca4cacfda"
+    sha256 "65d9989df4ec5cf21f86a18b7e697bc4580c58e2667325383743edfc178d0d05"
   end
   def install
     bin.install Dir["tank-*"].first => "tank"


### PR DESCRIPTION
Auto-generated by release pipeline; manually opened because GitHub Actions is not permitted to create pull requests.